### PR TITLE
remove +1 in z in dump_ed

### DIFF
--- a/scripts/dump-ed.py
+++ b/scripts/dump-ed.py
@@ -36,7 +36,7 @@ if __name__ == "__main__":
             if abs(yaw) > 0.001:
                 print "  pose: {{ x: {}, y: {}, z: {}, Z: {:.3f} }}".format(e.pose.position.x, e.pose.position.y, e.pose.position.z, yaw)
             else:
-                print "  pose: {{ x: {}, y: {}, z: {} }}".format(e.pose.position.x, e.pose.position.y, e.pose.position.z + 1)
+                print "  pose: {{ x: {}, y: {}, z: {} }}".format(e.pose.position.x, e.pose.position.y, e.pose.position.z)
 
     except rospy.ServiceException, e:
         print "Service call failed: %s"%e


### PR DESCRIPTION
I don't know why this +1 is added, because in the line which also prints the yaw, it is not there. Also it doesn't match the file which is loaded, so removing it.