### PR TITLE
SDF

### DIFF
--- a/models/robotics_testlabs/model-1_6.sdf
+++ b/models/robotics_testlabs/model-1_6.sdf
@@ -340,6 +340,11 @@
       <name>door2</name>
       <uri>model://robotics_testlabs/blue_door_right</uri>
     </include>
+    <include name="floor">
+      <pose>0 0 0 0 0 0</pose>
+      <name>floor</name>
+      <uri>model://floor</uri>
+    </include>
     <include name="plant">
       <pose>3.26 5.19 0 0 0 0</pose>
       <name>plant</name>
@@ -465,6 +470,18 @@
       <name>electro_bar_2</name>
       <uri>model://robotics_testlabs/electro_bar_2</uri>
     </include>
+    <physics type="ode">
+      <real_time_update_rate>333.0</real_time_update_rate>
+      <max_step_size>0.003</max_step_size>
+      <ode>
+        <constraints>
+          <cfm>0.0001</cfm>
+        </constraints>
+        <solver type="quick">
+          <iters>100</iters>
+        </solver>
+      </ode>
+    </physics>
     <name>robotics_testlabs</name>
   </world>
 </sdf>

--- a/models/robotics_testlabs/walls/model-1_6.sdf
+++ b/models/robotics_testlabs/walls/model-1_6.sdf
@@ -4,33 +4,17 @@
     <link name="1">
       <collision name="1">
         <geometry>
-          <heightmap>
-            <use_terrain_paging>false</use_terrain_paging>
-            <pos>6.2 1.0 0.0</pos>
-            <uri>model://robotics_testlabs/walls/shape/heightmap_converted.png</uri>
-            <texture>
-              <size>1</size>
-              <diffuse>file://media/materials/textures/grey.png</diffuse>
-              <normal>file://media/materials/textures/normal.png</normal>
-            </texture>
-            <size>51.225 51.225 2.0</size>
-          </heightmap>
+          <mesh>
+            <uri>model://robotics_testlabs/walls/shape/heightmap.stl</uri>
+          </mesh>
         </geometry>
         <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
-          <heightmap>
-            <use_terrain_paging>false</use_terrain_paging>
-            <pos>6.2 1.0 0.0</pos>
-            <uri>model://robotics_testlabs/walls/shape/heightmap_converted.png</uri>
-            <texture>
-              <size>1</size>
-              <diffuse>file://media/materials/textures/grey.png</diffuse>
-              <normal>file://media/materials/textures/normal.png</normal>
-            </texture>
-            <size>51.225 51.225 2.0</size>
-          </heightmap>
+          <mesh>
+            <uri>model://robotics_testlabs/walls/shape/heightmap.stl</uri>
+          </mesh>
         </geometry>
         <name>1</name>
       </visual>

--- a/models/robotics_testlabs/walls/shape/heightmap.stl
+++ b/models/robotics_testlabs/walls/shape/heightmap.stl
@@ -1,0 +1,1538 @@
+solid AssimpScene
+ facet normal 0 0 1
+  outer loop
+  vertex -0.125 8.125 0
+  vertex -0.125 8.125 1.2
+  vertex -0.125 8.1 0
+  endloop
+ endfacet
+
+ facet normal 0 -0.447214 0.894427
+  outer loop
+  vertex -0.125 8.125 1.2
+  vertex -0.125 8.1 1.2
+  vertex -0.125 8.1 0
+  endloop
+ endfacet
+
+ facet normal 0.57735 -0.57735 0.57735
+  outer loop
+  vertex -0.125 8.1 0
+  vertex -0.125 8.1 1.2
+  vertex -3.975 8.1 0
+  endloop
+ endfacet
+
+ facet normal 0.447214 0 0.894427
+  outer loop
+  vertex -0.125 8.1 1.2
+  vertex -3.975 8.1 1.2
+  vertex -3.975 8.1 0
+  endloop
+ endfacet
+
+ facet normal 0.57735 -0.57735 0.57735
+  outer loop
+  vertex -3.975 8.1 0
+  vertex -3.975 8.1 1.2
+  vertex -3.975 5.575 0
+  endloop
+ endfacet
+
+ facet normal 0 -0.447214 0.894427
+  outer loop
+  vertex -3.975 8.1 1.2
+  vertex -3.975 5.575 1.2
+  vertex -3.975 5.575 0
+  endloop
+ endfacet
+
+ facet normal -0.57735 -0.57735 0.57735
+  outer loop
+  vertex -3.975 5.575 0
+  vertex -3.975 5.575 1.2
+  vertex -4 5.575 0
+  endloop
+ endfacet
+
+ facet normal -0.447214 0 0.894427
+  outer loop
+  vertex -3.975 5.575 1.2
+  vertex -4 5.575 1.2
+  vertex -4 5.575 0
+  endloop
+ endfacet
+
+ facet normal -0.57735 0.57735 0.57735
+  outer loop
+  vertex -4 5.575 0
+  vertex -4 5.575 1.2
+  vertex -4 8.125 0
+  endloop
+ endfacet
+
+ facet normal 0 0.447214 0.894427
+  outer loop
+  vertex -4 5.575 1.2
+  vertex -4 8.125 1.2
+  vertex -4 8.125 0
+  endloop
+ endfacet
+
+ facet normal 0 0.894427 0.447214
+  outer loop
+  vertex -4 8.125 0
+  vertex -4 8.125 1.2
+  vertex -0.125 8.125 0
+  endloop
+ endfacet
+
+ facet normal 0 0.447214 0.894427
+  outer loop
+  vertex -4 8.125 1.2
+  vertex -0.125 8.125 1.2
+  vertex -0.125 8.125 0
+  endloop
+ endfacet
+
+ facet normal 0 0 1
+  outer loop
+  vertex -4 8.125 1.2
+  vertex -0.125 8.1 1.2
+  vertex -0.125 8.125 1.2
+  endloop
+ endfacet
+
+ facet normal 0 0 1
+  outer loop
+  vertex -4 8.125 1.2
+  vertex -3.975 8.1 1.2
+  vertex -0.125 8.1 1.2
+  endloop
+ endfacet
+
+ facet normal 0 0 1
+  outer loop
+  vertex -4 5.575 1.2
+  vertex -3.975 8.1 1.2
+  vertex -4 8.125 1.2
+  endloop
+ endfacet
+
+ facet normal 0 0 1
+  outer loop
+  vertex -4 5.575 1.2
+  vertex -3.975 5.575 1.2
+  vertex -3.975 8.1 1.2
+  endloop
+ endfacet
+
+ facet normal 0 0 1
+  outer loop
+  vertex 11.075 7.825 0
+  vertex 11.075 7.825 0.0392157
+  vertex 11.075 5.575 0
+  endloop
+ endfacet
+
+ facet normal 0 -0.447214 0.894427
+  outer loop
+  vertex 11.075 7.825 0.0392157
+  vertex 11.075 5.575 0.0392157
+  vertex 11.075 5.575 0
+  endloop
+ endfacet
+
+ facet normal -0.57735 -0.57735 0.57735
+  outer loop
+  vertex 11.075 5.575 0
+  vertex 11.075 5.575 0.0392157
+  vertex 11 5.575 0
+  endloop
+ endfacet
+
+ facet normal -0.447214 0 0.894427
+  outer loop
+  vertex 11.075 5.575 0.0392157
+  vertex 11 5.575 0.0392157
+  vertex 11 5.575 0
+  endloop
+ endfacet
+
+ facet normal -0.57735 -0.57735 0.57735
+  outer loop
+  vertex 11 5.575 0
+  vertex 11 5.575 0.0392157
+  vertex 11 7.75 0
+  endloop
+ endfacet
+
+ facet normal 0 -0.447214 0.894427
+  outer loop
+  vertex 11 5.575 0.0392157
+  vertex 11 7.75 0.0392157
+  vertex 11 7.75 0
+  endloop
+ endfacet
+
+ facet normal 0.57735 -0.57735 0.57735
+  outer loop
+  vertex 11 7.75 0
+  vertex 11 7.75 0.0392157
+  vertex -3.8 7.75 0
+  endloop
+ endfacet
+
+ facet normal 0.447214 0 0.894427
+  outer loop
+  vertex 11 7.75 0.0392157
+  vertex -3.8 7.75 0.0392157
+  vertex -3.8 7.75 0
+  endloop
+ endfacet
+
+ facet normal 0.57735 -0.57735 0.57735
+  outer loop
+  vertex -3.8 7.75 0
+  vertex -3.8 7.75 0.0392157
+  vertex -3.8 5.575 0
+  endloop
+ endfacet
+
+ facet normal 0 -0.447214 0.894427
+  outer loop
+  vertex -3.8 7.75 0.0392157
+  vertex -3.8 5.575 0.0392157
+  vertex -3.8 5.575 0
+  endloop
+ endfacet
+
+ facet normal -0.57735 -0.57735 0.57735
+  outer loop
+  vertex -3.8 5.575 0
+  vertex -3.8 5.575 0.0392157
+  vertex -3.825 5.575 0
+  endloop
+ endfacet
+
+ facet normal -0.447214 0 0.894427
+  outer loop
+  vertex -3.8 5.575 0.0392157
+  vertex -3.825 5.575 0.0392157
+  vertex -3.825 5.575 0
+  endloop
+ endfacet
+
+ facet normal -0.57735 0.57735 0.57735
+  outer loop
+  vertex -3.825 5.575 0
+  vertex -3.825 5.575 0.0392157
+  vertex -3.825 7.825 0
+  endloop
+ endfacet
+
+ facet normal 0 0.447214 0.894427
+  outer loop
+  vertex -3.825 5.575 0.0392157
+  vertex -3.825 7.825 0.0392157
+  vertex -3.825 7.825 0
+  endloop
+ endfacet
+
+ facet normal 0 0.894427 0.447214
+  outer loop
+  vertex -3.825 7.825 0
+  vertex -3.825 7.825 0.0392157
+  vertex 11.075 7.825 0
+  endloop
+ endfacet
+
+ facet normal 0 0.447214 0.894427
+  outer loop
+  vertex -3.825 7.825 0.0392157
+  vertex 11.075 7.825 0.0392157
+  vertex 11.075 7.825 0
+  endloop
+ endfacet
+
+ facet normal 0 0 1
+  outer loop
+  vertex 11.075 7.825 0.0392157
+  vertex 11 5.575 0.0392157
+  vertex 11.075 5.575 0.0392157
+  endloop
+ endfacet
+
+ facet normal 0 0 1
+  outer loop
+  vertex 11.075 7.825 0.0392157
+  vertex 11 7.75 0.0392157
+  vertex 11 5.575 0.0392157
+  endloop
+ endfacet
+
+ facet normal 0 0 1
+  outer loop
+  vertex -3.825 7.825 0.0392157
+  vertex 11 7.75 0.0392157
+  vertex 11.075 7.825 0.0392157
+  endloop
+ endfacet
+
+ facet normal 0 0 1
+  outer loop
+  vertex -3.825 7.825 0.0392157
+  vertex -3.8 7.75 0.0392157
+  vertex 11 7.75 0.0392157
+  endloop
+ endfacet
+
+ facet normal 0 0 1
+  outer loop
+  vertex -3.825 5.575 0.0392157
+  vertex -3.8 7.75 0.0392157
+  vertex -3.825 7.825 0.0392157
+  endloop
+ endfacet
+
+ facet normal 0 0 1
+  outer loop
+  vertex -3.825 5.575 0.0392157
+  vertex -3.8 5.575 0.0392157
+  vertex -3.8 7.75 0.0392157
+  endloop
+ endfacet
+
+ facet normal 0 0 1
+  outer loop
+  vertex -0.575 5.625 0
+  vertex -0.575 5.625 1.2
+  vertex -0.575 5.5 0
+  endloop
+ endfacet
+
+ facet normal 0 -0.447214 0.894427
+  outer loop
+  vertex -0.575 5.625 1.2
+  vertex -0.575 5.5 1.2
+  vertex -0.575 5.5 0
+  endloop
+ endfacet
+
+ facet normal 0.57735 -0.57735 0.57735
+  outer loop
+  vertex -0.575 5.5 0
+  vertex -0.575 5.5 1.2
+  vertex -3.75 5.5 0
+  endloop
+ endfacet
+
+ facet normal 0.447214 0 0.894427
+  outer loop
+  vertex -0.575 5.5 1.2
+  vertex -3.75 5.5 1.2
+  vertex -3.75 5.5 0
+  endloop
+ endfacet
+
+ facet normal 0.57735 0.57735 0.57735
+  outer loop
+  vertex -3.75 5.5 0
+  vertex -3.75 5.5 1.2
+  vertex -3.75 -1.7 0
+  endloop
+ endfacet
+
+ facet normal 0 0.447214 0.894427
+  outer loop
+  vertex -3.75 5.5 1.2
+  vertex -3.75 -1.7 1.2
+  vertex -3.75 -1.7 0
+  endloop
+ endfacet
+
+ facet normal -0.57735 0.57735 0.57735
+  outer loop
+  vertex -3.75 -1.7 0
+  vertex -3.75 -1.7 1.2
+  vertex 3.55 -1.7 0
+  endloop
+ endfacet
+
+ facet normal -0.447214 0 0.894427
+  outer loop
+  vertex -3.75 -1.7 1.2
+  vertex 3.55 -1.7 1.2
+  vertex 3.55 -1.7 0
+  endloop
+ endfacet
+
+ facet normal -0.57735 -0.57735 0.57735
+  outer loop
+  vertex 3.55 -1.7 0
+  vertex 3.55 -1.7 1.2
+  vertex 3.55 5.5 0
+  endloop
+ endfacet
+
+ facet normal 0 -0.447214 0.894427
+  outer loop
+  vertex 3.55 -1.7 1.2
+  vertex 3.55 5.5 1.2
+  vertex 3.55 5.5 0
+  endloop
+ endfacet
+
+ facet normal -0.57735 -0.57735 0.57735
+  outer loop
+  vertex 3.55 5.5 0
+  vertex 3.55 5.5 1.2
+  vertex 1.3 5.5 0
+  endloop
+ endfacet
+
+ facet normal -0.447214 0 0.894427
+  outer loop
+  vertex 3.55 5.5 1.2
+  vertex 1.3 5.5 1.2
+  vertex 1.3 5.5 0
+  endloop
+ endfacet
+
+ facet normal -0.57735 0.57735 0.57735
+  outer loop
+  vertex 1.3 5.5 0
+  vertex 1.3 5.5 1.2
+  vertex 1.3 5.625 0
+  endloop
+ endfacet
+
+ facet normal 0 0.447214 0.894427
+  outer loop
+  vertex 1.3 5.5 1.2
+  vertex 1.3 5.625 1.2
+  vertex 1.3 5.625 0
+  endloop
+ endfacet
+
+ facet normal 0.57735 0.57735 0.57735
+  outer loop
+  vertex 1.3 5.625 0
+  vertex 1.3 5.625 1.2
+  vertex 1.375 5.625 0
+  endloop
+ endfacet
+
+ facet normal 0.447214 0 0.894427
+  outer loop
+  vertex 1.3 5.625 1.2
+  vertex 1.375 5.625 1.2
+  vertex 1.375 5.625 0
+  endloop
+ endfacet
+
+ facet normal 0.57735 0.57735 0.57735
+  outer loop
+  vertex 1.375 5.625 0
+  vertex 1.375 5.625 1.2
+  vertex 1.375 5.575 0
+  endloop
+ endfacet
+
+ facet normal 0 0.447214 0.894427
+  outer loop
+  vertex 1.375 5.625 1.2
+  vertex 1.375 5.575 1.2
+  vertex 1.375 5.575 0
+  endloop
+ endfacet
+
+ facet normal 0.57735 0.57735 0.57735
+  outer loop
+  vertex 1.375 5.575 0
+  vertex 1.375 5.575 1.2
+  vertex 8.65 5.575 0
+  endloop
+ endfacet
+
+ facet normal 0.447214 0 0.894427
+  outer loop
+  vertex 1.375 5.575 1.2
+  vertex 8.65 5.575 1.2
+  vertex 8.65 5.575 0
+  endloop
+ endfacet
+
+ facet normal 0.57735 -0.57735 0.57735
+  outer loop
+  vertex 8.65 5.575 0
+  vertex 8.65 5.575 1.2
+  vertex 8.65 -1.775 0
+  endloop
+ endfacet
+
+ facet normal 0 -0.447214 0.894427
+  outer loop
+  vertex 8.65 5.575 1.2
+  vertex 8.65 -1.775 1.2
+  vertex 8.65 -1.775 0
+  endloop
+ endfacet
+
+ facet normal -0.57735 -0.57735 0.57735
+  outer loop
+  vertex 8.65 -1.775 0
+  vertex 8.65 -1.775 1.2
+  vertex -3.825 -1.775 0
+  endloop
+ endfacet
+
+ facet normal -0.447214 0 0.894427
+  outer loop
+  vertex 8.65 -1.775 1.2
+  vertex -3.825 -1.775 1.2
+  vertex -3.825 -1.775 0
+  endloop
+ endfacet
+
+ facet normal -0.57735 0.57735 0.57735
+  outer loop
+  vertex -3.825 -1.775 0
+  vertex -3.825 -1.775 1.2
+  vertex -3.825 5.575 0
+  endloop
+ endfacet
+
+ facet normal 0 0.447214 0.894427
+  outer loop
+  vertex -3.825 -1.775 1.2
+  vertex -3.825 5.575 1.2
+  vertex -3.825 5.575 0
+  endloop
+ endfacet
+
+ facet normal -0.57735 0.57735 0.57735
+  outer loop
+  vertex -3.825 5.575 0
+  vertex -3.825 5.575 1.2
+  vertex -0.675 5.575 0
+  endloop
+ endfacet
+
+ facet normal -0.447214 0 0.894427
+  outer loop
+  vertex -3.825 5.575 1.2
+  vertex -0.675 5.575 1.2
+  vertex -0.675 5.575 0
+  endloop
+ endfacet
+
+ facet normal -0.57735 0.57735 0.57735
+  outer loop
+  vertex -0.675 5.575 0
+  vertex -0.675 5.575 1.2
+  vertex -0.675 5.625 0
+  endloop
+ endfacet
+
+ facet normal 0 0.447214 0.894427
+  outer loop
+  vertex -0.675 5.575 1.2
+  vertex -0.675 5.625 1.2
+  vertex -0.675 5.625 0
+  endloop
+ endfacet
+
+ facet normal 0 0.894427 0.447214
+  outer loop
+  vertex -0.675 5.625 0
+  vertex -0.675 5.625 1.2
+  vertex -0.575 5.625 0
+  endloop
+ endfacet
+
+ facet normal 0 0.447214 0.894427
+  outer loop
+  vertex -0.675 5.625 1.2
+  vertex -0.575 5.625 1.2
+  vertex -0.575 5.625 0
+  endloop
+ endfacet
+
+ facet normal 0 0 1
+  outer loop
+  vertex 3.65 -1.7 0
+  vertex 3.65 -1.7 1.2
+  vertex 8.575 -1.7 0
+  endloop
+ endfacet
+
+ facet normal -0.447214 0 0.894427
+  outer loop
+  vertex 8.575 -1.7 0
+  vertex 3.65 -1.7 1.2
+  vertex 8.575 -1.7 1.2
+  endloop
+ endfacet
+
+ facet normal -0.57735 -0.57735 0.57735
+  outer loop
+  vertex 8.575 -1.7 0
+  vertex 8.575 -1.7 1.2
+  vertex 8.575 5.5 0
+  endloop
+ endfacet
+
+ facet normal 0 -0.447214 0.894427
+  outer loop
+  vertex 8.575 5.5 0
+  vertex 8.575 -1.7 1.2
+  vertex 8.575 5.5 1.2
+  endloop
+ endfacet
+
+ facet normal 0.57735 -0.57735 0.57735
+  outer loop
+  vertex 8.575 5.5 0
+  vertex 8.575 5.5 1.2
+  vertex 3.65 5.5 0
+  endloop
+ endfacet
+
+ facet normal 0.447214 0 0.894427
+  outer loop
+  vertex 3.65 5.5 0
+  vertex 8.575 5.5 1.2
+  vertex 3.65 5.5 1.2
+  endloop
+ endfacet
+
+ facet normal 0.894427 0 0.447214
+  outer loop
+  vertex 3.65 5.5 0
+  vertex 3.65 5.5 1.2
+  vertex 3.65 -1.7 0
+  endloop
+ endfacet
+
+ facet normal 0.447214 0 0.894427
+  outer loop
+  vertex 3.65 -1.7 0
+  vertex 3.65 5.5 1.2
+  vertex 3.65 -1.7 1.2
+  endloop
+ endfacet
+
+ facet normal 0 0 1
+  outer loop
+  vertex 8.65 5.575 1.2
+  vertex 8.575 -1.7 1.2
+  vertex 8.65 -1.775 1.2
+  endloop
+ endfacet
+
+ facet normal 0 0 1
+  outer loop
+  vertex 8.65 5.575 1.2
+  vertex 8.575 5.5 1.2
+  vertex 8.575 -1.7 1.2
+  endloop
+ endfacet
+
+ facet normal 0 0 1
+  outer loop
+  vertex 1.375 5.575 1.2
+  vertex 8.575 5.5 1.2
+  vertex 8.65 5.575 1.2
+  endloop
+ endfacet
+
+ facet normal 0 0 1
+  outer loop
+  vertex 1.375 5.575 1.2
+  vertex 3.65 5.5 1.2
+  vertex 8.575 5.5 1.2
+  endloop
+ endfacet
+
+ facet normal 0 0 1
+  outer loop
+  vertex 8.575 -1.7 1.2
+  vertex -3.825 -1.775 1.2
+  vertex 8.65 -1.775 1.2
+  endloop
+ endfacet
+
+ facet normal 0 0 1
+  outer loop
+  vertex 3.65 -1.7 1.2
+  vertex -3.825 -1.775 1.2
+  vertex 8.575 -1.7 1.2
+  endloop
+ endfacet
+
+ facet normal 0 0 1
+  outer loop
+  vertex -0.675 5.625 1.2
+  vertex -0.575 5.5 1.2
+  vertex -0.575 5.625 1.2
+  endloop
+ endfacet
+
+ facet normal 0 0 1
+  outer loop
+  vertex -0.675 5.575 1.2
+  vertex -0.575 5.5 1.2
+  vertex -0.675 5.625 1.2
+  endloop
+ endfacet
+
+ facet normal 0 0 1
+  outer loop
+  vertex -0.675 5.575 1.2
+  vertex -3.75 5.5 1.2
+  vertex -0.575 5.5 1.2
+  endloop
+ endfacet
+
+ facet normal 0 0 1
+  outer loop
+  vertex -3.825 5.575 1.2
+  vertex -3.75 5.5 1.2
+  vertex -0.675 5.575 1.2
+  endloop
+ endfacet
+
+ facet normal 0 0 1
+  outer loop
+  vertex -3.825 -1.775 1.2
+  vertex -3.75 5.5 1.2
+  vertex -3.825 5.575 1.2
+  endloop
+ endfacet
+
+ facet normal 0 0 1
+  outer loop
+  vertex -3.825 -1.775 1.2
+  vertex -3.75 -1.7 1.2
+  vertex -3.75 5.5 1.2
+  endloop
+ endfacet
+
+ facet normal 0 0 1
+  outer loop
+  vertex 1.3 5.5 1.2
+  vertex 1.375 5.625 1.2
+  vertex 1.3 5.625 1.2
+  endloop
+ endfacet
+
+ facet normal 0 0 1
+  outer loop
+  vertex 1.3 5.5 1.2
+  vertex 1.375 5.575 1.2
+  vertex 1.375 5.625 1.2
+  endloop
+ endfacet
+
+ facet normal 0 0 1
+  outer loop
+  vertex 3.55 5.5 1.2
+  vertex 1.375 5.575 1.2
+  vertex 1.3 5.5 1.2
+  endloop
+ endfacet
+
+ facet normal 0 0 1
+  outer loop
+  vertex 3.55 5.5 1.2
+  vertex 3.65 5.5 1.2
+  vertex 1.375 5.575 1.2
+  endloop
+ endfacet
+
+ facet normal 0 0 1
+  outer loop
+  vertex 3.55 -1.7 1.2
+  vertex 3.65 5.5 1.2
+  vertex 3.55 5.5 1.2
+  endloop
+ endfacet
+
+ facet normal 0 0 1
+  outer loop
+  vertex 3.55 -1.7 1.2
+  vertex 3.65 -1.7 1.2
+  vertex 3.65 5.5 1.2
+  endloop
+ endfacet
+
+ facet normal 0 0 1
+  outer loop
+  vertex 3.55 -1.7 1.2
+  vertex -3.825 -1.775 1.2
+  vertex 3.65 -1.7 1.2
+  endloop
+ endfacet
+
+ facet normal 0 0 1
+  outer loop
+  vertex -3.825 -1.775 1.2
+  vertex 3.55 -1.7 1.2
+  vertex -3.75 -1.7 1.2
+  endloop
+ endfacet
+
+ facet normal 0 0 1
+  outer loop
+  vertex 11.075 5.575 0
+  vertex 11.075 5.575 1.2
+  vertex 11.075 -1.775 0
+  endloop
+ endfacet
+
+ facet normal 0 -0.447214 0.894427
+  outer loop
+  vertex 11.075 5.575 1.2
+  vertex 11.075 -1.775 1.2
+  vertex 11.075 -1.775 0
+  endloop
+ endfacet
+
+ facet normal -0.57735 -0.57735 0.57735
+  outer loop
+  vertex 11.075 -1.775 0
+  vertex 11.075 -1.775 1.2
+  vertex 11 -1.775 0
+  endloop
+ endfacet
+
+ facet normal -0.447214 0 0.894427
+  outer loop
+  vertex 11.075 -1.775 1.2
+  vertex 11 -1.775 1.2
+  vertex 11 -1.775 0
+  endloop
+ endfacet
+
+ facet normal -0.57735 0.57735 0.57735
+  outer loop
+  vertex 11 -1.775 0
+  vertex 11 -1.775 1.2
+  vertex 11 5.575 0
+  endloop
+ endfacet
+
+ facet normal 0 0.447214 0.894427
+  outer loop
+  vertex 11 -1.775 1.2
+  vertex 11 5.575 1.2
+  vertex 11 5.575 0
+  endloop
+ endfacet
+
+ facet normal 0 0.894427 0.447214
+  outer loop
+  vertex 11 5.575 0
+  vertex 11 5.575 1.2
+  vertex 11.075 5.575 0
+  endloop
+ endfacet
+
+ facet normal 0 0.447214 0.894427
+  outer loop
+  vertex 11 5.575 1.2
+  vertex 11.075 5.575 1.2
+  vertex 11.075 5.575 0
+  endloop
+ endfacet
+
+ facet normal 0 0 1
+  outer loop
+  vertex 11 5.575 1.2
+  vertex 11.075 -1.775 1.2
+  vertex 11.075 5.575 1.2
+  endloop
+ endfacet
+
+ facet normal 0 0 1
+  outer loop
+  vertex 11 5.575 1.2
+  vertex 11 -1.775 1.2
+  vertex 11.075 -1.775 1.2
+  endloop
+ endfacet
+
+ facet normal 0 0 1
+  outer loop
+  vertex 1.55 5.5 0
+  vertex 1.55 5.5 0.8
+  vertex 1.55 4.7 0
+  endloop
+ endfacet
+
+ facet normal 0 -0.447214 0.894427
+  outer loop
+  vertex 1.55 5.5 0.8
+  vertex 1.55 4.7 0.8
+  vertex 1.55 4.7 0
+  endloop
+ endfacet
+
+ facet normal -0.57735 -0.57735 0.57735
+  outer loop
+  vertex 1.55 4.7 0
+  vertex 1.55 4.7 0.8
+  vertex 1.35 4.7 0
+  endloop
+ endfacet
+
+ facet normal -0.447214 0 0.894427
+  outer loop
+  vertex 1.55 4.7 0.8
+  vertex 1.35 4.7 0.8
+  vertex 1.35 4.7 0
+  endloop
+ endfacet
+
+ facet normal -0.57735 0.57735 0.57735
+  outer loop
+  vertex 1.35 4.7 0
+  vertex 1.35 4.7 0.8
+  vertex 1.35 5.5 0
+  endloop
+ endfacet
+
+ facet normal 0 0.447214 0.894427
+  outer loop
+  vertex 1.35 4.7 0.8
+  vertex 1.35 5.5 0.8
+  vertex 1.35 5.5 0
+  endloop
+ endfacet
+
+ facet normal 0 0.894427 0.447214
+  outer loop
+  vertex 1.35 5.5 0
+  vertex 1.35 5.5 0.8
+  vertex 1.55 5.5 0
+  endloop
+ endfacet
+
+ facet normal 0 0.447214 0.894427
+  outer loop
+  vertex 1.35 5.5 0.8
+  vertex 1.55 5.5 0.8
+  vertex 1.55 5.5 0
+  endloop
+ endfacet
+
+ facet normal 0 0 1
+  outer loop
+  vertex 1.35 5.5 0.8
+  vertex 1.55 4.7 0.8
+  vertex 1.55 5.5 0.8
+  endloop
+ endfacet
+
+ facet normal 0 0 1
+  outer loop
+  vertex 1.35 5.5 0.8
+  vertex 1.35 4.7 0.8
+  vertex 1.55 4.7 0.8
+  endloop
+ endfacet
+
+ facet normal 0 0 1
+  outer loop
+  vertex 1.55 3.65 0
+  vertex 1.55 3.65 0.8
+  vertex 1.55 3.025 0
+  endloop
+ endfacet
+
+ facet normal 0 -0.447214 0.894427
+  outer loop
+  vertex 1.55 3.65 0.8
+  vertex 1.55 3.025 0.8
+  vertex 1.55 3.025 0
+  endloop
+ endfacet
+
+ facet normal 0.57735 -0.57735 0.57735
+  outer loop
+  vertex 1.55 3.025 0
+  vertex 1.55 3.025 0.8
+  vertex -0.25 3.025 0
+  endloop
+ endfacet
+
+ facet normal 0.447214 0 0.894427
+  outer loop
+  vertex 1.55 3.025 0.8
+  vertex -0.25 3.025 0.8
+  vertex -0.25 3.025 0
+  endloop
+ endfacet
+
+ facet normal 0.57735 -0.57735 0.57735
+  outer loop
+  vertex -0.25 3.025 0
+  vertex -0.25 3.025 0.8
+  vertex -0.25 0.625 0
+  endloop
+ endfacet
+
+ facet normal 0 -0.447214 0.894427
+  outer loop
+  vertex -0.25 3.025 0.8
+  vertex -0.25 0.625 0.8
+  vertex -0.25 0.625 0
+  endloop
+ endfacet
+
+ facet normal -0.57735 -0.57735 0.57735
+  outer loop
+  vertex -0.25 0.625 0
+  vertex -0.25 0.625 0.8
+  vertex -0.85 0.625 0
+  endloop
+ endfacet
+
+ facet normal -0.447214 0 0.894427
+  outer loop
+  vertex -0.25 0.625 0.8
+  vertex -0.85 0.625 0.8
+  vertex -0.85 0.625 0
+  endloop
+ endfacet
+
+ facet normal -0.57735 0.57735 0.57735
+  outer loop
+  vertex -0.85 0.625 0
+  vertex -0.85 0.625 0.8
+  vertex -0.85 0.825 0
+  endloop
+ endfacet
+
+ facet normal 0 0.447214 0.894427
+  outer loop
+  vertex -0.85 0.625 0.8
+  vertex -0.85 0.825 0.8
+  vertex -0.85 0.825 0
+  endloop
+ endfacet
+
+ facet normal -0.57735 0.57735 0.57735
+  outer loop
+  vertex -0.85 0.825 0
+  vertex -0.85 0.825 0.8
+  vertex -0.45 0.825 0
+  endloop
+ endfacet
+
+ facet normal -0.447214 0 0.894427
+  outer loop
+  vertex -0.85 0.825 0.8
+  vertex -0.45 0.825 0.8
+  vertex -0.45 0.825 0
+  endloop
+ endfacet
+
+ facet normal -0.57735 0.57735 0.57735
+  outer loop
+  vertex -0.45 0.825 0
+  vertex -0.45 0.825 0.8
+  vertex -0.45 3.25 0
+  endloop
+ endfacet
+
+ facet normal 0 0.447214 0.894427
+  outer loop
+  vertex -0.45 0.825 0.8
+  vertex -0.45 3.25 0.8
+  vertex -0.45 3.25 0
+  endloop
+ endfacet
+
+ facet normal -0.57735 0.57735 0.57735
+  outer loop
+  vertex -0.45 3.25 0
+  vertex -0.45 3.25 0.8
+  vertex 1.35 3.25 0
+  endloop
+ endfacet
+
+ facet normal -0.447214 0 0.894427
+  outer loop
+  vertex -0.45 3.25 0.8
+  vertex 1.35 3.25 0.8
+  vertex 1.35 3.25 0
+  endloop
+ endfacet
+
+ facet normal -0.57735 0.57735 0.57735
+  outer loop
+  vertex 1.35 3.25 0
+  vertex 1.35 3.25 0.8
+  vertex 1.35 3.65 0
+  endloop
+ endfacet
+
+ facet normal 0 0.447214 0.894427
+  outer loop
+  vertex 1.35 3.25 0.8
+  vertex 1.35 3.65 0.8
+  vertex 1.35 3.65 0
+  endloop
+ endfacet
+
+ facet normal 0 0.894427 0.447214
+  outer loop
+  vertex 1.35 3.65 0
+  vertex 1.35 3.65 0.8
+  vertex 1.55 3.65 0
+  endloop
+ endfacet
+
+ facet normal 0 0.447214 0.894427
+  outer loop
+  vertex 1.35 3.65 0.8
+  vertex 1.55 3.65 0.8
+  vertex 1.55 3.65 0
+  endloop
+ endfacet
+
+ facet normal 0 0 1
+  outer loop
+  vertex 1.35 3.65 0.8
+  vertex 1.55 3.025 0.8
+  vertex 1.55 3.65 0.8
+  endloop
+ endfacet
+
+ facet normal 0 0 1
+  outer loop
+  vertex 1.35 3.25 0.8
+  vertex 1.55 3.025 0.8
+  vertex 1.35 3.65 0.8
+  endloop
+ endfacet
+
+ facet normal 0 0 1
+  outer loop
+  vertex 1.35 3.25 0.8
+  vertex -0.25 3.025 0.8
+  vertex 1.55 3.025 0.8
+  endloop
+ endfacet
+
+ facet normal 0 0 1
+  outer loop
+  vertex -0.45 3.25 0.8
+  vertex -0.25 3.025 0.8
+  vertex 1.35 3.25 0.8
+  endloop
+ endfacet
+
+ facet normal 0 0 1
+  outer loop
+  vertex -0.45 0.825 0.8
+  vertex -0.25 3.025 0.8
+  vertex -0.45 3.25 0.8
+  endloop
+ endfacet
+
+ facet normal 0 0 1
+  outer loop
+  vertex -0.45 0.825 0.8
+  vertex -0.25 0.625 0.8
+  vertex -0.25 3.025 0.8
+  endloop
+ endfacet
+
+ facet normal 0 0 1
+  outer loop
+  vertex -0.45 0.825 0.8
+  vertex -0.85 0.625 0.8
+  vertex -0.25 0.625 0.8
+  endloop
+ endfacet
+
+ facet normal 0 0 1
+  outer loop
+  vertex -0.45 0.825 0.8
+  vertex -0.85 0.825 0.8
+  vertex -0.85 0.625 0.8
+  endloop
+ endfacet
+
+ facet normal 0 0 1
+  outer loop
+  vertex 3.55 3.45 0
+  vertex 3.55 3.45 0.8
+  vertex 3.55 3.05 0
+  endloop
+ endfacet
+
+ facet normal 0 -0.447214 0.894427
+  outer loop
+  vertex 3.55 3.45 0.8
+  vertex 3.55 3.05 0.8
+  vertex 3.55 3.05 0
+  endloop
+ endfacet
+
+ facet normal -0.57735 -0.57735 0.57735
+  outer loop
+  vertex 3.55 3.05 0
+  vertex 3.55 3.05 0.8
+  vertex 2.55 3.05 0
+  endloop
+ endfacet
+
+ facet normal -0.447214 0 0.894427
+  outer loop
+  vertex 3.55 3.05 0.8
+  vertex 2.55 3.05 0.8
+  vertex 2.55 3.05 0
+  endloop
+ endfacet
+
+ facet normal -0.57735 0.57735 0.57735
+  outer loop
+  vertex 2.55 3.05 0
+  vertex 2.55 3.05 0.8
+  vertex 2.55 3.25 0
+  endloop
+ endfacet
+
+ facet normal 0 0.447214 0.894427
+  outer loop
+  vertex 2.55 3.05 0.8
+  vertex 2.55 3.25 0.8
+  vertex 2.55 3.25 0
+  endloop
+ endfacet
+
+ facet normal -0.57735 0.57735 0.57735
+  outer loop
+  vertex 2.55 3.25 0
+  vertex 2.55 3.25 0.8
+  vertex 3.35 3.25 0
+  endloop
+ endfacet
+
+ facet normal -0.447214 0 0.894427
+  outer loop
+  vertex 2.55 3.25 0.8
+  vertex 3.35 3.25 0.8
+  vertex 3.35 3.25 0
+  endloop
+ endfacet
+
+ facet normal -0.57735 0.57735 0.57735
+  outer loop
+  vertex 3.35 3.25 0
+  vertex 3.35 3.25 0.8
+  vertex 3.35 3.45 0
+  endloop
+ endfacet
+
+ facet normal 0 0.447214 0.894427
+  outer loop
+  vertex 3.35 3.25 0.8
+  vertex 3.35 3.45 0.8
+  vertex 3.35 3.45 0
+  endloop
+ endfacet
+
+ facet normal 0 0.894427 0.447214
+  outer loop
+  vertex 3.35 3.45 0
+  vertex 3.35 3.45 0.8
+  vertex 3.55 3.45 0
+  endloop
+ endfacet
+
+ facet normal 0 0.447214 0.894427
+  outer loop
+  vertex 3.35 3.45 0.8
+  vertex 3.55 3.45 0.8
+  vertex 3.55 3.45 0
+  endloop
+ endfacet
+
+ facet normal 0 0 1
+  outer loop
+  vertex 3.35 3.45 0.8
+  vertex 3.55 3.05 0.8
+  vertex 3.55 3.45 0.8
+  endloop
+ endfacet
+
+ facet normal 0 0 1
+  outer loop
+  vertex 3.35 3.25 0.8
+  vertex 3.55 3.05 0.8
+  vertex 3.35 3.45 0.8
+  endloop
+ endfacet
+
+ facet normal 0 0 1
+  outer loop
+  vertex 3.35 3.25 0.8
+  vertex 2.55 3.05 0.8
+  vertex 3.55 3.05 0.8
+  endloop
+ endfacet
+
+ facet normal 0 0 1
+  outer loop
+  vertex 3.35 3.25 0.8
+  vertex 2.55 3.25 0.8
+  vertex 2.55 3.05 0.8
+  endloop
+ endfacet
+
+ facet normal 0 0 1
+  outer loop
+  vertex -1.75 0.825 0
+  vertex -1.75 0.825 0.8
+  vertex -1.75 0.625 0
+  endloop
+ endfacet
+
+ facet normal 0 -0.447214 0.894427
+  outer loop
+  vertex -1.75 0.825 0.8
+  vertex -1.75 0.625 0.8
+  vertex -1.75 0.625 0
+  endloop
+ endfacet
+
+ facet normal -0.57735 -0.57735 0.57735
+  outer loop
+  vertex -1.75 0.625 0
+  vertex -1.75 0.625 0.8
+  vertex -3.75 0.625 0
+  endloop
+ endfacet
+
+ facet normal -0.447214 0 0.894427
+  outer loop
+  vertex -1.75 0.625 0.8
+  vertex -3.75 0.625 0.8
+  vertex -3.75 0.625 0
+  endloop
+ endfacet
+
+ facet normal -0.57735 0.57735 0.57735
+  outer loop
+  vertex -3.75 0.625 0
+  vertex -3.75 0.625 0.8
+  vertex -3.75 0.825 0
+  endloop
+ endfacet
+
+ facet normal 0 0.447214 0.894427
+  outer loop
+  vertex -3.75 0.625 0.8
+  vertex -3.75 0.825 0.8
+  vertex -3.75 0.825 0
+  endloop
+ endfacet
+
+ facet normal 0 0.894427 0.447214
+  outer loop
+  vertex -3.75 0.825 0
+  vertex -3.75 0.825 0.8
+  vertex -1.75 0.825 0
+  endloop
+ endfacet
+
+ facet normal 0 0.447214 0.894427
+  outer loop
+  vertex -3.75 0.825 0.8
+  vertex -1.75 0.825 0.8
+  vertex -1.75 0.825 0
+  endloop
+ endfacet
+
+ facet normal 0 0 1
+  outer loop
+  vertex -3.75 0.825 0.8
+  vertex -1.75 0.625 0.8
+  vertex -1.75 0.825 0.8
+  endloop
+ endfacet
+
+ facet normal 0 0 1
+  outer loop
+  vertex -3.75 0.825 0.8
+  vertex -3.75 0.625 0.8
+  vertex -1.75 0.625 0.8
+  endloop
+ endfacet
+
+ facet normal 0 0 1
+  outer loop
+  vertex -0.25 -0.5 0
+  vertex -0.25 -0.5 0.8
+  vertex -0.25 -1.7 0
+  endloop
+ endfacet
+
+ facet normal 0 -0.447214 0.894427
+  outer loop
+  vertex -0.25 -0.5 0.8
+  vertex -0.25 -1.7 0.8
+  vertex -0.25 -1.7 0
+  endloop
+ endfacet
+
+ facet normal -0.57735 -0.57735 0.57735
+  outer loop
+  vertex -0.25 -1.7 0
+  vertex -0.25 -1.7 0.8
+  vertex -0.45 -1.7 0
+  endloop
+ endfacet
+
+ facet normal -0.447214 0 0.894427
+  outer loop
+  vertex -0.25 -1.7 0.8
+  vertex -0.45 -1.7 0.8
+  vertex -0.45 -1.7 0
+  endloop
+ endfacet
+
+ facet normal -0.57735 0.57735 0.57735
+  outer loop
+  vertex -0.45 -1.7 0
+  vertex -0.45 -1.7 0.8
+  vertex -0.45 -0.5 0
+  endloop
+ endfacet
+
+ facet normal 0 0.447214 0.894427
+  outer loop
+  vertex -0.45 -1.7 0.8
+  vertex -0.45 -0.5 0.8
+  vertex -0.45 -0.5 0
+  endloop
+ endfacet
+
+ facet normal 0 0.894427 0.447214
+  outer loop
+  vertex -0.45 -0.5 0
+  vertex -0.45 -0.5 0.8
+  vertex -0.25 -0.5 0
+  endloop
+ endfacet
+
+ facet normal 0 0.447214 0.894427
+  outer loop
+  vertex -0.45 -0.5 0.8
+  vertex -0.25 -0.5 0.8
+  vertex -0.25 -0.5 0
+  endloop
+ endfacet
+
+ facet normal 0 0 1
+  outer loop
+  vertex -0.45 -0.5 0.8
+  vertex -0.25 -1.7 0.8
+  vertex -0.25 -0.5 0.8
+  endloop
+ endfacet
+
+ facet normal 0 0 1
+  outer loop
+  vertex -0.45 -0.5 0.8
+  vertex -0.45 -1.7 0.8
+  vertex -0.25 -1.7 0.8
+  endloop
+ endfacet
+
+ facet normal 0 0 1
+  outer loop
+  vertex 11 -1.7 0
+  vertex 11 -1.7 0.054902
+  vertex 11 -1.775 0
+  endloop
+ endfacet
+
+ facet normal 0 -0.447214 0.894427
+  outer loop
+  vertex 11 -1.7 0.054902
+  vertex 11 -1.775 0.054902
+  vertex 11 -1.775 0
+  endloop
+ endfacet
+
+ facet normal -0.57735 -0.57735 0.57735
+  outer loop
+  vertex 11 -1.775 0
+  vertex 11 -1.775 0.054902
+  vertex 8.65 -1.775 0
+  endloop
+ endfacet
+
+ facet normal -0.447214 0 0.894427
+  outer loop
+  vertex 11 -1.775 0.054902
+  vertex 8.65 -1.775 0.054902
+  vertex 8.65 -1.775 0
+  endloop
+ endfacet
+
+ facet normal -0.57735 0.57735 0.57735
+  outer loop
+  vertex 8.65 -1.775 0
+  vertex 8.65 -1.775 0.054902
+  vertex 8.65 -1.7 0
+  endloop
+ endfacet
+
+ facet normal 0 0.447214 0.894427
+  outer loop
+  vertex 8.65 -1.775 0.054902
+  vertex 8.65 -1.7 0.054902
+  vertex 8.65 -1.7 0
+  endloop
+ endfacet
+
+ facet normal 0 0.894427 0.447214
+  outer loop
+  vertex 8.65 -1.7 0
+  vertex 8.65 -1.7 0.054902
+  vertex 11 -1.7 0
+  endloop
+ endfacet
+
+ facet normal 0 0.447214 0.894427
+  outer loop
+  vertex 8.65 -1.7 0.054902
+  vertex 11 -1.7 0.054902
+  vertex 11 -1.7 0
+  endloop
+ endfacet
+
+ facet normal 0 0 1
+  outer loop
+  vertex 8.65 -1.7 0.054902
+  vertex 11 -1.775 0.054902
+  vertex 11 -1.7 0.054902
+  endloop
+ endfacet
+
+ facet normal 0 0 1
+  outer loop
+  vertex 8.65 -1.7 0.054902
+  vertex 8.65 -1.775 0.054902
+  vertex 11 -1.775 0.054902
+  endloop
+ endfacet
+
+endsolid AssimpScene

--- a/package.xml
+++ b/package.xml
@@ -21,6 +21,7 @@
   <run_depend>tue_filesystem</run_depend>
   <run_depend>tue_config</run_depend>
   <run_depend>yaml-cpp</run_depend>
+  <run_depend>ed</run_depend>
   <run_depend>ed_msgs</run_depend>
   <run_depend>gazebo_models</run_depend>
 

--- a/src/ed_object_models/conversion_sdf.py
+++ b/src/ed_object_models/conversion_sdf.py
@@ -409,11 +409,13 @@ def convert_world(yml, model_name, recursive=False):
     :return: sdf dict of the model
     :rtype: dict
     """
-    world = {"name": model_name, "include": [], "model": [],
-             "light": {"type": "directional", "name": "sun",
-                       "cast_shadows": "true", "pose": "0 0 10 0 0 0", "diffuse": "0.8 0.8 0.8 1",
-                       "specular": "0.2 0.2 0.2 1", "direction": "0.5 0.1 -0.9",
-                       "attenuation": {"range": 1000, "constant": 0.9, "linear": 0.01, "quadratic": 0.001}}}
+    light = {"type": "directional", "name": "sun",
+             "cast_shadows": "true", "pose": "0 0 10 0 0 0", "diffuse": "0.8 0.8 0.8 1",
+             "specular": "0.2 0.2 0.2 1", "direction": "0.5 0.1 -0.9",
+             "attenuation": {"range": 1000, "constant": 0.9, "linear": 0.01, "quadratic": 0.001}}
+    physics = {"type": "ode", "real_time_update_rate": 333.0, "max_step_size": 0.003,
+               "ode": {"solver": {"type": "quick", "iters": 100}, "constraints": {"cfm": 0.0001}}}
+    world = {"name": model_name, "include": [], "model": [], "light": light, "physics": physics}
 
     world_include = world["include"]
     world_model = world["model"]

--- a/src/ed_object_models/conversion_sdf.py
+++ b/src/ed_object_models/conversion_sdf.py
@@ -142,54 +142,25 @@ def read_geometry(shape_item, model_name):
         # If there is a path and a blockheight in the shape_item, then there is a heightmap included in the yaml file
         model_folder = path.dirname(get_model_path(model_name))
         image_path = model_folder + "/{}".format(shape_item["path"])
-        new_image_path = "{}_converted.png".format(path.splitext(image_path)[0])
+        mesh_path = "{}.stl".format(path.splitext(image_path)[0])
 
         # Execute ImageMagick command to invert the image
         try:
-            check_call("convert -negate {} {}".format(image_path, new_image_path), shell=True)
+            check_call("rosrun ed ed_heightmap_to_mesh {} {} {} {} {} {}".
+                       format(image_path,
+                              mesh_path,
+                              shape_item["resolution"],
+                              shape_item["blockheight"],
+                              shape_item["origin_x"],
+                              shape_item["origin_y"]),
+                       executable="/bin/bash",
+                       shell=True)
         except Exception as e:
             print(bcolors.FAIL + bcolors.BOLD + "[{}] ".format(model_name) + str(e) + bcolors.ENDC)
             raise
 
-        # Import the new png image and get its sizes to determine the physical square length (in meters) of the map
-        with Image.open(new_image_path, "r") as f:
-            width, height = f.size
-        new_image_size = int(pow(2, (max(width, height)-2).bit_length())+1)
-
-        # SDF heightmap origin is the center of the image, while our simulator has its origin at a corner (bottom-left).
-        # So the origin (in the yaml) is converted such that the heightmap is placed correctly in SDF
-        resolution = shape_item["resolution"]
-        old_map_center = [0.5 * width * resolution, 0.5 * height * resolution, 0.]
-        map_pos_list = [-round(-shape_item["origin_x"] - old_map_center[0], 3),
-                        -round(-shape_item["origin_y"] - old_map_center[1], 3),
-                        -round(-shape_item["origin_z"] - old_map_center[2], 3)]
-        map_pos = " ".join(map(str, map_pos_list))
-
-        size_new_list = [new_image_size * resolution, new_image_size * resolution, shape_item["blockheight"]] 
-        size_new = " ".join(map(str, size_new_list))
-
-        sdf_heightmap = {"uri": "model://{}/{}".format(model_name, path.relpath(new_image_path, model_folder)),
-                         "size": size_new,
-                         "pos": map_pos}
-        geometry["heightmap"] = sdf_heightmap
-
-        # Execute Imagemagick command to resize its canvas with provided resolution, keeping the image centered.
-        try:
-            check_call("convert {0} -background black -gravity center -extent {1}x{1} {0}"
-                       .format(new_image_path, new_image_size), shell=True)
-        except Exception as e:
-            print(bcolors.FAIL + bcolors.BOLD + "[{}] ".format(model_name) + str(e) + bcolors.ENDC)
-            raise
-
-        # Flatten image layers
-        try:
-            check_call("convert {0} -flatten {0}".format(new_image_path, new_image_size), shell=True)
-        except Exception as e:
-            print(bcolors.FAIL + bcolors.BOLD + "[{}] ".format(model_name) + str(e) + bcolors.ENDC)
-            raise
-
-        print(bcolors.OKGREEN + "[{}] Successfully created new heightmap:".format(model_name))
-        print(new_image_path + bcolors.ENDC)
+        sdf_mesh = {"uri": "model://{}/{}".format(model_name, path.relpath(mesh_path, model_folder))}
+        geometry["mesh"] = sdf_mesh
 
     elif "path" in shape_item and ".xml" in shape_item["path"]:
         print(bcolors.WARNING +


### PR DESCRIPTION
- add physics to world files, copied from Toyota's '_fast' models
- convert heightmaps to mesh, as gazebo doesn't like heightmaps
  - The code for converting the heightmap is in ed, this is a very ugly dependency. But I would like to keep the code there. @jlunenburg what do you think of this 'dependency'