### PR TITLE
Reduce diff sdf spec

### DIFF
--- a/models/amigo_case/model.sdf
+++ b/models/amigo_case/model.sdf
@@ -8,7 +8,6 @@
             <size>0.92 0.83 1.56</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -16,10 +15,8 @@
             <size>0.92 0.83 1.56</size>
           </box>
         </geometry>
-        <name>1</name>
       </visual>
       <pose>0 0 0.78 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="on_top_of">
       <virtual_volume name="on_top_of">
@@ -29,9 +26,7 @@
           </box>
         </geometry>
         <pose>0.0 0.0 1.705 0 0 0</pose>
-        <name>on_top_of</name>
       </virtual_volume>
-      <name>on_top_of</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
@@ -41,11 +36,8 @@
           </box>
         </geometry>
         <pose>0.96 0.0 0.005 0 0 0</pose>
-        <name>in_front_of</name>
       </virtual_volume>
-      <name>in_front_of</name>
     </link>
     <static>true</static>
-    <name>amigo_case</name>
   </model>
 </sdf>

--- a/models/bed/model.sdf
+++ b/models/bed/model.sdf
@@ -9,11 +9,8 @@
           </box>
         </geometry>
         <pose>0.0 -0.6 0.5 0 0 0</pose>
-        <name>in_front_of</name>
       </virtual_volume>
-      <name>in_front_of</name>
     </link>
     <static>true</static>
-    <name>bed</name>
   </model>
 </sdf>

--- a/models/cabinet/model.sdf
+++ b/models/cabinet/model.sdf
@@ -2,6 +2,5 @@
 <sdf version="1.6">
   <model name="cabinet">
     <static>true</static>
-    <name>cabinet</name>
   </model>
 </sdf>

--- a/models/coffee_table/model.sdf
+++ b/models/coffee_table/model.sdf
@@ -8,7 +8,6 @@
             <size>0.5 0.8 0.04</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -19,10 +18,8 @@
         <material>
           <ambient>0.7 0.4 0.25 1</ambient>
         </material>
-        <name>1</name>
       </visual>
       <pose>0 0 0.32 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="2">
       <collision name="2">
@@ -31,7 +28,6 @@
             <size>0.08 0.08 0.3</size>
           </box>
         </geometry>
-        <name>2</name>
       </collision>
       <visual name="2">
         <geometry>
@@ -42,10 +38,8 @@
         <material>
           <ambient>0.7 0.4 0.25 1</ambient>
         </material>
-        <name>2</name>
       </visual>
       <pose>-0.21 -0.36 0.15 0 0 0</pose>
-      <name>2</name>
     </link>
     <link name="3">
       <collision name="3">
@@ -54,7 +48,6 @@
             <size>0.08 0.08 0.3</size>
           </box>
         </geometry>
-        <name>3</name>
       </collision>
       <visual name="3">
         <geometry>
@@ -65,10 +58,8 @@
         <material>
           <ambient>0.7 0.4 0.25 1</ambient>
         </material>
-        <name>3</name>
       </visual>
       <pose>-0.21 0.36 0.15 0 0 0</pose>
-      <name>3</name>
     </link>
     <link name="4">
       <collision name="4">
@@ -77,7 +68,6 @@
             <size>0.08 0.08 0.3</size>
           </box>
         </geometry>
-        <name>4</name>
       </collision>
       <visual name="4">
         <geometry>
@@ -88,10 +78,8 @@
         <material>
           <ambient>0.7 0.4 0.25 1</ambient>
         </material>
-        <name>4</name>
       </visual>
       <pose>0.21 0.36 0.15 0 0 0</pose>
-      <name>4</name>
     </link>
     <link name="5">
       <collision name="5">
@@ -100,7 +88,6 @@
             <size>0.08 0.08 0.3</size>
           </box>
         </geometry>
-        <name>5</name>
       </collision>
       <visual name="5">
         <geometry>
@@ -111,12 +98,9 @@
         <material>
           <ambient>0.7 0.4 0.25 1</ambient>
         </material>
-        <name>5</name>
       </visual>
       <pose>0.21 -0.36 0.15 0 0 0</pose>
-      <name>5</name>
     </link>
     <static>true</static>
-    <name>coffee_table</name>
   </model>
 </sdf>

--- a/models/cover/model.sdf
+++ b/models/cover/model.sdf
@@ -4,7 +4,6 @@
     <light name="sun" type="directional">
       <direction>0.5 0.1 -0.9</direction>
       <pose>0 0 10 0 0 0</pose>
-      <name>sun</name>
       <specular>0.2 0.2 0.2 1</specular>
       <cast_shadows>true</cast_shadows>
       <diffuse>0.8 0.8 0.8 1</diffuse>
@@ -15,32 +14,32 @@
         <linear>0.01</linear>
       </attenuation>
     </light>
-    <include name="floor">
+    <include>
       <pose>0 0 0 0 0 0</pose>
       <name>floor</name>
       <uri>model://floor</uri>
     </include>
-    <include name="wall">
+    <include>
       <pose>0.0 0.0 0 0 0 0</pose>
       <name>wall</name>
       <uri>model://cover/walls</uri>
     </include>
-    <include name="expedit">
+    <include>
       <pose>1.495 1.1 0.0 0.0 0.0 1.57</pose>
       <name>expedit</name>
       <uri>model://expedit/cabinet</uri>
     </include>
-    <include name="expedit_door_left">
+    <include>
       <pose>1.3175 0.915 0.5875 0.0 0.0 1.57</pose>
       <name>expedit_door_left</name>
       <uri>model://expedit/door</uri>
     </include>
-    <include name="expedit_door_right">
+    <include>
       <pose>1.6725 0.915 0.5875 0.0 0.0 1.57</pose>
       <name>expedit_door_right</name>
       <uri>model://expedit.door</uri>
     </include>
-    <include name="coffee_table">
+    <include>
       <pose>2.0 -1.3 0.0 0.0 0.0 1.5708</pose>
       <name>coffee_table</name>
       <uri>model://coffee_table</uri>
@@ -57,6 +56,5 @@
         </solver>
       </ode>
     </physics>
-    <name>cover</name>
   </world>
 </sdf>

--- a/models/cover/walls/model.sdf
+++ b/models/cover/walls/model.sdf
@@ -8,7 +8,6 @@
             <uri>model://cover/walls/covered.stl</uri>
           </mesh>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -19,12 +18,9 @@
         <material>
           <ambient>0.4 0.4 0.0 1</ambient>
         </material>
-        <name>1</name>
       </visual>
       <pose>0 0 0 0 0 0</pose>
-      <name>1</name>
     </link>
     <static>true</static>
-    <name>cover/walls</name>
   </model>
 </sdf>

--- a/models/ddw/chair/model.sdf
+++ b/models/ddw/chair/model.sdf
@@ -8,7 +8,6 @@
             <size>0.4 0.4 1.0</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -16,10 +15,8 @@
             <size>0.4 0.4 1.0</size>
           </box>
         </geometry>
-        <name>1</name>
       </visual>
       <pose>0 0 0.5 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
@@ -29,11 +26,8 @@
           </box>
         </geometry>
         <pose>0.7 0.0 0.005 0 0 0</pose>
-        <name>in_front_of</name>
       </virtual_volume>
-      <name>in_front_of</name>
     </link>
     <static>true</static>
-    <name>ddw/chair</name>
   </model>
 </sdf>

--- a/models/ddw/couch/model.sdf
+++ b/models/ddw/couch/model.sdf
@@ -9,7 +9,6 @@
           </box>
         </geometry>
         <pose>0.0 0.0 0.375 0 0 0</pose>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -21,10 +20,8 @@
           <ambient>0.8 0.8 0.8 1</ambient>
         </material>
         <pose>0.0 0.0 0.375 0 0 0</pose>
-        <name>1</name>
       </visual>
       <pose>0 0 0 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
@@ -34,9 +31,7 @@
           </box>
         </geometry>
         <pose>0.45 0.0 0.005 0 0 0</pose>
-        <name>in_front_of</name>
       </virtual_volume>
-      <name>in_front_of</name>
     </link>
     <link name="on_top_of">
       <virtual_volume name="on_top_of">
@@ -46,11 +41,8 @@
           </box>
         </geometry>
         <pose>0.0 0.0 0.985 0 0 0</pose>
-        <name>on_top_of</name>
       </virtual_volume>
-      <name>on_top_of</name>
     </link>
     <static>true</static>
-    <name>ddw/couch</name>
   </model>
 </sdf>

--- a/models/ddw/desk/model.sdf
+++ b/models/ddw/desk/model.sdf
@@ -8,7 +8,6 @@
             <size>1.18 0.7 0.78</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -19,12 +18,9 @@
         <material>
           <ambient>0.8 0.8 0.8 1</ambient>
         </material>
-        <name>1</name>
       </visual>
       <pose>0.0 0.0 0.39 0 0 0</pose>
-      <name>1</name>
     </link>
     <static>true</static>
-    <name>ddw/desk</name>
   </model>
 </sdf>

--- a/models/ddw/model.sdf
+++ b/models/ddw/model.sdf
@@ -4,7 +4,6 @@
     <light name="sun" type="directional">
       <direction>0.5 0.1 -0.9</direction>
       <pose>0 0 10 0 0 0</pose>
-      <name>sun</name>
       <specular>0.2 0.2 0.2 1</specular>
       <cast_shadows>true</cast_shadows>
       <diffuse>0.8 0.8 0.8 1</diffuse>
@@ -15,42 +14,42 @@
         <linear>0.01</linear>
       </attenuation>
     </light>
-    <include name="walls">
+    <include>
       <pose>0 0 0 0 0 0</pose>
       <name>walls</name>
       <uri>model://ddw/walls</uri>
     </include>
-    <include name="floor">
+    <include>
       <pose>0 0 0 0 0 0</pose>
       <name>floor</name>
       <uri>model://floor</uri>
     </include>
-    <include name="couch">
+    <include>
       <pose>-0.4 -1.3 0 0 0 0</pose>
       <name>couch</name>
       <uri>model://ddw/couch</uri>
     </include>
-    <include name="chair">
+    <include>
       <pose>2.5 1.05 0 0 0 0</pose>
       <name>chair</name>
       <uri>model://ddw/chair</uri>
     </include>
-    <include name="table">
+    <include>
       <pose>0.9 1.22 0 0 0 0</pose>
       <name>table</name>
       <uri>model://ddw/table</uri>
     </include>
-    <include name="sidetable">
+    <include>
       <pose>0.2 3.25 0 0 0 0</pose>
       <name>sidetable</name>
       <uri>model://ddw/sidetable</uri>
     </include>
-    <include name="couchtable">
+    <include>
       <pose>1.56 -1.18 0 0 0 0</pose>
       <name>couchtable</name>
       <uri>model://ddw/salon</uri>
     </include>
-    <include name="desk">
+    <include>
       <pose>2.85 3.35 0 0 0 0</pose>
       <name>desk</name>
       <uri>model://ddw/desk</uri>
@@ -67,6 +66,5 @@
         </solver>
       </ode>
     </physics>
-    <name>ddw</name>
   </world>
 </sdf>

--- a/models/ddw/salon/model.sdf
+++ b/models/ddw/salon/model.sdf
@@ -8,7 +8,6 @@
             <size>0.4 1.2 0.4</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -19,10 +18,8 @@
         <material>
           <ambient>0.8 0.8 0.8 1</ambient>
         </material>
-        <name>1</name>
       </visual>
       <pose>0 0 0.2 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
@@ -32,9 +29,7 @@
           </box>
         </geometry>
         <pose>0.45 0.0 0.005 0 0 0</pose>
-        <name>in_front_of</name>
       </virtual_volume>
-      <name>in_front_of</name>
     </link>
     <link name="on_top_of">
       <virtual_volume name="on_top_of">
@@ -44,11 +39,8 @@
           </box>
         </geometry>
         <pose>0.0 0.0 0.62 0 0 0</pose>
-        <name>on_top_of</name>
       </virtual_volume>
-      <name>on_top_of</name>
     </link>
     <static>true</static>
-    <name>ddw/salon</name>
   </model>
 </sdf>

--- a/models/ddw/sidetable/model.sdf
+++ b/models/ddw/sidetable/model.sdf
@@ -8,7 +8,6 @@
             <size>1.8 0.4 0.9</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -19,12 +18,9 @@
         <material>
           <ambient>0.8 0.8 0.8 1</ambient>
         </material>
-        <name>1</name>
       </visual>
       <pose>0.0 0.0 0.45 0 0 0</pose>
-      <name>1</name>
     </link>
     <static>true</static>
-    <name>ddw/sidetable</name>
   </model>
 </sdf>

--- a/models/ddw/table/model.sdf
+++ b/models/ddw/table/model.sdf
@@ -8,7 +8,6 @@
             <size>0.4 1.5 0.75</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -19,10 +18,8 @@
         <material>
           <ambient>0.8 0.8 0.8 1</ambient>
         </material>
-        <name>1</name>
       </visual>
       <pose>0 0 0.375 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
@@ -32,9 +29,7 @@
           </box>
         </geometry>
         <pose>0.5 0.0 0.005 0 0 0</pose>
-        <name>in_front_of</name>
       </virtual_volume>
-      <name>in_front_of</name>
     </link>
     <link name="on_top_of">
       <virtual_volume name="on_top_of">
@@ -44,11 +39,8 @@
           </box>
         </geometry>
         <pose>0.0 0.0 0.92 0 0 0</pose>
-        <name>on_top_of</name>
       </virtual_volume>
-      <name>on_top_of</name>
     </link>
     <static>true</static>
-    <name>ddw/table</name>
   </model>
 </sdf>

--- a/models/ddw/walls/model.sdf
+++ b/models/ddw/walls/model.sdf
@@ -8,7 +8,6 @@
             <uri>model://ddw/walls/shape/heightmap.stl</uri>
           </mesh>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -19,12 +18,9 @@
         <material>
           <ambient>1.0 0.0 0.0 1</ambient>
         </material>
-        <name>1</name>
       </visual>
       <pose>0 0 0 0 0 0</pose>
-      <name>1</name>
     </link>
     <static>true</static>
-    <name>ddw/walls</name>
   </model>
 </sdf>

--- a/models/door/model.sdf
+++ b/models/door/model.sdf
@@ -2,6 +2,5 @@
 <sdf version="1.6">
   <model name="door">
     <static>true</static>
-    <name>door</name>
   </model>
 </sdf>

--- a/models/empty/model.sdf
+++ b/models/empty/model.sdf
@@ -4,7 +4,6 @@
     <light name="sun" type="directional">
       <direction>0.5 0.1 -0.9</direction>
       <pose>0 0 10 0 0 0</pose>
-      <name>sun</name>
       <specular>0.2 0.2 0.2 1</specular>
       <cast_shadows>true</cast_shadows>
       <diffuse>0.8 0.8 0.8 1</diffuse>
@@ -15,7 +14,7 @@
         <linear>0.01</linear>
       </attenuation>
     </light>
-    <include name="floor">
+    <include>
       <pose>0 0 0 0 0 0</pose>
       <name>floor</name>
       <uri>model://floor</uri>
@@ -32,6 +31,5 @@
         </solver>
       </ode>
     </physics>
-    <name>empty</name>
   </world>
 </sdf>

--- a/models/expedit/cabinet/model.sdf
+++ b/models/expedit/cabinet/model.sdf
@@ -8,7 +8,6 @@
             <size>0.4 0.79 0.05</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -19,10 +18,8 @@
         <material>
           <ambient>0.4 0.2 0.0745 1</ambient>
         </material>
-        <name>1</name>
       </visual>
       <pose>0 0 0.025 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="2">
       <collision name="2">
@@ -31,7 +28,6 @@
             <size>0.4 0.79 0.02</size>
           </box>
         </geometry>
-        <name>2</name>
       </collision>
       <visual name="2">
         <geometry>
@@ -42,10 +38,8 @@
         <material>
           <ambient>0.4 0.2 0.0745 1</ambient>
         </material>
-        <name>2</name>
       </visual>
       <pose>0 0 0.41 0 0 0</pose>
-      <name>2</name>
     </link>
     <link name="3">
       <collision name="3">
@@ -54,7 +48,6 @@
             <size>0.4 0.79 0.05</size>
           </box>
         </geometry>
-        <name>3</name>
       </collision>
       <visual name="3">
         <geometry>
@@ -65,10 +58,8 @@
         <material>
           <ambient>0.4 0.2 0.0745 1</ambient>
         </material>
-        <name>3</name>
       </visual>
       <pose>0 0 0.765 0 0 0</pose>
-      <name>3</name>
     </link>
     <link name="4">
       <collision name="4">
@@ -77,7 +68,6 @@
             <size>0.4 0.05 0.79</size>
           </box>
         </geometry>
-        <name>4</name>
       </collision>
       <visual name="4">
         <geometry>
@@ -88,10 +78,8 @@
         <material>
           <ambient>0.4 0.2 0.0745 1</ambient>
         </material>
-        <name>4</name>
       </visual>
       <pose>0 0.37 0.395 0 0 0</pose>
-      <name>4</name>
     </link>
     <link name="5">
       <collision name="5">
@@ -100,7 +88,6 @@
             <size>0.4 0.05 0.79</size>
           </box>
         </geometry>
-        <name>5</name>
       </collision>
       <visual name="5">
         <geometry>
@@ -111,10 +98,8 @@
         <material>
           <ambient>0.4 0.2 0.0745 1</ambient>
         </material>
-        <name>5</name>
       </visual>
       <pose>0 0 0.395 0 0 0</pose>
-      <name>5</name>
     </link>
     <link name="6">
       <collision name="6">
@@ -123,7 +108,6 @@
             <size>0.4 0.05 0.79</size>
           </box>
         </geometry>
-        <name>6</name>
       </collision>
       <visual name="6">
         <geometry>
@@ -134,12 +118,9 @@
         <material>
           <ambient>0.4 0.2 0.0745 1</ambient>
         </material>
-        <name>6</name>
       </visual>
       <pose>0 -0.37 0.395 0 0 0</pose>
-      <name>6</name>
     </link>
     <static>true</static>
-    <name>expedit/cabinet</name>
   </model>
 </sdf>

--- a/models/expedit/door/model.sdf
+++ b/models/expedit/door/model.sdf
@@ -8,7 +8,6 @@
             <size>0.02 0.335 0.335</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -19,12 +18,9 @@
         <material>
           <ambient>0.6 0.0 0.0 1</ambient>
         </material>
-        <name>1</name>
       </visual>
       <pose>0 0 0.025 0 0 0</pose>
-      <name>1</name>
     </link>
     <static>true</static>
-    <name>expedit/door</name>
   </model>
 </sdf>

--- a/models/floor/model.sdf
+++ b/models/floor/model.sdf
@@ -8,7 +8,6 @@
             <size>200 200 0.02</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -16,12 +15,9 @@
             <size>200 200 0.02</size>
           </box>
         </geometry>
-        <name>1</name>
       </visual>
       <pose>0 0 -0.01 0 0 0</pose>
-      <name>1</name>
     </link>
     <static>true</static>
-    <name>floor</name>
   </model>
 </sdf>

--- a/models/hero_case/model.sdf
+++ b/models/hero_case/model.sdf
@@ -8,7 +8,6 @@
             <size>0.5 0.6 1.2</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -16,10 +15,8 @@
             <size>0.49 0.71 1.01</size>
           </box>
         </geometry>
-        <name>1</name>
       </visual>
       <pose>0 0 0.505 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="on_top_of">
       <virtual_volume name="on_top_of">
@@ -29,11 +26,8 @@
           </box>
         </geometry>
         <pose>0.0 0.0 1.25 0 0 0</pose>
-        <name>on_top_of</name>
       </virtual_volume>
-      <name>on_top_of</name>
     </link>
     <static>true</static>
-    <name>floor</name>
   </model>
 </sdf>

--- a/models/human/model.sdf
+++ b/models/human/model.sdf
@@ -2,6 +2,5 @@
 <sdf version="1.6">
   <model name="human">
     <static>true</static>
-    <name>human</name>
   </model>
 </sdf>

--- a/models/laptop_case/model.sdf
+++ b/models/laptop_case/model.sdf
@@ -8,7 +8,6 @@
             <size>0.8 0.7 1.35</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -16,12 +15,9 @@
             <size>0.8 0.7 1.35</size>
           </box>
         </geometry>
-        <name>1</name>
       </visual>
       <pose>0.0 0.0 0.675 0 0 0</pose>
-      <name>1</name>
     </link>
     <static>true</static>
-    <name>laptop_case</name>
   </model>
 </sdf>

--- a/models/learn_objects/model.sdf
+++ b/models/learn_objects/model.sdf
@@ -4,7 +4,6 @@
     <light name="sun" type="directional">
       <direction>0.5 0.1 -0.9</direction>
       <pose>0 0 10 0 0 0</pose>
-      <name>sun</name>
       <specular>0.2 0.2 0.2 1</specular>
       <cast_shadows>true</cast_shadows>
       <diffuse>0.8 0.8 0.8 1</diffuse>
@@ -15,12 +14,12 @@
         <linear>0.01</linear>
       </attenuation>
     </light>
-    <include name="floor">
+    <include>
       <pose>0 0 0 0 0 0</pose>
       <name>floor</name>
       <uri>model://floor</uri>
     </include>
-    <include name="hero_case">
+    <include>
       <pose>0 -1 0 0 0 1.57</pose>
       <name>hero_case</name>
       <uri>model://hero_case</uri>
@@ -37,6 +36,5 @@
         </solver>
       </ode>
     </physics>
-    <name>learn_objects</name>
   </world>
 </sdf>

--- a/models/left_door/model.sdf
+++ b/models/left_door/model.sdf
@@ -2,6 +2,5 @@
 <sdf version="1.6">
   <model name="left_door">
     <static>true</static>
-    <name>left_door</name>
   </model>
 </sdf>

--- a/models/perception_learning/model.sdf
+++ b/models/perception_learning/model.sdf
@@ -4,7 +4,6 @@
     <light name="sun" type="directional">
       <direction>0.5 0.1 -0.9</direction>
       <pose>0 0 10 0 0 0</pose>
-      <name>sun</name>
       <specular>0.2 0.2 0.2 1</specular>
       <cast_shadows>true</cast_shadows>
       <diffuse>0.8 0.8 0.8 1</diffuse>
@@ -15,7 +14,7 @@
         <linear>0.01</linear>
       </attenuation>
     </light>
-    <include name="infinite_table">
+    <include>
       <pose>0 0 0.74 0 0 0</pose>
       <name>infinite_table</name>
       <uri>model://floor</uri>
@@ -32,6 +31,5 @@
         </solver>
       </ode>
     </physics>
-    <name>perception_learning</name>
   </world>
 </sdf>

--- a/models/rein_experiment/model.sdf
+++ b/models/rein_experiment/model.sdf
@@ -4,7 +4,6 @@
     <light name="sun" type="directional">
       <direction>0.5 0.1 -0.9</direction>
       <pose>0 0 10 0 0 0</pose>
-      <name>sun</name>
       <specular>0.2 0.2 0.2 1</specular>
       <cast_shadows>true</cast_shadows>
       <diffuse>0.8 0.8 0.8 1</diffuse>
@@ -18,34 +17,29 @@
     <model name="corridor_start" type="waypoint">
       <pose>7.3 5.6 0 0 0 0</pose>
       <static>true</static>
-      <name>corridor_start</name>
     </model>
     <model name="corridor_end" type="waypoint">
       <pose>7.3 -5.8 0 0 0 0</pose>
       <static>true</static>
-      <name>corridor_end</name>
     </model>
     <model name="chillout_corner" type="waypoint">
       <pose>5.5 -1.0 0 0 0 0</pose>
       <static>true</static>
-      <name>chillout_corner</name>
     </model>
     <model name="bedroom" type="waypoint">
       <pose>3.1 5.6 0 0 0 0</pose>
       <static>true</static>
-      <name>bedroom</name>
     </model>
     <model name="living_room" type="waypoint">
       <pose>0 -5.0 0 0 0 0</pose>
       <static>true</static>
-      <name>living_room</name>
     </model>
-    <include name="walls">
+    <include>
       <pose>0 0 0 0 0 0</pose>
       <name>walls</name>
       <uri>model://rein_experiment/walls</uri>
     </include>
-    <include name="floor">
+    <include>
       <pose>0 0 0 0 0 0</pose>
       <name>floor</name>
       <uri>model://floor</uri>
@@ -62,6 +56,5 @@
         </solver>
       </ode>
     </physics>
-    <name>rein_experiment</name>
   </world>
 </sdf>

--- a/models/rein_experiment/walls/model.sdf
+++ b/models/rein_experiment/walls/model.sdf
@@ -8,7 +8,6 @@
             <uri>model://rein_experiment/walls/shape/heightmap.stl</uri>
           </mesh>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -16,12 +15,9 @@
             <uri>model://rein_experiment/walls/shape/heightmap.stl</uri>
           </mesh>
         </geometry>
-        <name>1</name>
       </visual>
       <pose>0 0 0 0 0 0</pose>
-      <name>1</name>
     </link>
     <static>true</static>
-    <name>rein_experiment/walls</name>
   </model>
 </sdf>

--- a/models/reo2016/bed/model.sdf
+++ b/models/reo2016/bed/model.sdf
@@ -8,7 +8,6 @@
             <size>2.0 1.435 0.47</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -16,10 +15,8 @@
             <size>2.0 1.435 0.47</size>
           </box>
         </geometry>
-        <name>1</name>
       </visual>
       <pose>0.0 0.0 0.235 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="on_top_of">
       <virtual_volume name="on_top_of">
@@ -29,9 +26,7 @@
           </box>
         </geometry>
         <pose>0.0 0.0 0.615 0 0 0</pose>
-        <name>on_top_of</name>
       </virtual_volume>
-      <name>on_top_of</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
@@ -41,11 +36,8 @@
           </box>
         </geometry>
         <pose>-1.7 0.0 0.005 0 0 0</pose>
-        <name>in_front_of</name>
       </virtual_volume>
-      <name>in_front_of</name>
     </link>
     <static>true</static>
-    <name>reo2016/bed</name>
   </model>
 </sdf>

--- a/models/reo2016/bookcase/model.sdf
+++ b/models/reo2016/bookcase/model.sdf
@@ -8,7 +8,6 @@
             <size>0.28 0.018 2.025</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -16,10 +15,8 @@
             <size>0.28 0.018 2.025</size>
           </box>
         </geometry>
-        <name>1</name>
       </visual>
       <pose>0 -0.391 1.0125 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="2">
       <collision name="2">
@@ -28,7 +25,6 @@
             <size>0.28 0.018 2.025</size>
           </box>
         </geometry>
-        <name>2</name>
       </collision>
       <visual name="2">
         <geometry>
@@ -36,10 +32,8 @@
             <size>0.28 0.018 2.025</size>
           </box>
         </geometry>
-        <name>2</name>
       </visual>
       <pose>0 0.391 1.0125 0 0 0</pose>
-      <name>2</name>
     </link>
     <link name="3">
       <collision name="3">
@@ -48,7 +42,6 @@
             <size>0.018 0.8 2.025</size>
           </box>
         </geometry>
-        <name>3</name>
       </collision>
       <visual name="3">
         <geometry>
@@ -56,10 +49,8 @@
             <size>0.018 0.8 2.025</size>
           </box>
         </geometry>
-        <name>3</name>
       </visual>
       <pose>0.131 0 1.0125 0 0 0</pose>
-      <name>3</name>
     </link>
     <link name="4">
       <collision name="4">
@@ -68,7 +59,6 @@
             <size>0.262 0.764 0.018</size>
           </box>
         </geometry>
-        <name>4</name>
       </collision>
       <visual name="4">
         <geometry>
@@ -76,10 +66,8 @@
             <size>0.262 0.764 0.018</size>
           </box>
         </geometry>
-        <name>4</name>
       </visual>
       <pose>-0.009 0 2.016 0 0 0</pose>
-      <name>4</name>
     </link>
     <link name="5">
       <collision name="5">
@@ -88,7 +76,6 @@
             <size>0.262 0.764 0.018</size>
           </box>
         </geometry>
-        <name>5</name>
       </collision>
       <visual name="5">
         <geometry>
@@ -96,10 +83,8 @@
             <size>0.262 0.764 0.018</size>
           </box>
         </geometry>
-        <name>5</name>
       </visual>
       <pose>-0.009 0 0.081 0 0 0</pose>
-      <name>5</name>
     </link>
     <link name="6">
       <collision name="6">
@@ -108,7 +93,6 @@
             <size>0.262 0.764 0.018</size>
           </box>
         </geometry>
-        <name>6</name>
       </collision>
       <visual name="6">
         <geometry>
@@ -116,10 +100,8 @@
             <size>0.262 0.764 0.018</size>
           </box>
         </geometry>
-        <name>6</name>
       </visual>
       <pose>-0.009 0 0.408 0 0 0</pose>
-      <name>6</name>
     </link>
     <link name="7">
       <collision name="7">
@@ -128,7 +110,6 @@
             <size>0.262 0.764 0.018</size>
           </box>
         </geometry>
-        <name>7</name>
       </collision>
       <visual name="7">
         <geometry>
@@ -136,10 +117,8 @@
             <size>0.262 0.764 0.018</size>
           </box>
         </geometry>
-        <name>7</name>
       </visual>
       <pose>-0.009 0 0.729 0 0 0</pose>
-      <name>7</name>
     </link>
     <link name="8">
       <collision name="8">
@@ -148,7 +127,6 @@
             <size>0.262 0.764 0.018</size>
           </box>
         </geometry>
-        <name>8</name>
       </collision>
       <visual name="8">
         <geometry>
@@ -156,10 +134,8 @@
             <size>0.262 0.764 0.018</size>
           </box>
         </geometry>
-        <name>8</name>
       </visual>
       <pose>-0.009 0 1.053 0 0 0</pose>
-      <name>8</name>
     </link>
     <link name="9">
       <collision name="9">
@@ -168,7 +144,6 @@
             <size>0.262 0.764 0.018</size>
           </box>
         </geometry>
-        <name>9</name>
       </collision>
       <visual name="9">
         <geometry>
@@ -176,10 +151,8 @@
             <size>0.262 0.764 0.018</size>
           </box>
         </geometry>
-        <name>9</name>
       </visual>
       <pose>-0.009 0 1.368 0 0 0</pose>
-      <name>9</name>
     </link>
     <link name="10">
       <collision name="10">
@@ -188,7 +161,6 @@
             <size>0.262 0.764 0.018</size>
           </box>
         </geometry>
-        <name>10</name>
       </collision>
       <visual name="10">
         <geometry>
@@ -196,10 +168,8 @@
             <size>0.262 0.764 0.018</size>
           </box>
         </geometry>
-        <name>10</name>
       </visual>
       <pose>-0.009 0 1.689 0 0 0</pose>
-      <name>10</name>
     </link>
     <link name="on_top_of">
       <virtual_volume name="on_top_of">
@@ -209,9 +179,7 @@
           </box>
         </geometry>
         <pose>-0.015 0.0 0.895 0 0 0</pose>
-        <name>on_top_of</name>
       </virtual_volume>
-      <name>on_top_of</name>
     </link>
     <link name="shelf1">
       <virtual_volume name="shelf1">
@@ -221,9 +189,7 @@
           </box>
         </geometry>
         <pose>-0.015 0.0 0.245 0 0 0</pose>
-        <name>shelf1</name>
       </virtual_volume>
-      <name>shelf1</name>
     </link>
     <link name="shelf2">
       <virtual_volume name="shelf2">
@@ -233,9 +199,7 @@
           </box>
         </geometry>
         <pose>-0.065 0.0 0.565 0 0 0</pose>
-        <name>shelf2</name>
       </virtual_volume>
-      <name>shelf2</name>
     </link>
     <link name="shelf3">
       <virtual_volume name="shelf3">
@@ -245,9 +209,7 @@
           </box>
         </geometry>
         <pose>-0.015 0.0 0.895 0 0 0</pose>
-        <name>shelf3</name>
       </virtual_volume>
-      <name>shelf3</name>
     </link>
     <link name="shelf4">
       <virtual_volume name="shelf4">
@@ -257,9 +219,7 @@
           </box>
         </geometry>
         <pose>-0.015 0.0 1.215 0 0 0</pose>
-        <name>shelf4</name>
       </virtual_volume>
-      <name>shelf4</name>
     </link>
     <link name="shelf5">
       <virtual_volume name="shelf5">
@@ -269,9 +229,7 @@
           </box>
         </geometry>
         <pose>-0.015 0.0 1.535 0 0 0</pose>
-        <name>shelf5</name>
       </virtual_volume>
-      <name>shelf5</name>
     </link>
     <link name="shelf6">
       <virtual_volume name="shelf6">
@@ -281,9 +239,7 @@
           </box>
         </geometry>
         <pose>-0.015 0.0 1.855 0 0 0</pose>
-        <name>shelf6</name>
       </virtual_volume>
-      <name>shelf6</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
@@ -293,11 +249,8 @@
           </box>
         </geometry>
         <pose>-0.83 0.0 0.005 0 0 0</pose>
-        <name>in_front_of</name>
       </virtual_volume>
-      <name>in_front_of</name>
     </link>
     <static>true</static>
-    <name>reo2016/bookcase</name>
   </model>
 </sdf>

--- a/models/reo2016/closet/model.sdf
+++ b/models/reo2016/closet/model.sdf
@@ -8,7 +8,6 @@
             <size>1.0 0.6 0.995</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -16,10 +15,8 @@
             <size>1.0 0.6 0.995</size>
           </box>
         </geometry>
-        <name>1</name>
       </visual>
       <pose>0 0 0.4975 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="2">
       <collision name="2">
@@ -28,7 +25,6 @@
             <size>0.022 0.4 1.1</size>
           </box>
         </geometry>
-        <name>2</name>
       </collision>
       <visual name="2">
         <geometry>
@@ -36,10 +32,8 @@
             <size>0.022 0.4 1.1</size>
           </box>
         </geometry>
-        <name>2</name>
       </visual>
       <pose>-0.489 0.1 1.545 0 0 0</pose>
-      <name>2</name>
     </link>
     <link name="3">
       <collision name="3">
@@ -48,7 +42,6 @@
             <size>0.022 0.4 1.1</size>
           </box>
         </geometry>
-        <name>3</name>
       </collision>
       <visual name="3">
         <geometry>
@@ -56,10 +49,8 @@
             <size>0.022 0.4 1.1</size>
           </box>
         </geometry>
-        <name>3</name>
       </visual>
       <pose>0.0 0.1 1.545 0 0 0</pose>
-      <name>3</name>
     </link>
     <link name="4">
       <collision name="4">
@@ -68,7 +59,6 @@
             <size>0.022 0.4 1.1</size>
           </box>
         </geometry>
-        <name>4</name>
       </collision>
       <visual name="4">
         <geometry>
@@ -76,10 +66,8 @@
             <size>0.022 0.4 1.1</size>
           </box>
         </geometry>
-        <name>4</name>
       </visual>
       <pose>0.489 0.1 1.545 0 0 0</pose>
-      <name>4</name>
     </link>
     <link name="5">
       <collision name="5">
@@ -88,7 +76,6 @@
             <size>1.0 0.4 0.022</size>
           </box>
         </geometry>
-        <name>5</name>
       </collision>
       <visual name="5">
         <geometry>
@@ -96,10 +83,8 @@
             <size>1.0 0.4 0.022</size>
           </box>
         </geometry>
-        <name>5</name>
       </visual>
       <pose>0.0 0.1 1.541 0 0 0</pose>
-      <name>5</name>
     </link>
     <link name="6">
       <collision name="6">
@@ -108,7 +93,6 @@
             <size>1.0 0.4 0.022</size>
           </box>
         </geometry>
-        <name>6</name>
       </collision>
       <visual name="6">
         <geometry>
@@ -116,10 +100,8 @@
             <size>1.0 0.4 0.022</size>
           </box>
         </geometry>
-        <name>6</name>
       </visual>
       <pose>0.0 0.1 2.084 0 0 0</pose>
-      <name>6</name>
     </link>
     <link name="7">
       <collision name="7">
@@ -128,7 +110,6 @@
             <size>1.0 0.022 2.095</size>
           </box>
         </geometry>
-        <name>7</name>
       </collision>
       <visual name="7">
         <geometry>
@@ -136,10 +117,8 @@
             <size>1.0 0.022 2.095</size>
           </box>
         </geometry>
-        <name>7</name>
       </visual>
       <pose>0.0 0.289 1.0475 0 0 0</pose>
-      <name>7</name>
     </link>
     <link name="on_top_of">
       <virtual_volume name="on_top_of">
@@ -149,9 +128,7 @@
           </box>
         </geometry>
         <pose>0.0 0.025 1.1425 0 0 0</pose>
-        <name>on_top_of</name>
       </virtual_volume>
-      <name>on_top_of</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
@@ -161,11 +138,8 @@
           </box>
         </geometry>
         <pose>0.0 -1.0 0.005 0 0 0</pose>
-        <name>in_front_of</name>
       </virtual_volume>
-      <name>in_front_of</name>
     </link>
     <static>true</static>
-    <name>reo2016/closet</name>
   </model>
 </sdf>

--- a/models/reo2016/couch/model.sdf
+++ b/models/reo2016/couch/model.sdf
@@ -8,7 +8,6 @@
             <size>1.6 0.7 0.47</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -16,10 +15,8 @@
             <size>1.6 0.7 0.47</size>
           </box>
         </geometry>
-        <name>1</name>
       </visual>
       <pose>0.0 0.0 0.235 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="2">
       <collision name="2">
@@ -28,7 +25,6 @@
             <size>1.6 0.13 0.37</size>
           </box>
         </geometry>
-        <name>2</name>
       </collision>
       <visual name="2">
         <geometry>
@@ -36,10 +32,8 @@
             <size>1.6 0.13 0.37</size>
           </box>
         </geometry>
-        <name>2</name>
       </visual>
       <pose>0.0 0.285 0.655 0 0 0</pose>
-      <name>2</name>
     </link>
     <link name="3">
       <collision name="3">
@@ -48,7 +42,6 @@
             <size>0.13 0.7 0.37</size>
           </box>
         </geometry>
-        <name>3</name>
       </collision>
       <visual name="3">
         <geometry>
@@ -56,10 +49,8 @@
             <size>0.13 0.7 0.37</size>
           </box>
         </geometry>
-        <name>3</name>
       </visual>
       <pose>-0.735 0.0 0.655 0 0 0</pose>
-      <name>3</name>
     </link>
     <link name="4">
       <collision name="4">
@@ -68,7 +59,6 @@
             <size>0.13 0.7 0.37</size>
           </box>
         </geometry>
-        <name>4</name>
       </collision>
       <visual name="4">
         <geometry>
@@ -76,10 +66,8 @@
             <size>0.13 0.7 0.37</size>
           </box>
         </geometry>
-        <name>4</name>
       </visual>
       <pose>0.735 0.0 0.655 0 0 0</pose>
-      <name>4</name>
     </link>
     <link name="on_top_of">
       <virtual_volume name="on_top_of">
@@ -89,9 +77,7 @@
           </box>
         </geometry>
         <pose>0.0 -0.175 0.65 0 0 0</pose>
-        <name>on_top_of</name>
       </virtual_volume>
-      <name>on_top_of</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
@@ -101,11 +87,8 @@
           </box>
         </geometry>
         <pose>0.0 -1.05 0.005 0 0 0</pose>
-        <name>in_front_of</name>
       </virtual_volume>
-      <name>in_front_of</name>
     </link>
     <static>true</static>
-    <name>reo2016/couch</name>
   </model>
 </sdf>

--- a/models/reo2016/dinnertable/model.sdf
+++ b/models/reo2016/dinnertable/model.sdf
@@ -8,7 +8,6 @@
             <size>2.41 0.98 0.03</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -16,10 +15,8 @@
             <size>2.41 0.98 0.03</size>
           </box>
         </geometry>
-        <name>1</name>
       </visual>
       <pose>0 0 0.745 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="2">
       <collision name="2">
@@ -28,7 +25,6 @@
             <size>0.085 0.085 0.73</size>
           </box>
         </geometry>
-        <name>2</name>
       </collision>
       <visual name="2">
         <geometry>
@@ -36,10 +32,8 @@
             <size>0.085 0.085 0.73</size>
           </box>
         </geometry>
-        <name>2</name>
       </visual>
       <pose>-1.1035 -0.4275 0.365 0 0 0</pose>
-      <name>2</name>
     </link>
     <link name="3">
       <collision name="3">
@@ -48,7 +42,6 @@
             <size>0.085 0.085 0.73</size>
           </box>
         </geometry>
-        <name>3</name>
       </collision>
       <visual name="3">
         <geometry>
@@ -56,10 +49,8 @@
             <size>0.085 0.085 0.73</size>
           </box>
         </geometry>
-        <name>3</name>
       </visual>
       <pose>1.1035 -0.4275 0.365 0 0 0</pose>
-      <name>3</name>
     </link>
     <link name="4">
       <collision name="4">
@@ -68,7 +59,6 @@
             <size>0.085 0.085 0.73</size>
           </box>
         </geometry>
-        <name>4</name>
       </collision>
       <visual name="4">
         <geometry>
@@ -76,10 +66,8 @@
             <size>0.085 0.085 0.73</size>
           </box>
         </geometry>
-        <name>4</name>
       </visual>
       <pose>-1.1035 0.4275 0.365 0 0 0</pose>
-      <name>4</name>
     </link>
     <link name="5">
       <collision name="5">
@@ -88,7 +76,6 @@
             <size>0.085 0.085 0.73</size>
           </box>
         </geometry>
-        <name>5</name>
       </collision>
       <visual name="5">
         <geometry>
@@ -96,10 +83,8 @@
             <size>0.085 0.085 0.73</size>
           </box>
         </geometry>
-        <name>5</name>
       </visual>
       <pose>1.1035 0.4275 0.365 0 0 0</pose>
-      <name>5</name>
     </link>
     <link name="on_top_of">
       <virtual_volume name="on_top_of">
@@ -109,9 +94,7 @@
           </box>
         </geometry>
         <pose>-0.95 0.0 0.925 0 0 0</pose>
-        <name>on_top_of</name>
       </virtual_volume>
-      <name>on_top_of</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
@@ -121,11 +104,8 @@
           </box>
         </geometry>
         <pose>-1.9 0.0 0.005 0 0 0</pose>
-        <name>in_front_of</name>
       </virtual_volume>
-      <name>in_front_of</name>
     </link>
     <static>true</static>
-    <name>reo2016/dinnertable</name>
   </model>
 </sdf>

--- a/models/reo2016/fridge/model.sdf
+++ b/models/reo2016/fridge/model.sdf
@@ -8,7 +8,6 @@
             <size>0.67 0.6 1.53</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -16,10 +15,8 @@
             <size>0.67 0.6 1.53</size>
           </box>
         </geometry>
-        <name>1</name>
       </visual>
       <pose>0.0 0.0 0.765 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="on_top_of">
       <virtual_volume name="on_top_of">
@@ -29,9 +26,7 @@
           </box>
         </geometry>
         <pose>0.0 0.0 1.695 0 0 0</pose>
-        <name>on_top_of</name>
       </virtual_volume>
-      <name>on_top_of</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
@@ -41,11 +36,8 @@
           </box>
         </geometry>
         <pose>-1.03 0.0 0.005 0 0 0</pose>
-        <name>in_front_of</name>
       </virtual_volume>
-      <name>in_front_of</name>
     </link>
     <static>true</static>
-    <name>reo2016/fridge</name>
   </model>
 </sdf>

--- a/models/reo2016/hallway_trashbin/model.sdf
+++ b/models/reo2016/hallway_trashbin/model.sdf
@@ -9,7 +9,6 @@
             <radius>0.185</radius>
           </cylinder>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -18,12 +17,9 @@
             <radius>0.185</radius>
           </cylinder>
         </geometry>
-        <name>1</name>
       </visual>
       <pose>0 0 0 0 0 0</pose>
-      <name>1</name>
     </link>
     <static>true</static>
-    <name>reo2016/hallway_trashbin</name>
   </model>
 </sdf>

--- a/models/reo2016/kitchen_trashbin/model.sdf
+++ b/models/reo2016/kitchen_trashbin/model.sdf
@@ -9,7 +9,6 @@
             <radius>0.17</radius>
           </cylinder>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -18,12 +17,9 @@
             <radius>0.17</radius>
           </cylinder>
         </geometry>
-        <name>1</name>
       </visual>
       <pose>0 0 0 0 0 0</pose>
-      <name>1</name>
     </link>
     <static>true</static>
-    <name>reo2016/kitchen_trashbin</name>
   </model>
 </sdf>

--- a/models/reo2016/kitchencounter/model.sdf
+++ b/models/reo2016/kitchencounter/model.sdf
@@ -8,7 +8,6 @@
             <size>0.59 3.0 0.95</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -16,10 +15,8 @@
             <size>0.59 3.0 0.95</size>
           </box>
         </geometry>
-        <name>1</name>
       </visual>
       <pose>0.0 0.0 0.475 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="on_top_of">
       <virtual_volume name="on_top_of">
@@ -29,9 +26,7 @@
           </box>
         </geometry>
         <pose>0.0 0.0 1.145 0 0 0</pose>
-        <name>on_top_of</name>
       </virtual_volume>
-      <name>on_top_of</name>
     </link>
     <link name="left_of_sink">
       <virtual_volume name="left_of_sink">
@@ -41,9 +36,7 @@
           </box>
         </geometry>
         <pose>0.0 0.875 1.15 0 0 0</pose>
-        <name>left_of_sink</name>
       </virtual_volume>
-      <name>left_of_sink</name>
     </link>
     <link name="right_of_sink">
       <virtual_volume name="right_of_sink">
@@ -53,9 +46,7 @@
           </box>
         </geometry>
         <pose>0.0 -0.875 1.15 0 0 0</pose>
-        <name>right_of_sink</name>
       </virtual_volume>
-      <name>right_of_sink</name>
     </link>
     <link name="in_front_of_left_sink">
       <virtual_volume name="in_front_of_left_sink">
@@ -65,9 +56,7 @@
           </box>
         </geometry>
         <pose>-1.1 0.875 0.005 0 0 0</pose>
-        <name>in_front_of_left_sink</name>
       </virtual_volume>
-      <name>in_front_of_left_sink</name>
     </link>
     <link name="in_front_of_right_sink">
       <virtual_volume name="in_front_of_right_sink">
@@ -77,9 +66,7 @@
           </box>
         </geometry>
         <pose>-1.1 -0.875 0.005 0 0 0</pose>
-        <name>in_front_of_right_sink</name>
       </virtual_volume>
-      <name>in_front_of_right_sink</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
@@ -89,11 +76,8 @@
           </box>
         </geometry>
         <pose>-1.1 0.0 0.005 0 0 0</pose>
-        <name>in_front_of</name>
       </virtual_volume>
-      <name>in_front_of</name>
     </link>
     <static>true</static>
-    <name>reo2016/kitchencounter</name>
   </model>
 </sdf>

--- a/models/reo2016/model.sdf
+++ b/models/reo2016/model.sdf
@@ -4,7 +4,6 @@
     <light name="sun" type="directional">
       <direction>0.5 0.1 -0.9</direction>
       <pose>0 0 10 0 0 0</pose>
-      <name>sun</name>
       <specular>0.2 0.2 0.2 1</specular>
       <cast_shadows>true</cast_shadows>
       <diffuse>0.8 0.8 0.8 1</diffuse>
@@ -24,13 +23,10 @@
             </box>
           </geometry>
           <pose>0.0 0.75 0.005 0 0 0</pose>
-          <name>in</name>
         </virtual_volume>
-        <name>in</name>
       </link>
       <pose>4.5 2.5 0 0 0 0</pose>
       <static>true</static>
-      <name>kitchen</name>
     </model>
     <model name="livingroom" type="room">
       <link name="in">
@@ -41,13 +37,10 @@
             </box>
           </geometry>
           <pose>-1.25 -0.3 0.005 0 0 0</pose>
-          <name>in</name>
         </virtual_volume>
-        <name>in</name>
       </link>
       <pose>4.0 -4.0 0.0 0 0 0</pose>
       <static>true</static>
-      <name>livingroom</name>
     </model>
     <model name="bedroom" type="room">
       <link name="in">
@@ -58,13 +51,10 @@
             </box>
           </geometry>
           <pose>0.0 0.0 0.005 0 0 0</pose>
-          <name>in</name>
         </virtual_volume>
-        <name>in</name>
       </link>
       <pose>2.0 2.0 0 0 0 0</pose>
       <static>true</static>
-      <name>bedroom</name>
     </model>
     <model name="entrance" type="room">
       <link name="in">
@@ -75,13 +65,10 @@
             </box>
           </geometry>
           <pose>0.0 0.0 0.005 0 0 0</pose>
-          <name>in</name>
         </virtual_volume>
-        <name>in</name>
       </link>
       <pose>0.1 0.0 0 0 0 0</pose>
       <static>true</static>
-      <name>entrance</name>
     </model>
     <model name="exit" type="room">
       <link name="in">
@@ -92,195 +79,170 @@
             </box>
           </geometry>
           <pose>0.0 0.0 0.005 0 0 0</pose>
-          <name>in</name>
         </virtual_volume>
-        <name>in</name>
       </link>
       <pose>0.1 -1.8 0 0 0 0</pose>
       <static>true</static>
-      <name>exit</name>
     </model>
     <model name="navigation_waypoint_1" type="waypoint">
       <pose>2.45 -5.22 0 0 0 0</pose>
       <static>true</static>
-      <name>navigation_waypoint_1</name>
     </model>
     <model name="navigation_waypoint_2_pre" type="waypoint">
       <pose>4.3 0.4 0 0 0 1.57</pose>
       <static>true</static>
-      <name>navigation_waypoint_2_pre</name>
     </model>
     <model name="navigation_waypoint_2" type="waypoint">
       <pose>4.36 3.91 0 0 0 0</pose>
       <static>true</static>
-      <name>navigation_waypoint_2</name>
     </model>
     <model name="navigation_waypoint_3" type="waypoint">
       <pose>0.507 -1.84 0 0 0 3.1415</pose>
       <static>true</static>
-      <name>navigation_waypoint_3</name>
     </model>
     <model name="initial_pose" type="waypoint">
       <pose>-0.5 0 0 0 0 0</pose>
       <static>true</static>
-      <name>initial_pose</name>
     </model>
     <model name="initial_pose_door_A" type="waypoint">
       <pose>-0.5 0 0 0 0 0</pose>
       <static>true</static>
-      <name>initial_pose_door_A</name>
     </model>
     <model name="initial_pose_door_B" type="waypoint">
       <pose>-0.485 -1.85 0 0 0 0</pose>
       <static>true</static>
-      <name>initial_pose_door_B</name>
     </model>
     <model name="entry_point_A" type="waypoint">
       <pose>1.0 0.0 0 0 0 0</pose>
       <static>true</static>
-      <name>entry_point_A</name>
     </model>
     <model name="entry_point_B" type="waypoint">
       <pose>1.0 -2.0 0 0 0 0</pose>
       <static>true</static>
-      <name>entry_point_B</name>
     </model>
     <model name="exit_door_A1" type="waypoint">
       <pose>-1.0 0.0 0 0 0 3.1415</pose>
       <static>true</static>
-      <name>exit_door_A1</name>
     </model>
     <model name="exit_door_A2" type="waypoint">
       <pose>-2.0 0.5 0 0 0 3.1415</pose>
       <static>true</static>
-      <name>exit_door_A2</name>
     </model>
     <model name="exit_door_A3" type="waypoint">
       <pose>0.5 0.0 0 0 0 3.1415</pose>
       <static>true</static>
-      <name>exit_door_A3</name>
     </model>
     <model name="exit_door_B1" type="waypoint">
       <pose>-1.0 -1.85 0 0 0 3.1415</pose>
       <static>true</static>
-      <name>exit_door_B1</name>
     </model>
     <model name="exit_door_B2" type="waypoint">
       <pose>-1.0 -2.35 0 0 0 3.1415</pose>
       <static>true</static>
-      <name>exit_door_B2</name>
     </model>
     <model name="exit_door_B3" type="waypoint">
       <pose>0.5 -1.85 0 0 0 3.1415</pose>
       <static>true</static>
-      <name>exit_door_B3</name>
     </model>
     <model name="rips1" type="waypoint">
       <pose>4.8 -2.0 0 0 0 1.2</pose>
       <static>true</static>
-      <name>rips1</name>
     </model>
     <model name="rips2" type="waypoint">
       <pose>2.5 -2.25 0 0 0 0.0</pose>
       <static>true</static>
-      <name>rips2</name>
     </model>
     <model name="rips3" type="waypoint">
       <pose>2.5 0.0 0 0 0 3.14</pose>
       <static>true</static>
-      <name>rips3</name>
     </model>
     <model name="person_rec_learning" type="waypoint">
       <pose>3.6 -3.6 0 0 0 0.0</pose>
       <static>true</static>
-      <name>person_rec_learning</name>
     </model>
     <model name="person_rec_living_room_1" type="waypoint">
       <pose>3.6 -3.6 0 0 0 3.1415</pose>
       <static>true</static>
-      <name>person_rec_living_room_1</name>
     </model>
     <model name="gpsr_starting_pose" type="waypoint">
       <pose>1.755 1.4386 0 0 0 -1.57</pose>
       <static>true</static>
-      <name>gpsr_starting_pose</name>
     </model>
     <model name="eegpsr_starting_pose" type="waypoint">
       <pose>0.76 -3.98 0 0 0 2.0</pose>
       <static>true</static>
-      <name>eegpsr_starting_pose</name>
     </model>
-    <include name="walls">
+    <include>
       <pose>0 0 0 0 0 0</pose>
       <name>walls</name>
       <uri>model://reo2016/walls</uri>
     </include>
-    <include name="dinnertable">
+    <include>
       <pose>4.192 -5.189 0.0 0 0 0</pose>
       <name>dinnertable</name>
       <uri>model://reo2016/dinnertable</uri>
     </include>
-    <include name="sideboard">
+    <include>
       <pose>5.202 -3.1665 0.0 0 0 0</pose>
       <name>sideboard</name>
       <uri>model://reo2016/sideboard</uri>
     </include>
-    <include name="bookcase">
+    <include>
       <pose>0.893 -4.712 0.0 0.0 0.0 3.75</pose>
       <name>bookcase</name>
       <uri>model://reo2016/bookcase</uri>
     </include>
-    <include name="tv_stand">
+    <include>
       <pose>3.278 -1.37 0.0 0 0 1.57075</pose>
       <name>tv_stand</name>
       <uri>model://reo2016/tv_stand</uri>
     </include>
-    <include name="couch">
+    <include>
       <pose>3.151 -3.216 0.0 0 0 3.1415</pose>
       <name>couch</name>
       <uri>model://reo2016/couch</uri>
     </include>
-    <include name="kitchencounter">
+    <include>
       <pose>5.105 3.052 0.0 0 0 0</pose>
       <name>kitchencounter</name>
       <uri>model://reo2016/kitchencounter</uri>
     </include>
-    <include name="sink">
+    <include>
       <pose>5.105 3.052 0.86 0 0 0</pose>
       <name>sink</name>
       <uri>model://reo2016/sink</uri>
     </include>
-    <include name="kitchen_trashbin">
+    <include>
       <pose>4.558 4.882 0.0 0 0 0</pose>
       <name>kitchen_trashbin</name>
       <uri>model://reo2016/kitchen_trashbin</uri>
     </include>
-    <include name="fridge">
+    <include>
       <pose>3.92 4.872 0.0 0 0 1.57075</pose>
       <name>fridge</name>
       <uri>model://reo2016/fridge</uri>
     </include>
-    <include name="bed">
+    <include>
       <pose>2.6725 3.216 0.0 0 0 1.57075</pose>
       <name>bed</name>
       <uri>model://reo2016/bed</uri>
     </include>
-    <include name="nightstand">
+    <include>
       <pose>1.5 3.0 0.0 0 0 1.57075</pose>
       <name>nightstand</name>
       <uri>model://reo2016/nightstand</uri>
     </include>
-    <include name="closet">
+    <include>
       <pose>0.712 1.769 0.0 0 0 1.25</pose>
       <name>closet</name>
       <uri>model://reo2016/closet</uri>
     </include>
-    <include name="hallway_trashbin">
+    <include>
       <pose>5.131 1.033 0.0 0 0 0</pose>
       <name>hallway_trashbin</name>
       <uri>model://reo2016/hallway_trashbin</uri>
     </include>
-    <include name="suitcase">
+    <include>
       <pose>0.437 -1.21 0.0 0 0 0</pose>
       <name>suitcase</name>
       <uri>model://reo2016/suitcase</uri>
@@ -297,6 +259,5 @@
         </solver>
       </ode>
     </physics>
-    <name>reo2016</name>
   </world>
 </sdf>

--- a/models/reo2016/nightstand/model.sdf
+++ b/models/reo2016/nightstand/model.sdf
@@ -8,7 +8,6 @@
             <size>0.45 0.4 0.54</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -16,10 +15,8 @@
             <size>0.45 0.4 0.54</size>
           </box>
         </geometry>
-        <name>1</name>
       </visual>
       <pose>0.0 0.0 0.27 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="on_top_of">
       <virtual_volume name="on_top_of">
@@ -29,9 +26,7 @@
           </box>
         </geometry>
         <pose>0.0 0.0 0.705 0 0 0</pose>
-        <name>on_top_of</name>
       </virtual_volume>
-      <name>on_top_of</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
@@ -41,11 +36,8 @@
           </box>
         </geometry>
         <pose>-0.925 0.0 0.005 0 0 0</pose>
-        <name>in_front_of</name>
       </virtual_volume>
-      <name>in_front_of</name>
     </link>
     <static>true</static>
-    <name>reo2016/nightstand</name>
   </model>
 </sdf>

--- a/models/reo2016/sideboard/model.sdf
+++ b/models/reo2016/sideboard/model.sdf
@@ -8,7 +8,6 @@
             <size>0.39 1.465 0.035</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -16,10 +15,8 @@
             <size>0.39 1.465 0.035</size>
           </box>
         </geometry>
-        <name>1</name>
       </visual>
       <pose>0.0 0.0 0.0175 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="2">
       <collision name="2">
@@ -28,7 +25,6 @@
             <size>0.39 1.465 0.017</size>
           </box>
         </geometry>
-        <name>2</name>
       </collision>
       <visual name="2">
         <geometry>
@@ -36,10 +32,8 @@
             <size>0.39 1.465 0.017</size>
           </box>
         </geometry>
-        <name>2</name>
       </visual>
       <pose>0.0 0.0 0.3815 0 0 0</pose>
-      <name>2</name>
     </link>
     <link name="3">
       <collision name="3">
@@ -48,7 +42,6 @@
             <size>0.39 1.465 0.035</size>
           </box>
         </geometry>
-        <name>3</name>
       </collision>
       <visual name="3">
         <geometry>
@@ -56,10 +49,8 @@
             <size>0.39 1.465 0.035</size>
           </box>
         </geometry>
-        <name>3</name>
       </visual>
       <pose>0.0 0.0 0.805 0 0 0</pose>
-      <name>3</name>
     </link>
     <link name="4">
       <collision name="4">
@@ -68,7 +59,6 @@
             <size>0.39 0.035 0.795</size>
           </box>
         </geometry>
-        <name>4</name>
       </collision>
       <visual name="4">
         <geometry>
@@ -76,10 +66,8 @@
             <size>0.39 0.035 0.795</size>
           </box>
         </geometry>
-        <name>4</name>
       </visual>
       <pose>0.0 -0.715 0.3975 0 0 0</pose>
-      <name>4</name>
     </link>
     <link name="5">
       <collision name="5">
@@ -88,7 +76,6 @@
             <size>0.39 0.017 0.795</size>
           </box>
         </geometry>
-        <name>5</name>
       </collision>
       <visual name="5">
         <geometry>
@@ -96,10 +83,8 @@
             <size>0.39 0.017 0.795</size>
           </box>
         </geometry>
-        <name>5</name>
       </visual>
       <pose>0.0 -0.35 0.3975 0 0 0</pose>
-      <name>5</name>
     </link>
     <link name="6">
       <collision name="6">
@@ -108,7 +93,6 @@
             <size>0.39 0.017 0.795</size>
           </box>
         </geometry>
-        <name>6</name>
       </collision>
       <visual name="6">
         <geometry>
@@ -116,10 +100,8 @@
             <size>0.39 0.017 0.795</size>
           </box>
         </geometry>
-        <name>6</name>
       </visual>
       <pose>0.0 0 0.3975 0 0 0</pose>
-      <name>6</name>
     </link>
     <link name="7">
       <collision name="7">
@@ -128,7 +110,6 @@
             <size>0.39 0.017 0.795</size>
           </box>
         </geometry>
-        <name>7</name>
       </collision>
       <visual name="7">
         <geometry>
@@ -136,10 +117,8 @@
             <size>0.39 0.017 0.795</size>
           </box>
         </geometry>
-        <name>7</name>
       </visual>
       <pose>0.0 0.35 0.3975 0 0 0</pose>
-      <name>7</name>
     </link>
     <link name="8">
       <collision name="8">
@@ -148,7 +127,6 @@
             <size>0.39 0.035 0.795</size>
           </box>
         </geometry>
-        <name>8</name>
       </collision>
       <visual name="8">
         <geometry>
@@ -156,10 +134,8 @@
             <size>0.39 0.035 0.795</size>
           </box>
         </geometry>
-        <name>8</name>
       </visual>
       <pose>0.0 0.715 0.3975 0 0 0</pose>
-      <name>8</name>
     </link>
     <link name="on_top_of">
       <virtual_volume name="on_top_of">
@@ -169,9 +145,7 @@
           </box>
         </geometry>
         <pose>0.0 0.0 0.985 0 0 0</pose>
-        <name>on_top_of</name>
       </virtual_volume>
-      <name>on_top_of</name>
     </link>
     <link name="on_top_of_left">
       <virtual_volume name="on_top_of_left">
@@ -181,9 +155,7 @@
           </box>
         </geometry>
         <pose>0.0 -0.365 0.985 0 0 0</pose>
-        <name>on_top_of_left</name>
       </virtual_volume>
-      <name>on_top_of_left</name>
     </link>
     <link name="on_top_of_right">
       <virtual_volume name="on_top_of_right">
@@ -193,9 +165,7 @@
           </box>
         </geometry>
         <pose>0.0 0.365 0.985 0 0 0</pose>
-        <name>on_top_of_right</name>
       </virtual_volume>
-      <name>on_top_of_right</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
@@ -205,11 +175,8 @@
           </box>
         </geometry>
         <pose>-0.9 0.0 0.005 0 0 0</pose>
-        <name>in_front_of</name>
       </virtual_volume>
-      <name>in_front_of</name>
     </link>
     <static>true</static>
-    <name>reo2016/sideboard</name>
   </model>
 </sdf>

--- a/models/reo2016/sink/model.sdf
+++ b/models/reo2016/sink/model.sdf
@@ -9,7 +9,6 @@
             <radius>0.19</radius>
           </cylinder>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -18,10 +17,8 @@
             <radius>0.19</radius>
           </cylinder>
         </geometry>
-        <name>1</name>
       </visual>
       <pose>0 0 0 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
@@ -31,11 +28,8 @@
           </box>
         </geometry>
         <pose>-1.1 0.0 -0.865 0 0 0</pose>
-        <name>in_front_of</name>
       </virtual_volume>
-      <name>in_front_of</name>
     </link>
     <static>true</static>
-    <name>reo2016/sink</name>
   </model>
 </sdf>

--- a/models/reo2016/suitcase/model.sdf
+++ b/models/reo2016/suitcase/model.sdf
@@ -8,7 +8,6 @@
             <size>0.66 0.17 0.47</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -16,12 +15,9 @@
             <size>0.66 0.17 0.47</size>
           </box>
         </geometry>
-        <name>1</name>
       </visual>
       <pose>0.0 0.0 0.235 0 0 0</pose>
-      <name>1</name>
     </link>
     <static>true</static>
-    <name>reo2016/suitcase</name>
   </model>
 </sdf>

--- a/models/reo2016/tv_stand/model.sdf
+++ b/models/reo2016/tv_stand/model.sdf
@@ -8,7 +8,6 @@
             <size>0.4 1.8 0.485</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -16,10 +15,8 @@
             <size>0.4 1.8 0.485</size>
           </box>
         </geometry>
-        <name>1</name>
       </visual>
       <pose>0.0 0.0 0.2525 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="on_top_of">
       <virtual_volume name="on_top_of">
@@ -29,9 +26,7 @@
           </box>
         </geometry>
         <pose>0.0 0.0 0.65 0 0 0</pose>
-        <name>on_top_of</name>
       </virtual_volume>
-      <name>on_top_of</name>
     </link>
     <link name="on_top_of_left">
       <virtual_volume name="on_top_of_left">
@@ -41,9 +36,7 @@
           </box>
         </geometry>
         <pose>0.0 -0.45 0.65 0 0 0</pose>
-        <name>on_top_of_left</name>
       </virtual_volume>
-      <name>on_top_of_left</name>
     </link>
     <link name="on_top_of_right">
       <virtual_volume name="on_top_of_right">
@@ -53,9 +46,7 @@
           </box>
         </geometry>
         <pose>0.0 0.45 0.65 0 0 0</pose>
-        <name>on_top_of_right</name>
       </virtual_volume>
-      <name>on_top_of_right</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
@@ -65,11 +56,8 @@
           </box>
         </geometry>
         <pose>-0.9 0.0 0.005 0 0 0</pose>
-        <name>in_front_of</name>
       </virtual_volume>
-      <name>in_front_of</name>
     </link>
     <static>true</static>
-    <name>reo2016/tv_stand</name>
   </model>
 </sdf>

--- a/models/reo2016/walls/model.sdf
+++ b/models/reo2016/walls/model.sdf
@@ -8,7 +8,6 @@
             <uri>model://reo2016/walls/heightmap.stl</uri>
           </mesh>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -16,12 +15,9 @@
             <uri>model://reo2016/walls/heightmap.stl</uri>
           </mesh>
         </geometry>
-        <name>1</name>
       </visual>
       <pose>0 0 0 0 0 0</pose>
-      <name>1</name>
     </link>
     <static>true</static>
-    <name>reo2016/walls</name>
   </model>
 </sdf>

--- a/models/reo2016/workbench/model.sdf
+++ b/models/reo2016/workbench/model.sdf
@@ -8,7 +8,6 @@
             <size>1.2 0.76 0.02</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -16,10 +15,8 @@
             <size>1.2 0.76 0.02</size>
           </box>
         </geometry>
-        <name>1</name>
       </visual>
       <pose>0.0 0.0 0.75 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="on_top_of">
       <virtual_volume name="on_top_of">
@@ -29,11 +26,8 @@
           </box>
         </geometry>
         <pose>0.0 0.0 0.95 0 0 0</pose>
-        <name>on_top_of</name>
       </virtual_volume>
-      <name>on_top_of</name>
     </link>
     <static>true</static>
-    <name>reo2016/workbench</name>
   </model>
 </sdf>

--- a/models/rgo2015/bar_table/legs/model.sdf
+++ b/models/rgo2015/bar_table/legs/model.sdf
@@ -8,7 +8,6 @@
             <size>0.12 0.12 1.09</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -19,12 +18,9 @@
         <material>
           <ambient>0.8 0.8 0.8 1</ambient>
         </material>
-        <name>1</name>
       </visual>
       <pose>-0.0 0.0 0.545 0 0 0</pose>
-      <name>1</name>
     </link>
     <static>true</static>
-    <name>rgo2015/bar_table/legs</name>
   </model>
 </sdf>

--- a/models/rgo2015/bar_table/model.sdf
+++ b/models/rgo2015/bar_table/model.sdf
@@ -4,7 +4,6 @@
     <light name="sun" type="directional">
       <direction>0.5 0.1 -0.9</direction>
       <pose>0 0 10 0 0 0</pose>
-      <name>sun</name>
       <specular>0.2 0.2 0.2 1</specular>
       <cast_shadows>true</cast_shadows>
       <diffuse>0.8 0.8 0.8 1</diffuse>
@@ -15,12 +14,12 @@
         <linear>0.01</linear>
       </attenuation>
     </light>
-    <include name="top">
+    <include>
       <pose>0 0 1.07 0 0 0</pose>
       <name>top</name>
       <uri>model://rgo2015/bar_table/top</uri>
     </include>
-    <include name="legs">
+    <include>
       <pose>0 0 0 0 0 0</pose>
       <name>legs</name>
       <uri>model://rgo2015/bar_table/legs</uri>
@@ -37,6 +36,5 @@
         </solver>
       </ode>
     </physics>
-    <name>rgo2015/bar_table</name>
   </world>
 </sdf>

--- a/models/rgo2015/bar_table/top/model.sdf
+++ b/models/rgo2015/bar_table/top/model.sdf
@@ -8,7 +8,6 @@
             <uri>model://rgo2015/bar_table/top/shape/top.stl</uri>
           </mesh>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -16,12 +15,9 @@
             <uri>model://rgo2015/bar_table/top/shape/top.stl</uri>
           </mesh>
         </geometry>
-        <name>1</name>
       </visual>
       <pose>0 0 0 0 0 0</pose>
-      <name>1</name>
     </link>
     <static>true</static>
-    <name>rgo2015/bar_table/top</name>
   </model>
 </sdf>

--- a/models/rgo2015/bed/model.sdf
+++ b/models/rgo2015/bed/model.sdf
@@ -8,7 +8,6 @@
             <size>2.06 1.55 0.45</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -19,12 +18,9 @@
         <material>
           <ambient>0.9 0.9 0.9 1</ambient>
         </material>
-        <name>1</name>
       </visual>
       <pose>0.0 0.0 0.225 0 0 0</pose>
-      <name>1</name>
     </link>
     <static>true</static>
-    <name>rgo2015/bed</name>
   </model>
 </sdf>

--- a/models/rgo2015/bedstand/model.sdf
+++ b/models/rgo2015/bedstand/model.sdf
@@ -8,7 +8,6 @@
             <size>0.34 0.435 0.63</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -19,12 +18,9 @@
         <material>
           <ambient>0.9 0.9 0.9 1</ambient>
         </material>
-        <name>1</name>
       </visual>
       <pose>0.0 0.0 0.315 0 0 0</pose>
-      <name>1</name>
     </link>
     <static>true</static>
-    <name>rgo2015/bedstand</name>
   </model>
 </sdf>

--- a/models/rgo2015/cabinet/cabinet_frame/model.sdf
+++ b/models/rgo2015/cabinet/cabinet_frame/model.sdf
@@ -8,7 +8,6 @@
             <size>0.28 0.02 2.02</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -19,10 +18,8 @@
         <material>
           <ambient>0.9 0.9 0.9 1</ambient>
         </material>
-        <name>1</name>
       </visual>
       <pose>0.0 -0.39 1.01 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="2">
       <collision name="2">
@@ -31,7 +28,6 @@
             <size>0.28 0.02 2.02</size>
           </box>
         </geometry>
-        <name>2</name>
       </collision>
       <visual name="2">
         <geometry>
@@ -42,12 +38,9 @@
         <material>
           <ambient>0.9 0.9 0.9 1</ambient>
         </material>
-        <name>2</name>
       </visual>
       <pose>0.0 0.39 1.01 0 0 0</pose>
-      <name>2</name>
     </link>
     <static>true</static>
-    <name>rgo2015/cabinet/cabinet_frame</name>
   </model>
 </sdf>

--- a/models/rgo2015/cabinet/model.sdf
+++ b/models/rgo2015/cabinet/model.sdf
@@ -4,7 +4,6 @@
     <light name="sun" type="directional">
       <direction>0.5 0.1 -0.9</direction>
       <pose>0 0 10 0 0 0</pose>
-      <name>sun</name>
       <specular>0.2 0.2 0.2 1</specular>
       <cast_shadows>true</cast_shadows>
       <diffuse>0.8 0.8 0.8 1</diffuse>
@@ -15,37 +14,37 @@
         <linear>0.01</linear>
       </attenuation>
     </light>
-    <include name="cabinet_frame">
+    <include>
       <pose>0 0 0 0 0 0</pose>
       <name>cabinet_frame</name>
       <uri>model://rgo2015/cabinet/cabinet_frame</uri>
     </include>
-    <include name="shelf1">
+    <include>
       <pose>0 0 0.08 0 0 0</pose>
       <name>shelf1</name>
       <uri>model://rgo2015/cabinet/shelf</uri>
     </include>
-    <include name="shelf2">
+    <include>
       <pose>0 0 0.335 0 0 0</pose>
       <name>shelf2</name>
       <uri>model://rgo2015/cabinet/shelf</uri>
     </include>
-    <include name="shelf3">
+    <include>
       <pose>0 0 0.685 0 0 0</pose>
       <name>shelf3</name>
       <uri>model://rgo2015/cabinet/shelf</uri>
     </include>
-    <include name="shelf4">
+    <include>
       <pose>0 0 1.04 0 0 0</pose>
       <name>shelf4</name>
       <uri>model://rgo2015/cabinet/shelf</uri>
     </include>
-    <include name="shelf5">
+    <include>
       <pose>0 0 1.36 0 0 0</pose>
       <name>shelf5</name>
       <uri>model://rgo2015/cabinet/shelf</uri>
     </include>
-    <include name="shelf6">
+    <include>
       <pose>0 0 2.0 0 0 0</pose>
       <name>shelf6</name>
       <uri>model://rgo2015/cabinet/shelf</uri>
@@ -62,6 +61,5 @@
         </solver>
       </ode>
     </physics>
-    <name>rgo2015/cabinet</name>
   </world>
 </sdf>

--- a/models/rgo2015/cabinet/shelf/model.sdf
+++ b/models/rgo2015/cabinet/shelf/model.sdf
@@ -8,7 +8,6 @@
             <size>0.28 0.8 0.02</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -19,10 +18,8 @@
         <material>
           <ambient>0.9 0.9 0.9 1</ambient>
         </material>
-        <name>1</name>
       </visual>
       <pose>0.0 0.0 0.0 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
@@ -32,11 +29,8 @@
           </box>
         </geometry>
         <pose>0.84 0.0 0.5 0 0 0</pose>
-        <name>in_front_of</name>
       </virtual_volume>
-      <name>in_front_of</name>
     </link>
     <static>true</static>
-    <name>rgo2015/cabinet/shelf</name>
   </model>
 </sdf>

--- a/models/rgo2015/coathanger/model.sdf
+++ b/models/rgo2015/coathanger/model.sdf
@@ -8,7 +8,6 @@
             <size>0.35 0.35 0.055</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -19,10 +18,8 @@
         <material>
           <ambient>0.9 0.9 0.9 1</ambient>
         </material>
-        <name>1</name>
       </visual>
       <pose>0 0 0.0275 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="2">
       <collision name="2">
@@ -31,7 +28,6 @@
             <size>0.05 0.05 1.29</size>
           </box>
         </geometry>
-        <name>2</name>
       </collision>
       <visual name="2">
         <geometry>
@@ -42,12 +38,9 @@
         <material>
           <ambient>0.9 0.9 0.9 1</ambient>
         </material>
-        <name>2</name>
       </visual>
       <pose>0 0 0.645 0 0 0</pose>
-      <name>2</name>
     </link>
     <static>true</static>
-    <name>rgo2015/coathanger</name>
   </model>
 </sdf>

--- a/models/rgo2015/couch/model.sdf
+++ b/models/rgo2015/couch/model.sdf
@@ -8,7 +8,6 @@
             <size>0.865 1.8 0.67</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -19,12 +18,9 @@
         <material>
           <ambient>0.1 0.1 0.1 1</ambient>
         </material>
-        <name>1</name>
       </visual>
       <pose>0.0 0.0 0.335 0 0 0</pose>
-      <name>1</name>
     </link>
     <static>true</static>
-    <name>rgo2015/couch</name>
   </model>
 </sdf>

--- a/models/rgo2015/couch_table/model.sdf
+++ b/models/rgo2015/couch_table/model.sdf
@@ -8,7 +8,6 @@
             <size>0.55 0.9 0.05</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -19,10 +18,8 @@
         <material>
           <ambient>0.1 0.1 0.1 1</ambient>
         </material>
-        <name>1</name>
       </visual>
       <pose>0.0 0.0 0.425 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="2">
       <collision name="2">
@@ -31,7 +28,6 @@
             <size>0.05 0.05 0.45</size>
           </box>
         </geometry>
-        <name>2</name>
       </collision>
       <visual name="2">
         <geometry>
@@ -42,10 +38,8 @@
         <material>
           <ambient>0.1 0.1 0.1 1</ambient>
         </material>
-        <name>2</name>
       </visual>
       <pose>-0.25 -0.425 0.225 0 0 0</pose>
-      <name>2</name>
     </link>
     <link name="3">
       <collision name="3">
@@ -54,7 +48,6 @@
             <size>0.05 0.05 0.45</size>
           </box>
         </geometry>
-        <name>3</name>
       </collision>
       <visual name="3">
         <geometry>
@@ -65,10 +58,8 @@
         <material>
           <ambient>0.1 0.1 0.1 1</ambient>
         </material>
-        <name>3</name>
       </visual>
       <pose>-0.25 0.425 0.225 0 0 0</pose>
-      <name>3</name>
     </link>
     <link name="4">
       <collision name="4">
@@ -77,7 +68,6 @@
             <size>0.05 0.05 0.45</size>
           </box>
         </geometry>
-        <name>4</name>
       </collision>
       <visual name="4">
         <geometry>
@@ -88,10 +78,8 @@
         <material>
           <ambient>0.1 0.1 0.1 1</ambient>
         </material>
-        <name>4</name>
       </visual>
       <pose>0.25 -0.425 0.225 0 0 0</pose>
-      <name>4</name>
     </link>
     <link name="5">
       <collision name="5">
@@ -100,7 +88,6 @@
             <size>0.05 0.05 0.45</size>
           </box>
         </geometry>
-        <name>5</name>
       </collision>
       <visual name="5">
         <geometry>
@@ -111,12 +98,9 @@
         <material>
           <ambient>0.1 0.1 0.1 1</ambient>
         </material>
-        <name>5</name>
       </visual>
       <pose>0.25 0.425 0.225 0 0 0</pose>
-      <name>5</name>
     </link>
     <static>true</static>
-    <name>rgo2015/couch_table</name>
   </model>
 </sdf>

--- a/models/rgo2015/cupboard/frame/model.sdf
+++ b/models/rgo2015/cupboard/frame/model.sdf
@@ -8,7 +8,6 @@
             <size>0.32 0.75 0.93</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -19,10 +18,8 @@
         <material>
           <ambient>0.9 0.9 0.9 1</ambient>
         </material>
-        <name>1</name>
       </visual>
       <pose>0.0 0.0 0.465 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="2">
       <collision name="2">
@@ -31,7 +28,6 @@
             <size>0.3 0.02 1.815</size>
           </box>
         </geometry>
-        <name>2</name>
       </collision>
       <visual name="2">
         <geometry>
@@ -42,10 +38,8 @@
         <material>
           <ambient>0.9 0.9 0.9 1</ambient>
         </material>
-        <name>2</name>
       </visual>
       <pose>-0.01 -0.365 0.9075 0 0 0</pose>
-      <name>2</name>
     </link>
     <link name="3">
       <collision name="3">
@@ -54,7 +48,6 @@
             <size>0.3 0.02 1.815</size>
           </box>
         </geometry>
-        <name>3</name>
       </collision>
       <visual name="3">
         <geometry>
@@ -65,12 +58,9 @@
         <material>
           <ambient>0.9 0.9 0.9 1</ambient>
         </material>
-        <name>3</name>
       </visual>
       <pose>-0.01 0.365 0.9075 0 0 0</pose>
-      <name>3</name>
     </link>
     <static>true</static>
-    <name>rgo2015/cupboard/frame</name>
   </model>
 </sdf>

--- a/models/rgo2015/cupboard/model.sdf
+++ b/models/rgo2015/cupboard/model.sdf
@@ -4,7 +4,6 @@
     <light name="sun" type="directional">
       <direction>0.5 0.1 -0.9</direction>
       <pose>0 0 10 0 0 0</pose>
-      <name>sun</name>
       <specular>0.2 0.2 0.2 1</specular>
       <cast_shadows>true</cast_shadows>
       <diffuse>0.8 0.8 0.8 1</diffuse>
@@ -15,27 +14,27 @@
         <linear>0.01</linear>
       </attenuation>
     </light>
-    <include name="frame">
+    <include>
       <pose>0 0 0 0 0 0</pose>
       <name>frame</name>
       <uri>model://rgo2015/cupboard/frame</uri>
     </include>
-    <include name="shelf1">
+    <include>
       <pose>0 0 0.91 0 0 0</pose>
       <name>shelf1</name>
       <uri>model://rgo2015/cupboard/shelf</uri>
     </include>
-    <include name="shelf2">
+    <include>
       <pose>0 0 1.265 0 0 0</pose>
       <name>shelf2</name>
       <uri>model://rgo2015/cupboard/shelf</uri>
     </include>
-    <include name="shelf3">
+    <include>
       <pose>0 0 1.555 0 0 0</pose>
       <name>shelf3</name>
       <uri>model://rgo2015/cupboard/shelf</uri>
     </include>
-    <include name="shelf4">
+    <include>
       <pose>0 0 1.795 0 0 0</pose>
       <name>shelf4</name>
       <uri>model://rgo2015/cupboard/shelf</uri>
@@ -52,6 +51,5 @@
         </solver>
       </ode>
     </physics>
-    <name>rgo2015/cupboard</name>
   </world>
 </sdf>

--- a/models/rgo2015/cupboard/shelf/model.sdf
+++ b/models/rgo2015/cupboard/shelf/model.sdf
@@ -8,7 +8,6 @@
             <size>0.28 0.75 0.02</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -19,12 +18,9 @@
         <material>
           <ambient>0.9 0.9 0.9 1</ambient>
         </material>
-        <name>1</name>
       </visual>
       <pose>-0.01 0.0 0.01 0 0 0</pose>
-      <name>1</name>
     </link>
     <static>true</static>
-    <name>rgo2015/cupboard/shelf</name>
   </model>
 </sdf>

--- a/models/rgo2015/fridge/model.sdf
+++ b/models/rgo2015/fridge/model.sdf
@@ -8,7 +8,6 @@
             <size>0.69 0.6 1.02</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -19,12 +18,9 @@
         <material>
           <ambient>0.9 0.9 0.9 1</ambient>
         </material>
-        <name>1</name>
       </visual>
       <pose>0.0 0.0 0.51 0 0 0</pose>
-      <name>1</name>
     </link>
     <static>true</static>
-    <name>rgo2015/fridge</name>
   </model>
 </sdf>

--- a/models/rgo2015/kitchen_counter/model.sdf
+++ b/models/rgo2015/kitchen_counter/model.sdf
@@ -8,7 +8,6 @@
             <size>0.69 1.205 1.02</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -19,10 +18,8 @@
         <material>
           <ambient>0.9 0.9 0.9 1</ambient>
         </material>
-        <name>1</name>
       </visual>
       <pose>0.0 0.0 0.51 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="2">
       <collision name="2">
@@ -31,7 +28,6 @@
             <size>0.08 1.205 2.01</size>
           </box>
         </geometry>
-        <name>2</name>
       </collision>
       <visual name="2">
         <geometry>
@@ -42,10 +38,8 @@
         <material>
           <ambient>0.9 0.9 0.9 1</ambient>
         </material>
-        <name>2</name>
       </visual>
       <pose>-0.305 0.0 1.005 0 0 0</pose>
-      <name>2</name>
     </link>
     <link name="3">
       <collision name="3">
@@ -54,7 +48,6 @@
             <size>0.43 1.205 0.48</size>
           </box>
         </geometry>
-        <name>3</name>
       </collision>
       <visual name="3">
         <geometry>
@@ -65,12 +58,9 @@
         <material>
           <ambient>0.9 0.9 0.9 1</ambient>
         </material>
-        <name>3</name>
       </visual>
       <pose>-0.13 0.0 1.77 0 0 0</pose>
-      <name>3</name>
     </link>
     <static>true</static>
-    <name>rgo2015/kitchen_counter</name>
   </model>
 </sdf>

--- a/models/rgo2015/kitchen_table/model.sdf
+++ b/models/rgo2015/kitchen_table/model.sdf
@@ -8,7 +8,6 @@
             <size>0.78 1.17 0.02</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -19,10 +18,8 @@
         <material>
           <ambient>0.1 0.1 0.1 1</ambient>
         </material>
-        <name>1</name>
       </visual>
       <pose>0.0 0.0 0.73 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="2">
       <collision name="2">
@@ -31,7 +28,6 @@
             <size>0.04 0.04 0.74</size>
           </box>
         </geometry>
-        <name>2</name>
       </collision>
       <visual name="2">
         <geometry>
@@ -42,10 +38,8 @@
         <material>
           <ambient>0.1 0.1 0.1 1</ambient>
         </material>
-        <name>2</name>
       </visual>
       <pose>-0.335 -0.265 0.37 0 0 0</pose>
-      <name>2</name>
     </link>
     <link name="3">
       <collision name="3">
@@ -54,7 +48,6 @@
             <size>0.04 0.04 0.74</size>
           </box>
         </geometry>
-        <name>3</name>
       </collision>
       <visual name="3">
         <geometry>
@@ -65,10 +58,8 @@
         <material>
           <ambient>0.1 0.1 0.1 1</ambient>
         </material>
-        <name>3</name>
       </visual>
       <pose>-0.335 0.265 0.37 0 0 0</pose>
-      <name>3</name>
     </link>
     <link name="4">
       <collision name="4">
@@ -77,7 +68,6 @@
             <size>0.04 0.04 0.74</size>
           </box>
         </geometry>
-        <name>4</name>
       </collision>
       <visual name="4">
         <geometry>
@@ -88,10 +78,8 @@
         <material>
           <ambient>0.1 0.1 0.1 1</ambient>
         </material>
-        <name>4</name>
       </visual>
       <pose>0.335 -0.265 0.37 0 0 0</pose>
-      <name>4</name>
     </link>
     <link name="5">
       <collision name="5">
@@ -100,7 +88,6 @@
             <size>0.04 0.04 0.74</size>
           </box>
         </geometry>
-        <name>5</name>
       </collision>
       <visual name="5">
         <geometry>
@@ -111,10 +98,8 @@
         <material>
           <ambient>0.1 0.1 0.1 1</ambient>
         </material>
-        <name>5</name>
       </visual>
       <pose>0.335 0.265 0.37 0 0 0</pose>
-      <name>5</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
@@ -124,11 +109,8 @@
           </box>
         </geometry>
         <pose>1.165 0.0 0.5 0 0 0</pose>
-        <name>in_front_of</name>
       </virtual_volume>
-      <name>in_front_of</name>
     </link>
     <static>true</static>
-    <name>rgo2015/kitchen_table</name>
   </model>
 </sdf>

--- a/models/rgo2015/model.sdf
+++ b/models/rgo2015/model.sdf
@@ -4,7 +4,6 @@
     <light name="sun" type="directional">
       <direction>0.5 0.1 -0.9</direction>
       <pose>0 0 10 0 0 0</pose>
-      <name>sun</name>
       <specular>0.2 0.2 0.2 1</specular>
       <cast_shadows>true</cast_shadows>
       <diffuse>0.8 0.8 0.8 1</diffuse>
@@ -18,227 +17,182 @@
     <model name="initial_pose_door_A" type="waypoint">
       <pose>0.0 0.0 0 0 0 0</pose>
       <static>true</static>
-      <name>initial_pose_door_A</name>
     </model>
     <model name="initial_pose_door_B" type="waypoint">
       <pose>2.0 8.9 0 0 0 -1.57</pose>
       <static>true</static>
-      <name>initial_pose_door_B</name>
     </model>
     <model name="initial_pose" type="waypoint">
       <pose>0.0 0.0 0 0 0 0</pose>
       <static>true</static>
-      <name>initial_pose</name>
     </model>
     <model name="entry_point" type="waypoint">
       <pose>1.897 4.295 0 0 0 0</pose>
       <static>true</static>
-      <name>entry_point</name>
     </model>
     <model name="exit" type="waypoint">
       <pose>-1.48 -0.031 0 0 0 3.1415</pose>
       <static>true</static>
-      <name>exit</name>
     </model>
     <model name="rips1" type="waypoint">
       <pose>4.0 0.5 0 0 0 -1.57</pose>
       <static>true</static>
-      <name>rips1</name>
     </model>
     <model name="rips2" type="waypoint">
       <pose>4.0 2.5 0 0 0 -1.57</pose>
       <static>true</static>
-      <name>rips2</name>
     </model>
     <model name="exit_1_rips" type="waypoint">
       <pose>2.0 10.5 0 0 0 1.57</pose>
       <static>true</static>
-      <name>exit_1_rips</name>
     </model>
     <model name="exit_2_rips" type="waypoint">
       <pose>2.0 8.0 0 0 0 1.57</pose>
       <static>true</static>
-      <name>exit_2_rips</name>
     </model>
     <model name="exit_3_rips" type="waypoint">
       <pose>3.0 3.0 0 0 0 1.57</pose>
       <static>true</static>
-      <name>exit_3_rips</name>
     </model>
     <model name="exit_1_A" type="waypoint">
       <pose>-1.0 0.0 0 0 0 3.14</pose>
       <static>true</static>
-      <name>exit_1_A</name>
     </model>
     <model name="exit_2_A" type="waypoint">
       <pose>1.0 0.0 0 0 0 3.14</pose>
       <static>true</static>
-      <name>exit_2_A</name>
     </model>
     <model name="exit_3_A" type="waypoint">
       <pose>1.0 0.0 0 0 0 3.14</pose>
       <static>true</static>
-      <name>exit_3_A</name>
     </model>
     <model name="manipulation_init_pose" type="waypoint">
       <pose>2.0 6.5 0 0 0 3.14</pose>
       <static>true</static>
-      <name>manipulation_init_pose</name>
     </model>
     <model name="person_rec_learning" type="waypoint">
       <pose>7.069 1.045 0 0 0 0.0</pose>
       <static>true</static>
-      <name>person_rec_learning</name>
     </model>
     <model name="person_rec_living_room_1" type="waypoint">
       <pose>6.304 0.607 0 0 0 -2.719</pose>
       <static>true</static>
-      <name>person_rec_living_room_1</name>
     </model>
     <model name="person_rec_living_room_2" type="waypoint">
       <pose>4.041 1.935 0 0 0 -1.585</pose>
       <static>true</static>
-      <name>person_rec_living_room_2</name>
     </model>
     <model name="person_rec_living_room_3" type="waypoint">
       <pose>1.801 0.151 0 0 0 -0.11</pose>
       <static>true</static>
-      <name>person_rec_living_room_3</name>
     </model>
     <model name="wakemeup_bedside_1" type="waypoint">
       <pose>1.771 0.244 0 0 0 2.27</pose>
       <static>true</static>
-      <name>wakemeup_bedside_1</name>
     </model>
     <model name="wakemeup_bedside_2" type="waypoint">
       <pose>2.749 0.333 0 0 0 2.48</pose>
       <static>true</static>
-      <name>wakemeup_bedside_2</name>
     </model>
     <model name="wakemeup_bedside_3" type="waypoint">
       <pose>3.509 1.065 0 0 0 3.006</pose>
       <static>true</static>
-      <name>wakemeup_bedside_3</name>
     </model>
     <model name="wakemeup_bedside_4" type="waypoint">
       <pose>3.364 2.344 0 0 0 -2.919</pose>
       <static>true</static>
-      <name>wakemeup_bedside_4</name>
     </model>
     <model name="wakemeup_kitchen_table" type="waypoint">
       <pose>3.313 5.155 0 0 0 1.49</pose>
       <static>true</static>
-      <name>wakemeup_kitchen_table</name>
     </model>
     <model name="open_challenge_start" type="waypoint">
       <pose>6.0 7.0 0 0 0 0.0</pose>
       <static>true</static>
-      <name>open_challenge_start</name>
     </model>
     <model name="gpsr_meeting_point" type="waypoint">
       <pose>8.166 5.417 0 0 0 -1.823</pose>
       <static>true</static>
-      <name>gpsr_meeting_point</name>
     </model>
     <model name="exit_gpsr" type="waypoint">
       <pose>2.0 10.5 0 0 0 1.57</pose>
       <static>true</static>
-      <name>exit_gpsr</name>
     </model>
     <model name="gpsr_bed" type="waypoint">
       <pose>3.125 1.892 0 0 0 3.1</pose>
       <static>true</static>
-      <name>gpsr_bed</name>
     </model>
     <model name="gpsr_left_bedside_table" type="waypoint">
       <pose>1.374 0.26 0 0 0 2.67</pose>
       <static>true</static>
-      <name>gpsr_left_bedside_table</name>
     </model>
     <model name="gpsr_right_bedside_table" type="waypoint">
       <pose>1.707 3.041 0 0 0 3.136</pose>
       <static>true</static>
-      <name>gpsr_right_bedside_table</name>
     </model>
     <model name="gpsr_small_table" type="waypoint">
       <pose>4.447 0.13 0 0 0 -1.5</pose>
       <static>true</static>
-      <name>gpsr_small_table</name>
     </model>
     <model name="gpsr_bartable" type="waypoint">
       <pose>7.627 0.14 0 0 0 -0.7</pose>
       <static>true</static>
-      <name>gpsr_bartable</name>
     </model>
     <model name="gpsr_kitchencounter" type="waypoint">
       <pose>7.088 2.22 0 0 0 -3.13</pose>
       <static>true</static>
-      <name>gpsr_kitchencounter</name>
     </model>
     <model name="gpsr_fridge" type="waypoint">
       <pose>7.088 2.22 0 0 0 -3.13</pose>
       <static>true</static>
-      <name>gpsr_fridge</name>
     </model>
     <model name="gpsr_stove" type="waypoint">
       <pose>7.088 2.22 0 0 0 -3.13</pose>
       <static>true</static>
-      <name>gpsr_stove</name>
     </model>
     <model name="gpsr_sink" type="waypoint">
       <pose>7.088 2.22 0 0 0 -0.313</pose>
       <static>true</static>
-      <name>gpsr_sink</name>
     </model>
     <model name="gpsr_cabinet" type="waypoint">
       <pose>8.137 3.103 0 0 0 0.0</pose>
       <static>true</static>
-      <name>gpsr_cabinet</name>
     </model>
     <model name="gpsr_couchtable" type="waypoint">
       <pose>8.199 5.609 0 0 0 1.57</pose>
       <static>true</static>
-      <name>gpsr_couchtable</name>
     </model>
     <model name="gpsr_cupboard" type="waypoint">
       <pose>5.797 7.241 0 0 0 1.35</pose>
       <static>true</static>
-      <name>gpsr_cupboard</name>
     </model>
     <model name="gpsr_right_bookcase" type="waypoint">
       <pose>1.688 7.021 0 0 0 -3.0</pose>
       <static>true</static>
-      <name>gpsr_right_bookcase</name>
     </model>
     <model name="gpsr_left_bookcase" type="waypoint">
       <pose>1.81 5.929 0 0 0 3.0</pose>
       <static>true</static>
-      <name>gpsr_left_bookcase</name>
     </model>
     <model name="gpsr_dinnertable" type="waypoint">
       <pose>1.945 6.51 0 0 0 0.0</pose>
       <static>true</static>
-      <name>gpsr_dinnertable</name>
     </model>
     <model name="gpsr_counter" type="waypoint">
       <pose>3.006 4.653 0 0 0 -3.1</pose>
       <static>true</static>
-      <name>gpsr_counter</name>
     </model>
     <model name="gpsr_desk" type="waypoint">
       <pose>4.681 5.232 0 0 0 -1.58</pose>
       <static>true</static>
-      <name>gpsr_desk</name>
     </model>
     <model name="robonurse_initial" type="waypoint">
       <pose>8.262 4.994 0 0 0 1.56</pose>
       <static>true</static>
-      <name>robonurse_initial</name>
     </model>
     <model name="robonurse_granny_loc" type="waypoint">
       <pose>6.033 7.437 0 0 0 0.0</pose>
       <static>true</static>
-      <name>robonurse_granny_loc</name>
     </model>
     <model name="office" type="room">
       <link name="in">
@@ -249,13 +203,10 @@
             </box>
           </geometry>
           <pose>0.0 0.0 0.0 0 0 0</pose>
-          <name>in</name>
         </virtual_volume>
-        <name>in</name>
       </link>
       <pose>3.0 6.25 0 0 0 0</pose>
       <static>true</static>
-      <name>office</name>
     </model>
     <model name="kitchen" type="room">
       <link name="in">
@@ -266,13 +217,10 @@
             </box>
           </geometry>
           <pose>0.0 0.0 0.0 0 0 0</pose>
-          <name>in</name>
         </virtual_volume>
-        <name>in</name>
       </link>
       <pose>7.5 1.0 0 0 0 0</pose>
       <static>true</static>
-      <name>kitchen</name>
     </model>
     <model name="livingroom" type="room">
       <link name="in">
@@ -283,13 +231,10 @@
             </box>
           </geometry>
           <pose>0.0 0.0 0.0 0 0 0</pose>
-          <name>in</name>
         </virtual_volume>
-        <name>in</name>
       </link>
       <pose>7.5 5.5 0 0 0 0</pose>
       <static>true</static>
-      <name>livingroom</name>
     </model>
     <model name="bedroom" type="room">
       <link name="in">
@@ -300,13 +245,10 @@
             </box>
           </geometry>
           <pose>0.0 0.0 0.0 0 0 0</pose>
-          <name>in</name>
         </virtual_volume>
-        <name>in</name>
       </link>
       <pose>3.0 2.0 0 0 0 0</pose>
       <static>true</static>
-      <name>bedroom</name>
     </model>
     <model name="hall" type="room">
       <link name="in">
@@ -317,130 +259,127 @@
             </box>
           </geometry>
           <pose>0.0 0.0 0.0 0 0 0</pose>
-          <name>in</name>
         </virtual_volume>
-        <name>in</name>
       </link>
       <pose>3.0 0.0 0 0 0 0</pose>
       <static>true</static>
-      <name>hall</name>
     </model>
-    <include name="walls">
+    <include>
       <pose>0 0 0 0 0 0</pose>
       <name>walls</name>
       <uri>model://rgo2015/walls</uri>
     </include>
-    <include name="floor">
+    <include>
       <pose>0 0 0 0 0 0</pose>
       <name>floor</name>
       <uri>model://floor</uri>
     </include>
-    <include name="bed">
+    <include>
       <pose>1.555 1.775 0 0 0 0</pose>
       <name>bed</name>
       <uri>model://rgo2015/bed</uri>
     </include>
-    <include name="left_bedside_table">
+    <include>
       <pose>0.695 0.7775 0 0 0 0</pose>
       <name>left_bedside_table</name>
       <uri>model://rgo2015/bedstand</uri>
     </include>
-    <include name="right_bedside_table">
+    <include>
       <pose>0.695 2.9775 0 0 0 0</pose>
       <name>right_bedside_table</name>
       <uri>model://rgo2015/bedstand</uri>
     </include>
-    <include name="coathanger">
+    <include>
       <pose>1.525 -1.0 0 0 0 0</pose>
       <name>coathanger</name>
       <uri>model://rgo2015/coathanger</uri>
     </include>
-    <include name="small_table">
+    <include>
       <pose>4.46 -0.985 0 0 0 0</pose>
       <name>small_table</name>
       <uri>model://rgo2015/small_table</uri>
     </include>
-    <include name="bartable">
+    <include>
       <pose>8.65 -0.81 0 0 0 0</pose>
       <name>bartable</name>
       <uri>model://rgo2015/bar_table</uri>
     </include>
-    <include name="kitchencounter">
+    <include>
       <pose>5.87 2.3425 0 0 0 0</pose>
       <name>kitchencounter</name>
       <uri>model://rgo2015/kitchen_counter</uri>
     </include>
-    <include name="fridge">
+    <include>
       <pose>5.87 2.6425 0 0 0 0</pose>
       <name>fridge</name>
       <uri>model://rgo2015/fridge</uri>
     </include>
-    <include name="stove">
+    <include>
       <pose>5.9 2.695 1.02 0 0 0</pose>
       <name>stove</name>
       <uri>model://rgo2015/stove</uri>
     </include>
-    <include name="sink">
+    <include>
       <pose>5.85 2.14 1.02 0 0 0</pose>
       <name>sink</name>
       <uri>model://rgo2015/sink</uri>
     </include>
-    <include name="thrashbin">
+    <include>
       <pose>5.7075 1.585 0 0 0 1.57</pose>
       <name>thrashbin</name>
       <uri>model://rgo2015/thrashbin</uri>
     </include>
-    <include name="cabinet">
+    <include>
       <pose>9.25 3.12 0 0 0 0</pose>
       <name>cabinet</name>
       <uri>model://rgo2015/tv_stand</uri>
     </include>
-    <include name="couchtable">
+    <include>
       <pose>8.2 6.755 0 0 0 1.57</pose>
       <name>couchtable</name>
       <uri>model://rgo2015/couch_table</uri>
     </include>
-    <include name="couch">
+    <include>
       <pose>8.17 8.0675 0 0 0 -1.57</pose>
       <name>couch</name>
       <uri>model://rgo2015/couch</uri>
     </include>
-    <include name="tv">
+    <include>
       <pose>6.025 4.1 0 0 0 0</pose>
       <name>tv</name>
       <uri>model://rgo2015/tv</uri>
     </include>
-    <include name="cupboard">
+    <include>
       <pose>5.945 8.34 0 0 0 -1.57</pose>
       <name>cupboard</name>
       <uri>model://rgo2015/cupboard</uri>
     </include>
-    <include name="right_bookcase">
+    <include>
       <pose>0.665 6.83 0 0 0 0</pose>
       <name>right_bookcase</name>
       <uri>model://rgo2015/cabinet</uri>
     </include>
-    <include name="bookcase">
+    <include>
       <pose>0.665 6.83 0.685 0 0 0</pose>
       <name>bookcase</name>
       <uri>model://rgo2015/cabinet/shelf</uri>
     </include>
-    <include name="left_bookcase">
+    <include>
       <pose>0.665 6.03 0 0 0 0</pose>
       <name>left_bookcase</name>
       <uri>model://rgo2015/cabinet</uri>
     </include>
-    <include name="dinnertable">
+    <include>
       <pose>3.56 8.0 0 0 0 1.57</pose>
       <name>dinnertable</name>
       <uri>model://rgo2015/kitchen_table</uri>
     </include>
-    <include name="counter">
+    <include>
       <pose>1.76 4.4 0 0 0 0</pose>
       <name>counter</name>
       <uri>model://rgo2015/table</uri>
     </include>
-    <include name="desk">
+    <include>
       <pose>4.675 5.2 0 0 0 1.57</pose>
       <name>desk</name>
       <uri>model://rgo2015/table</uri>
@@ -457,6 +396,5 @@
         </solver>
       </ode>
     </physics>
-    <name>rgo2015</name>
   </world>
 </sdf>

--- a/models/rgo2015/sink/model.sdf
+++ b/models/rgo2015/sink/model.sdf
@@ -8,7 +8,6 @@
             <size>0.5 0.6 0.01</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -19,12 +18,9 @@
         <material>
           <ambient>0.8 0.8 0.8 1</ambient>
         </material>
-        <name>1</name>
       </visual>
       <pose>0.0 0.0 0.05 0 0 0</pose>
-      <name>1</name>
     </link>
     <static>true</static>
-    <name>rgo2015/sink</name>
   </model>
 </sdf>

--- a/models/rgo2015/small_table/model.sdf
+++ b/models/rgo2015/small_table/model.sdf
@@ -8,7 +8,6 @@
             <size>0.55 0.55 0.05</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -19,10 +18,8 @@
         <material>
           <ambient>0.0 0.0 0.0 1</ambient>
         </material>
-        <name>1</name>
       </visual>
       <pose>0.0 0.0 0.425 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="2">
       <collision name="2">
@@ -31,7 +28,6 @@
             <size>0.05 0.05 0.45</size>
           </box>
         </geometry>
-        <name>2</name>
       </collision>
       <visual name="2">
         <geometry>
@@ -42,10 +38,8 @@
         <material>
           <ambient>0.0 0.0 0.0 1</ambient>
         </material>
-        <name>2</name>
       </visual>
       <pose>-0.25 -0.25 0.225 0 0 0</pose>
-      <name>2</name>
     </link>
     <link name="3">
       <collision name="3">
@@ -54,7 +48,6 @@
             <size>0.05 0.05 0.45</size>
           </box>
         </geometry>
-        <name>3</name>
       </collision>
       <visual name="3">
         <geometry>
@@ -65,10 +58,8 @@
         <material>
           <ambient>0.0 0.0 0.0 1</ambient>
         </material>
-        <name>3</name>
       </visual>
       <pose>-0.25 0.25 0.225 0 0 0</pose>
-      <name>3</name>
     </link>
     <link name="4">
       <collision name="4">
@@ -77,7 +68,6 @@
             <size>0.05 0.05 0.45</size>
           </box>
         </geometry>
-        <name>4</name>
       </collision>
       <visual name="4">
         <geometry>
@@ -88,10 +78,8 @@
         <material>
           <ambient>0.0 0.0 0.0 1</ambient>
         </material>
-        <name>4</name>
       </visual>
       <pose>0.25 -0.25 0.225 0 0 0</pose>
-      <name>4</name>
     </link>
     <link name="5">
       <collision name="5">
@@ -100,7 +88,6 @@
             <size>0.05 0.05 0.45</size>
           </box>
         </geometry>
-        <name>5</name>
       </collision>
       <visual name="5">
         <geometry>
@@ -111,12 +98,9 @@
         <material>
           <ambient>0.0 0.0 0.0 1</ambient>
         </material>
-        <name>5</name>
       </visual>
       <pose>0.25 0.25 0.225 0 0 0</pose>
-      <name>5</name>
     </link>
     <static>true</static>
-    <name>rgo2015/small_table</name>
   </model>
 </sdf>

--- a/models/rgo2015/stove/model.sdf
+++ b/models/rgo2015/stove/model.sdf
@@ -8,7 +8,6 @@
             <size>0.51 0.29 0.01</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -19,12 +18,9 @@
         <material>
           <ambient>0.1 0.1 0.1 1</ambient>
         </material>
-        <name>1</name>
       </visual>
       <pose>0.0 0.0 0.05 0 0 0</pose>
-      <name>1</name>
     </link>
     <static>true</static>
-    <name>rgo2015/stove</name>
   </model>
 </sdf>

--- a/models/rgo2015/table/model.sdf
+++ b/models/rgo2015/table/model.sdf
@@ -8,7 +8,6 @@
             <size>0.8 1.6 0.02</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -19,10 +18,8 @@
         <material>
           <ambient>0.5 0.5 0.5 1</ambient>
         </material>
-        <name>1</name>
       </visual>
       <pose>0.0 0.0 0.725 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="2">
       <collision name="2">
@@ -31,7 +28,6 @@
             <size>0.04 0.04 0.735</size>
           </box>
         </geometry>
-        <name>2</name>
       </collision>
       <visual name="2">
         <geometry>
@@ -42,10 +38,8 @@
         <material>
           <ambient>0.5 0.5 0.5 1</ambient>
         </material>
-        <name>2</name>
       </visual>
       <pose>-0.06 -0.7 0.3675 0 0 0</pose>
-      <name>2</name>
     </link>
     <link name="3">
       <collision name="3">
@@ -54,7 +48,6 @@
             <size>0.04 0.04 0.735</size>
           </box>
         </geometry>
-        <name>3</name>
       </collision>
       <visual name="3">
         <geometry>
@@ -65,10 +58,8 @@
         <material>
           <ambient>0.5 0.5 0.5 1</ambient>
         </material>
-        <name>3</name>
       </visual>
       <pose>-0.06 0.7 0.3675 0 0 0</pose>
-      <name>3</name>
     </link>
     <link name="4">
       <collision name="4">
@@ -77,7 +68,6 @@
             <size>0.04 0.04 0.735</size>
           </box>
         </geometry>
-        <name>4</name>
       </collision>
       <visual name="4">
         <geometry>
@@ -88,10 +78,8 @@
         <material>
           <ambient>0.5 0.5 0.5 1</ambient>
         </material>
-        <name>4</name>
       </visual>
       <pose>0.06 -0.7 0.3675 0 0 0</pose>
-      <name>4</name>
     </link>
     <link name="5">
       <collision name="5">
@@ -100,7 +88,6 @@
             <size>0.04 0.04 0.735</size>
           </box>
         </geometry>
-        <name>5</name>
       </collision>
       <visual name="5">
         <geometry>
@@ -111,10 +98,8 @@
         <material>
           <ambient>0.5 0.5 0.5 1</ambient>
         </material>
-        <name>5</name>
       </visual>
       <pose>0.06 0.7 0.3675 0 0 0</pose>
-      <name>5</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
@@ -124,11 +109,8 @@
           </box>
         </geometry>
         <pose>1.175 0.0 0.5 0 0 0</pose>
-        <name>in_front_of</name>
       </virtual_volume>
-      <name>in_front_of</name>
     </link>
     <static>true</static>
-    <name>rgo2015/table</name>
   </model>
 </sdf>

--- a/models/rgo2015/thrashbin/model.sdf
+++ b/models/rgo2015/thrashbin/model.sdf
@@ -8,7 +8,6 @@
             <size>0.29 0.365 0.55</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -19,12 +18,9 @@
         <material>
           <ambient>0.8 0.8 0.8 1</ambient>
         </material>
-        <name>1</name>
       </visual>
       <pose>0 0 0.275 0 0 0</pose>
-      <name>1</name>
     </link>
     <static>true</static>
-    <name>rgo2015/thrashbin</name>
   </model>
 </sdf>

--- a/models/rgo2015/tv/foot/model.sdf
+++ b/models/rgo2015/tv/foot/model.sdf
@@ -8,7 +8,6 @@
             <uri>model://rgo2015/tv/foot/shape/disc.stl</uri>
           </mesh>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -16,12 +15,9 @@
             <uri>model://rgo2015/tv/foot/shape/disc.stl</uri>
           </mesh>
         </geometry>
-        <name>1</name>
       </visual>
       <pose>0 0 0 0 0 0</pose>
-      <name>1</name>
     </link>
     <static>true</static>
-    <name>rgo2015/tv/foot</name>
   </model>
 </sdf>

--- a/models/rgo2015/tv/model.sdf
+++ b/models/rgo2015/tv/model.sdf
@@ -4,7 +4,6 @@
     <light name="sun" type="directional">
       <direction>0.5 0.1 -0.9</direction>
       <pose>0 0 10 0 0 0</pose>
-      <name>sun</name>
       <specular>0.2 0.2 0.2 1</specular>
       <cast_shadows>true</cast_shadows>
       <diffuse>0.8 0.8 0.8 1</diffuse>
@@ -15,17 +14,17 @@
         <linear>0.01</linear>
       </attenuation>
     </light>
-    <include name="foot">
+    <include>
       <pose>0 0 0 0 0 0</pose>
       <name>foot</name>
       <uri>model://rgo2015/tv/foot</uri>
     </include>
-    <include name="pole">
+    <include>
       <pose>0 0 0 0 0 0</pose>
       <name>pole</name>
       <uri>model://rgo2015/tv/pole</uri>
     </include>
-    <include name="tv">
+    <include>
       <pose>0.23 0 1.67 0 0.1 0</pose>
       <name>tv</name>
       <uri>model://rgo2015/tv/tv</uri>
@@ -42,6 +41,5 @@
         </solver>
       </ode>
     </physics>
-    <name>rgo2015/tv</name>
   </world>
 </sdf>

--- a/models/rgo2015/tv/pole/model.sdf
+++ b/models/rgo2015/tv/pole/model.sdf
@@ -8,7 +8,6 @@
             <size>0.28 0.28 2.0</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -19,12 +18,9 @@
         <material>
           <ambient>0.7 0.7 0.7 1</ambient>
         </material>
-        <name>1</name>
       </visual>
       <pose>0 0 1.0 0 0 0</pose>
-      <name>1</name>
     </link>
     <static>true</static>
-    <name>rgo2015/tv/pole</name>
   </model>
 </sdf>

--- a/models/rgo2015/tv/tv/model.sdf
+++ b/models/rgo2015/tv/tv/model.sdf
@@ -8,7 +8,6 @@
             <size>0.1 1.5 0.92</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -19,12 +18,9 @@
         <material>
           <ambient>0.1 0.1 0.1 1</ambient>
         </material>
-        <name>1</name>
       </visual>
       <pose>0 0 0.46 0 0 0</pose>
-      <name>1</name>
     </link>
     <static>true</static>
-    <name>rgo2015/tv/tv</name>
   </model>
 </sdf>

--- a/models/rgo2015/tv_stand/model.sdf
+++ b/models/rgo2015/tv_stand/model.sdf
@@ -8,7 +8,6 @@
             <size>0.4 1.2 0.39</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -19,12 +18,9 @@
         <material>
           <ambient>0.9 0.9 0.9 1</ambient>
         </material>
-        <name>1</name>
       </visual>
       <pose>0.0 0.0 0.195 0 0 0</pose>
-      <name>1</name>
     </link>
     <static>true</static>
-    <name>rgo2015/tv_stand</name>
   </model>
 </sdf>

--- a/models/rgo2015/walls/model.sdf
+++ b/models/rgo2015/walls/model.sdf
@@ -8,7 +8,6 @@
             <uri>model://rgo2015/walls/shape/heightmap.stl</uri>
           </mesh>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -16,12 +15,9 @@
             <uri>model://rgo2015/walls/shape/heightmap.stl</uri>
           </mesh>
         </geometry>
-        <name>1</name>
       </visual>
       <pose>0 0 0 0 0 0</pose>
-      <name>1</name>
     </link>
     <static>true</static>
-    <name>rgo2015/walls</name>
   </model>
 </sdf>

--- a/models/rgo2015_final/model.sdf
+++ b/models/rgo2015_final/model.sdf
@@ -4,7 +4,6 @@
     <light name="sun" type="directional">
       <direction>0.5 0.1 -0.9</direction>
       <pose>0 0 10 0 0 0</pose>
-      <name>sun</name>
       <specular>0.2 0.2 0.2 1</specular>
       <cast_shadows>true</cast_shadows>
       <diffuse>0.8 0.8 0.8 1</diffuse>
@@ -18,107 +17,86 @@
     <model name="initial_pose_door_A" type="waypoint">
       <pose>0.0 0.0 0 0 0 0</pose>
       <static>true</static>
-      <name>initial_pose_door_A</name>
     </model>
     <model name="initial_pose_door_B" type="waypoint">
       <pose>2.0 8.9 0 0 0 -1.57</pose>
       <static>true</static>
-      <name>initial_pose_door_B</name>
     </model>
     <model name="initial_pose" type="waypoint">
       <pose>0.0 0.0 0 0 0 0</pose>
       <static>true</static>
-      <name>initial_pose</name>
     </model>
     <model name="entry_point" type="waypoint">
       <pose>1.897 4.295 0 0 0 0</pose>
       <static>true</static>
-      <name>entry_point</name>
     </model>
     <model name="exit_door_A" type="waypoint">
       <pose>-1.48 -0.031 0 0 0 3.1415</pose>
       <static>true</static>
-      <name>exit_door_A</name>
     </model>
     <model name="exit_door_B" type="waypoint">
       <pose>2.0 10.5 0 0 0 1.57</pose>
       <static>true</static>
-      <name>exit_door_B</name>
     </model>
     <model name="final_cupboard" type="waypoint">
       <pose>6.0 7.0 0 0 0 1.57</pose>
       <static>true</static>
-      <name>final_cupboard</name>
     </model>
     <model name="final_dinnertable" type="waypoint">
       <pose>3.6 6.5 0 0 0 1.54</pose>
       <static>true</static>
-      <name>final_dinnertable</name>
     </model>
     <model name="final_desk" type="waypoint">
       <pose>4.6 6.8 0 0 0 -1.57</pose>
       <static>true</static>
-      <name>final_desk</name>
     </model>
     <model name="task_location_sergio" type="waypoint">
       <pose>7.982 5.026 0 0 0 2.854</pose>
       <static>true</static>
-      <name>task_location_sergio</name>
     </model>
     <model name="final_tv" type="waypoint">
       <pose>7.702 4.224 0 0 0 3.14</pose>
       <static>true</static>
-      <name>final_tv</name>
     </model>
     <model name="final_kitchencounter" type="waypoint">
       <pose>7.2 2.0 0 0 0 3.127</pose>
       <static>true</static>
-      <name>final_kitchencounter</name>
     </model>
     <model name="final_cabinet" type="waypoint">
       <pose>7.255 1.284 0 0 0 0.768</pose>
       <static>true</static>
-      <name>final_cabinet</name>
     </model>
     <model name="final_bartable" type="waypoint">
       <pose>7.496 0.436 0 0 0 -0.8</pose>
       <static>true</static>
-      <name>final_bartable</name>
     </model>
     <model name="final_small_table_1" type="waypoint">
       <pose>4.069 0.891 0 0 0 -1.078</pose>
       <static>true</static>
-      <name>final_small_table_1</name>
     </model>
     <model name="final_small_table_2" type="waypoint">
       <pose>4.069 0.891 0 0 0 -1.819</pose>
       <static>true</static>
-      <name>final_small_table_2</name>
     </model>
     <model name="final_coathanger" type="waypoint">
       <pose>2.886 0.256 0 0 0 -2.367</pose>
       <static>true</static>
-      <name>final_coathanger</name>
     </model>
     <model name="final_left_bedside_table" type="waypoint">
       <pose>2.153 -0.252 0 0 0 2.328</pose>
       <static>true</static>
-      <name>final_left_bedside_table</name>
     </model>
     <model name="final_right_bedside_table" type="waypoint">
       <pose>3.107 3.042 0 0 0 -3.125</pose>
       <static>true</static>
-      <name>final_right_bedside_table</name>
     </model>
     <model name="final_last_position_sergio" type="waypoint">
       <pose>7.667 0.894 0 0 0 0.478</pose>
       <static>true</static>
-      <name>final_last_position_sergio</name>
     </model>
     <model name="final_last_position_amigo" type="waypoint">
       <pose>7.29 2.139 0 0 0 0.195</pose>
       <static>true</static>
-      <name>final_last_position_amigo</name>
     </model>
     <model name="office" type="room">
       <link name="in">
@@ -129,13 +107,10 @@
             </box>
           </geometry>
           <pose>0.0 0.0 0.0 0 0 0</pose>
-          <name>in</name>
         </virtual_volume>
-        <name>in</name>
       </link>
       <pose>3.0 6.25 0 0 0 0</pose>
       <static>true</static>
-      <name>office</name>
     </model>
     <model name="kitchen" type="room">
       <link name="in">
@@ -146,13 +121,10 @@
             </box>
           </geometry>
           <pose>0.0 0.0 0.0 0 0 0</pose>
-          <name>in</name>
         </virtual_volume>
-        <name>in</name>
       </link>
       <pose>7.5 1.0 0 0 0 0</pose>
       <static>true</static>
-      <name>kitchen</name>
     </model>
     <model name="livingroom" type="room">
       <link name="in">
@@ -163,13 +135,10 @@
             </box>
           </geometry>
           <pose>0.0 0.0 0.0 0 0 0</pose>
-          <name>in</name>
         </virtual_volume>
-        <name>in</name>
       </link>
       <pose>7.5 5.5 0 0 0 0</pose>
       <static>true</static>
-      <name>livingroom</name>
     </model>
     <model name="bedroom" type="room">
       <link name="in">
@@ -180,13 +149,10 @@
             </box>
           </geometry>
           <pose>0.0 0.0 0.0 0 0 0</pose>
-          <name>in</name>
         </virtual_volume>
-        <name>in</name>
       </link>
       <pose>3.0 2.0 0 0 0 0</pose>
       <static>true</static>
-      <name>bedroom</name>
     </model>
     <model name="hall" type="room">
       <link name="in">
@@ -197,30 +163,27 @@
             </box>
           </geometry>
           <pose>0.0 0.0 0.0 0 0 0</pose>
-          <name>in</name>
         </virtual_volume>
-        <name>in</name>
       </link>
       <pose>3.0 0.0 0 0 0 0</pose>
       <static>true</static>
-      <name>hall</name>
     </model>
-    <include name="walls">
+    <include>
       <pose>0 0 0 0 0 0</pose>
       <name>walls</name>
       <uri>model://rgo2015/walls</uri>
     </include>
-    <include name="floor">
+    <include>
       <pose>0 0 0 0 0 0</pose>
       <name>floor</name>
       <uri>model://floor</uri>
     </include>
-    <include name="bed">
+    <include>
       <pose>1.555 1.775 0 0 0 0</pose>
       <name>bed</name>
       <uri>model://rgo2015/bed</uri>
     </include>
-    <include name="tv">
+    <include>
       <pose>6.025 4.1 0 0 0 0</pose>
       <name>tv</name>
       <uri>model://rgo2015_final/tv</uri>
@@ -237,6 +200,5 @@
         </solver>
       </ode>
     </physics>
-    <name>rgo2015_final</name>
   </world>
 </sdf>

--- a/models/rgo2015_final/tv/foot/model.sdf
+++ b/models/rgo2015_final/tv/foot/model.sdf
@@ -8,7 +8,6 @@
             <uri>model://rgo2015_final/tv/foot/shape/disc.stl</uri>
           </mesh>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -16,12 +15,9 @@
             <uri>model://rgo2015_final/tv/foot/shape/disc.stl</uri>
           </mesh>
         </geometry>
-        <name>1</name>
       </visual>
       <pose>0 0 0 0 0 0</pose>
-      <name>1</name>
     </link>
     <static>true</static>
-    <name>rgo2015_final/tv/foot</name>
   </model>
 </sdf>

--- a/models/rgo2015_final/tv/model.sdf
+++ b/models/rgo2015_final/tv/model.sdf
@@ -4,7 +4,6 @@
     <light name="sun" type="directional">
       <direction>0.5 0.1 -0.9</direction>
       <pose>0 0 10 0 0 0</pose>
-      <name>sun</name>
       <specular>0.2 0.2 0.2 1</specular>
       <cast_shadows>true</cast_shadows>
       <diffuse>0.8 0.8 0.8 1</diffuse>
@@ -15,7 +14,7 @@
         <linear>0.01</linear>
       </attenuation>
     </light>
-    <include name="foot">
+    <include>
       <pose>0 0 0 0 0 0</pose>
       <name>foot</name>
       <uri>model://rgo2015/tv/foot</uri>
@@ -32,6 +31,5 @@
         </solver>
       </ode>
     </physics>
-    <name>rgo2015_final/tv</name>
   </world>
 </sdf>

--- a/models/rgo2015_final/tv/pole/model.sdf
+++ b/models/rgo2015_final/tv/pole/model.sdf
@@ -8,7 +8,6 @@
             <size>0.28 0.28 2.0</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -19,12 +18,9 @@
         <material>
           <ambient>0.7 0.7 0.7 1</ambient>
         </material>
-        <name>1</name>
       </visual>
       <pose>0.0 0.0 1.0 0 0 0</pose>
-      <name>1</name>
     </link>
     <static>true</static>
-    <name>rgo2015_final/tv/pole</name>
   </model>
 </sdf>

--- a/models/rgo2015_final/tv/tv/model.sdf
+++ b/models/rgo2015_final/tv/tv/model.sdf
@@ -8,7 +8,6 @@
             <size>0.1 1.5 0.92</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -19,12 +18,9 @@
         <material>
           <ambient>0.1 0.1 0.1 1</ambient>
         </material>
-        <name>1</name>
       </visual>
       <pose>0.0 0.0 0.46 0 0 0</pose>
-      <name>1</name>
     </link>
     <static>true</static>
-    <name>rgo2015_final/tv/tv</name>
   </model>
 </sdf>

--- a/models/rgo2017/armchair/model.sdf
+++ b/models/rgo2017/armchair/model.sdf
@@ -8,7 +8,6 @@
             <uri>model://rgo2017/armchair/heightmap.stl</uri>
           </mesh>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -16,12 +15,9 @@
             <uri>model://rgo2017/armchair/heightmap.stl</uri>
           </mesh>
         </geometry>
-        <name>1</name>
       </visual>
       <pose>0 0 0 0 0 -1.57</pose>
-      <name>1</name>
     </link>
     <static>true</static>
-    <name>rgo2017/armchair</name>
   </model>
 </sdf>

--- a/models/rgo2017/bed_frame/model.sdf
+++ b/models/rgo2017/bed_frame/model.sdf
@@ -8,7 +8,6 @@
             <size>1.02 2.12 0.46</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -19,10 +18,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>1</name>
       </visual>
       <pose>0 0 0.23 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="2">
       <collision name="2">
@@ -31,7 +28,6 @@
             <size>1.02 0.075 0.19</size>
           </box>
         </geometry>
-        <name>2</name>
       </collision>
       <visual name="2">
         <geometry>
@@ -42,10 +38,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>2</name>
       </visual>
       <pose>0 -1.0225 0.555 0 0 0</pose>
-      <name>2</name>
     </link>
     <link name="3">
       <collision name="3">
@@ -54,7 +48,6 @@
             <size>1.02 0.075 0.19</size>
           </box>
         </geometry>
-        <name>3</name>
       </collision>
       <visual name="3">
         <geometry>
@@ -65,10 +58,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>3</name>
       </visual>
       <pose>0 1.0225 0.555 0 0 0</pose>
-      <name>3</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
@@ -78,11 +69,8 @@
           </box>
         </geometry>
         <pose>0.0 0.55 0.005 0 0 0</pose>
-        <name>in_front_of</name>
       </virtual_volume>
-      <name>in_front_of</name>
     </link>
     <static>true</static>
-    <name>rgo2017/bed_frame</name>
   </model>
 </sdf>

--- a/models/rgo2017/bookcase/model.sdf
+++ b/models/rgo2017/bookcase/model.sdf
@@ -8,7 +8,6 @@
             <size>0.28 0.018 2.015</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -19,10 +18,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>1</name>
       </visual>
       <pose>0 -0.39 1.0075 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="2">
       <collision name="2">
@@ -31,7 +28,6 @@
             <size>0.28 0.018 2.015</size>
           </box>
         </geometry>
-        <name>2</name>
       </collision>
       <visual name="2">
         <geometry>
@@ -42,10 +38,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>2</name>
       </visual>
       <pose>0 0.39 1.0075 0 0 0</pose>
-      <name>2</name>
     </link>
     <link name="3">
       <collision name="3">
@@ -54,7 +48,6 @@
             <size>0.018 0.798 2.015</size>
           </box>
         </geometry>
-        <name>3</name>
       </collision>
       <visual name="3">
         <geometry>
@@ -65,10 +58,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>3</name>
       </visual>
       <pose>-0.131 0 1.0075 0 0 0</pose>
-      <name>3</name>
     </link>
     <link name="4">
       <collision name="4">
@@ -77,7 +68,6 @@
             <size>0.262 0.762 0.018</size>
           </box>
         </geometry>
-        <name>4</name>
       </collision>
       <visual name="4">
         <geometry>
@@ -88,10 +78,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>4</name>
       </visual>
       <pose>0.009 0 2.006 0 0 0</pose>
-      <name>4</name>
     </link>
     <link name="5">
       <collision name="5">
@@ -100,7 +88,6 @@
             <size>0.262 0.762 0.097</size>
           </box>
         </geometry>
-        <name>5</name>
       </collision>
       <visual name="5">
         <geometry>
@@ -111,10 +98,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>5</name>
       </visual>
       <pose>0.009 0 0.0485 0 0 0</pose>
-      <name>5</name>
     </link>
     <link name="6">
       <collision name="6">
@@ -123,7 +108,6 @@
             <size>0.262 0.762 0.018</size>
           </box>
         </geometry>
-        <name>6</name>
       </collision>
       <visual name="6">
         <geometry>
@@ -134,10 +118,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>6</name>
       </visual>
       <pose>0.009 0 0.439 0 0 0</pose>
-      <name>6</name>
     </link>
     <link name="7">
       <collision name="7">
@@ -146,7 +128,6 @@
             <size>0.262 0.762 0.018</size>
           </box>
         </geometry>
-        <name>7</name>
       </collision>
       <visual name="7">
         <geometry>
@@ -157,10 +138,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>7</name>
       </visual>
       <pose>0.009 0 0.726 0 0 0</pose>
-      <name>7</name>
     </link>
     <link name="8">
       <collision name="8">
@@ -169,7 +148,6 @@
             <size>0.262 0.762 0.018</size>
           </box>
         </geometry>
-        <name>8</name>
       </collision>
       <visual name="8">
         <geometry>
@@ -180,10 +158,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>8</name>
       </visual>
       <pose>0.009 0 1.044 0 0 0</pose>
-      <name>8</name>
     </link>
     <link name="9">
       <collision name="9">
@@ -192,7 +168,6 @@
             <size>0.262 0.762 0.018</size>
           </box>
         </geometry>
-        <name>9</name>
       </collision>
       <visual name="9">
         <geometry>
@@ -203,10 +178,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>9</name>
       </visual>
       <pose>0.009 0 1.43 0 0 0</pose>
-      <name>9</name>
     </link>
     <link name="10">
       <collision name="10">
@@ -215,7 +188,6 @@
             <size>0.262 0.762 0.018</size>
           </box>
         </geometry>
-        <name>10</name>
       </collision>
       <visual name="10">
         <geometry>
@@ -226,10 +198,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>10</name>
       </visual>
       <pose>0.009 0 1.718 0 0 0</pose>
-      <name>10</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
@@ -239,9 +209,7 @@
           </box>
         </geometry>
         <pose>0.64 0.0 0.005 0 0 0</pose>
-        <name>in_front_of</name>
       </virtual_volume>
-      <name>in_front_of</name>
     </link>
     <link name="on_top_of">
       <virtual_volume name="on_top_of">
@@ -251,9 +219,7 @@
           </box>
         </geometry>
         <pose>0.009 0.0 0.88 0 0 0</pose>
-        <name>on_top_of</name>
       </virtual_volume>
-      <name>on_top_of</name>
     </link>
     <link name="shelf1">
       <virtual_volume name="shelf1">
@@ -263,9 +229,7 @@
           </box>
         </geometry>
         <pose>0.009 0.0 0.242 0 0 0</pose>
-        <name>shelf1</name>
       </virtual_volume>
-      <name>shelf1</name>
     </link>
     <link name="shelf2">
       <virtual_volume name="shelf2">
@@ -275,9 +239,7 @@
           </box>
         </geometry>
         <pose>0.009 0.0 0.574 0 0 0</pose>
-        <name>shelf2</name>
       </virtual_volume>
-      <name>shelf2</name>
     </link>
     <link name="shelf3">
       <virtual_volume name="shelf3">
@@ -287,9 +249,7 @@
           </box>
         </geometry>
         <pose>0.009 0.0 0.88 0 0 0</pose>
-        <name>shelf3</name>
       </virtual_volume>
-      <name>shelf3</name>
     </link>
     <link name="shelf4">
       <virtual_volume name="shelf4">
@@ -299,9 +259,7 @@
           </box>
         </geometry>
         <pose>0.009 0.0 1.198 0 0 0</pose>
-        <name>shelf4</name>
       </virtual_volume>
-      <name>shelf4</name>
     </link>
     <link name="shelf5">
       <virtual_volume name="shelf5">
@@ -311,9 +269,7 @@
           </box>
         </geometry>
         <pose>0.009 0.0 1.5695 0 0 0</pose>
-        <name>shelf5</name>
       </virtual_volume>
-      <name>shelf5</name>
     </link>
     <link name="shelf6">
       <virtual_volume name="shelf6">
@@ -323,11 +279,8 @@
           </box>
         </geometry>
         <pose>0.009 0.0 1.8585 0 0 0</pose>
-        <name>shelf6</name>
       </virtual_volume>
-      <name>shelf6</name>
     </link>
     <static>true</static>
-    <name>rgo2017/bookcase</name>
   </model>
 </sdf>

--- a/models/rgo2017/couch/model.sdf
+++ b/models/rgo2017/couch/model.sdf
@@ -8,7 +8,6 @@
             <size>0.85 1.8 0.42</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -19,10 +18,8 @@
         <material>
           <ambient>0.1 0.1 0.1 1</ambient>
         </material>
-        <name>1</name>
       </visual>
       <pose>0.0 0.0 0.21 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="2">
       <collision name="2">
@@ -31,7 +28,6 @@
             <size>0.3 1.8 0.225</size>
           </box>
         </geometry>
-        <name>2</name>
       </collision>
       <visual name="2">
         <geometry>
@@ -42,10 +38,8 @@
         <material>
           <ambient>0.1 0.1 0.1 1</ambient>
         </material>
-        <name>2</name>
       </visual>
       <pose>-0.275 0.0 0.5325 0 0 0</pose>
-      <name>2</name>
     </link>
     <link name="3">
       <collision name="3">
@@ -54,7 +48,6 @@
             <size>0.85 0.175 0.225</size>
           </box>
         </geometry>
-        <name>3</name>
       </collision>
       <visual name="3">
         <geometry>
@@ -65,10 +58,8 @@
         <material>
           <ambient>0.1 0.1 0.1 1</ambient>
         </material>
-        <name>3</name>
       </visual>
       <pose>0.0 -0.812 0.5325 0 0 0</pose>
-      <name>3</name>
     </link>
     <link name="4">
       <collision name="4">
@@ -77,7 +68,6 @@
             <size>0.85 0.175 0.225</size>
           </box>
         </geometry>
-        <name>4</name>
       </collision>
       <visual name="4">
         <geometry>
@@ -88,10 +78,8 @@
         <material>
           <ambient>0.1 0.1 0.1 1</ambient>
         </material>
-        <name>4</name>
       </visual>
       <pose>0.0 0.812 0.5325 0 0 0</pose>
-      <name>4</name>
     </link>
     <link name="on_top_of">
       <virtual_volume name="on_top_of">
@@ -101,9 +89,7 @@
           </box>
         </geometry>
         <pose>0.175 0.0 0.6 0 0 0</pose>
-        <name>on_top_of</name>
       </virtual_volume>
-      <name>on_top_of</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
@@ -113,11 +99,8 @@
           </box>
         </geometry>
         <pose>1.05 0.0 0.005 0 0 0</pose>
-        <name>in_front_of</name>
       </virtual_volume>
-      <name>in_front_of</name>
     </link>
     <static>true</static>
-    <name>rgo2017/couch</name>
   </model>
 </sdf>

--- a/models/rgo2017/kitchen_counter/model.sdf
+++ b/models/rgo2017/kitchen_counter/model.sdf
@@ -8,7 +8,6 @@
             <size>0.59 0.018 1.02</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -19,10 +18,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>1</name>
       </visual>
       <pose>0.078 -0.5935 0.51 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="2">
       <collision name="2">
@@ -31,7 +28,6 @@
             <size>0.59 0.018 1.02</size>
           </box>
         </geometry>
-        <name>2</name>
       </collision>
       <visual name="2">
         <geometry>
@@ -42,10 +38,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>2</name>
       </visual>
       <pose>0.078 0.5935 0.51 0 0 0</pose>
-      <name>2</name>
     </link>
     <link name="3">
       <collision name="3">
@@ -54,7 +48,6 @@
             <size>0.078 1.205 2.002</size>
           </box>
         </geometry>
-        <name>3</name>
       </collision>
       <visual name="3">
         <geometry>
@@ -65,10 +58,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>3</name>
       </visual>
       <pose>-0.256 0 1.001 0 0 0</pose>
-      <name>3</name>
     </link>
     <link name="4">
       <collision name="4">
@@ -77,7 +68,6 @@
             <size>0.6 1.169 0.038</size>
           </box>
         </geometry>
-        <name>4</name>
       </collision>
       <visual name="4">
         <geometry>
@@ -88,10 +78,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>4</name>
       </visual>
       <pose>0.083 0 1.001 0 0 0</pose>
-      <name>4</name>
     </link>
     <link name="5">
       <collision name="5">
@@ -100,7 +88,6 @@
             <size>0.59 1.169 0.138</size>
           </box>
         </geometry>
-        <name>5</name>
       </collision>
       <visual name="5">
         <geometry>
@@ -111,10 +98,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>5</name>
       </visual>
       <pose>0.078 0 0.069 0 0 0</pose>
-      <name>5</name>
     </link>
     <link name="6">
       <collision name="6">
@@ -123,7 +108,6 @@
             <size>0.572 1.169 0.018</size>
           </box>
         </geometry>
-        <name>6</name>
       </collision>
       <visual name="6">
         <geometry>
@@ -134,10 +118,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>6</name>
       </visual>
       <pose>0.069 0 0.544 0 0 0</pose>
-      <name>6</name>
     </link>
     <link name="7">
       <collision name="7">
@@ -146,7 +128,6 @@
             <size>0.572 0.018 1.0</size>
           </box>
         </geometry>
-        <name>7</name>
       </collision>
       <visual name="7">
         <geometry>
@@ -157,10 +138,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>7</name>
       </visual>
       <pose>0.069 0 0.5 0 0 0</pose>
-      <name>7</name>
     </link>
     <link name="8">
       <collision name="8">
@@ -169,7 +148,6 @@
             <size>0.35 0.018 0.482</size>
           </box>
         </geometry>
-        <name>8</name>
       </collision>
       <visual name="8">
         <geometry>
@@ -180,10 +158,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>8</name>
       </visual>
       <pose>-0.042 -0.5935 1.76 0 0 0</pose>
-      <name>8</name>
     </link>
     <link name="9">
       <collision name="9">
@@ -192,7 +168,6 @@
             <size>0.35 0.018 0.482</size>
           </box>
         </geometry>
-        <name>9</name>
       </collision>
       <visual name="9">
         <geometry>
@@ -203,10 +178,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>9</name>
       </visual>
       <pose>-0.042 0.5935 1.76 0 0 0</pose>
-      <name>9</name>
     </link>
     <link name="10">
       <collision name="10">
@@ -215,7 +188,6 @@
             <size>0.35 1.169 0.018</size>
           </box>
         </geometry>
-        <name>10</name>
       </collision>
       <visual name="10">
         <geometry>
@@ -226,10 +198,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>10</name>
       </visual>
       <pose>-0.042 0 1.993 0 0 0</pose>
-      <name>10</name>
     </link>
     <link name="11">
       <collision name="11">
@@ -238,7 +208,6 @@
             <size>0.35 1.169 0.018</size>
           </box>
         </geometry>
-        <name>11</name>
       </collision>
       <visual name="11">
         <geometry>
@@ -249,10 +218,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>11</name>
       </visual>
       <pose>-0.042 0 1.529 0 0 0</pose>
-      <name>11</name>
     </link>
     <link name="12">
       <collision name="12">
@@ -261,7 +228,6 @@
             <size>0.35 1.169 0.018</size>
           </box>
         </geometry>
-        <name>12</name>
       </collision>
       <visual name="12">
         <geometry>
@@ -272,10 +238,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>12</name>
       </visual>
       <pose>-0.042 0 1.754 0 0 0</pose>
-      <name>12</name>
     </link>
     <link name="13">
       <collision name="13">
@@ -284,7 +248,6 @@
             <size>0.35 0.036 0.482</size>
           </box>
         </geometry>
-        <name>13</name>
       </collision>
       <visual name="13">
         <geometry>
@@ -295,10 +258,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>13</name>
       </visual>
       <pose>-0.042 0 1.76 0 0 0</pose>
-      <name>13</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
@@ -308,9 +269,7 @@
           </box>
         </geometry>
         <pose>1.3 0.0 0.005 0 0 0</pose>
-        <name>in_front_of</name>
       </virtual_volume>
-      <name>in_front_of</name>
     </link>
     <link name="on_top_of">
       <virtual_volume name="on_top_of">
@@ -320,11 +279,8 @@
           </box>
         </geometry>
         <pose>0.078 0.0 1.19 0 0 0</pose>
-        <name>on_top_of</name>
       </virtual_volume>
-      <name>on_top_of</name>
     </link>
     <static>true</static>
-    <name>rgo2017/kitchen_counter</name>
   </model>
 </sdf>

--- a/models/rgo2017/kitchen_sink/model.sdf
+++ b/models/rgo2017/kitchen_sink/model.sdf
@@ -8,7 +8,6 @@
             <size>0.6 1.169 1.02</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -19,10 +18,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>1</name>
       </visual>
       <pose>0.083 0 0.51 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="2">
       <collision name="2">
@@ -31,7 +28,6 @@
             <size>0.078 1.205 2.002</size>
           </box>
         </geometry>
-        <name>2</name>
       </collision>
       <visual name="2">
         <geometry>
@@ -42,10 +38,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>2</name>
       </visual>
       <pose>-0.256 0 1.001 0 0 0</pose>
-      <name>2</name>
     </link>
     <link name="3">
       <collision name="3">
@@ -54,7 +48,6 @@
             <size>0.35 0.018 0.482</size>
           </box>
         </geometry>
-        <name>3</name>
       </collision>
       <visual name="3">
         <geometry>
@@ -65,10 +58,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>3</name>
       </visual>
       <pose>-0.042 -0.5935 1.76 0 0 0</pose>
-      <name>3</name>
     </link>
     <link name="4">
       <collision name="4">
@@ -77,7 +68,6 @@
             <size>0.35 0.018 0.482</size>
           </box>
         </geometry>
-        <name>4</name>
       </collision>
       <visual name="4">
         <geometry>
@@ -88,10 +78,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>4</name>
       </visual>
       <pose>-0.042 0.5935 1.76 0 0 0</pose>
-      <name>4</name>
     </link>
     <link name="5">
       <collision name="5">
@@ -100,7 +88,6 @@
             <size>0.35 1.169 0.018</size>
           </box>
         </geometry>
-        <name>5</name>
       </collision>
       <visual name="5">
         <geometry>
@@ -111,10 +98,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>5</name>
       </visual>
       <pose>-0.042 0 1.993 0 0 0</pose>
-      <name>5</name>
     </link>
     <link name="6">
       <collision name="6">
@@ -123,7 +108,6 @@
             <size>0.35 1.169 0.018</size>
           </box>
         </geometry>
-        <name>6</name>
       </collision>
       <visual name="6">
         <geometry>
@@ -134,10 +118,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>6</name>
       </visual>
       <pose>-0.042 0 1.529 0 0 0</pose>
-      <name>6</name>
     </link>
     <link name="7">
       <collision name="7">
@@ -146,7 +128,6 @@
             <size>0.35 1.169 0.018</size>
           </box>
         </geometry>
-        <name>7</name>
       </collision>
       <visual name="7">
         <geometry>
@@ -157,10 +138,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>7</name>
       </visual>
       <pose>-0.042 0 1.754 0 0 0</pose>
-      <name>7</name>
     </link>
     <link name="8">
       <collision name="8">
@@ -169,7 +148,6 @@
             <size>0.35 0.036 0.482</size>
           </box>
         </geometry>
-        <name>8</name>
       </collision>
       <visual name="8">
         <geometry>
@@ -180,10 +158,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>8</name>
       </visual>
       <pose>-0.042 0 1.76 0 0 0</pose>
-      <name>8</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
@@ -193,9 +169,7 @@
           </box>
         </geometry>
         <pose>1.3 0.0 0.005 0 0 0</pose>
-        <name>in_front_of</name>
       </virtual_volume>
-      <name>in_front_of</name>
     </link>
     <link name="on_top_of">
       <virtual_volume name="on_top_of">
@@ -205,11 +179,8 @@
           </box>
         </geometry>
         <pose>0.078 0.0 1.19 0 0 0</pose>
-        <name>on_top_of</name>
       </virtual_volume>
-      <name>on_top_of</name>
     </link>
     <static>true</static>
-    <name>rgo2017/kitchen_sink</name>
   </model>
 </sdf>

--- a/models/rgo2017/model.sdf
+++ b/models/rgo2017/model.sdf
@@ -4,7 +4,6 @@
     <light name="sun" type="directional">
       <direction>0.5 0.1 -0.9</direction>
       <pose>0 0 10 0 0 0</pose>
-      <name>sun</name>
       <specular>0.2 0.2 0.2 1</specular>
       <cast_shadows>true</cast_shadows>
       <diffuse>0.8 0.8 0.8 1</diffuse>
@@ -24,13 +23,10 @@
             </box>
           </geometry>
           <pose>0.315 0.3 0.005 0 0 0</pose>
-          <name>in</name>
         </virtual_volume>
-        <name>in</name>
       </link>
       <pose>1.8 5.25 0 0 0 0</pose>
       <static>true</static>
-      <name>living_room</name>
     </model>
     <model name="bedroom" type="room">
       <link name="in">
@@ -41,13 +37,10 @@
             </box>
           </geometry>
           <pose>-0.55 0.975 0.005 0 0 0</pose>
-          <name>in</name>
         </virtual_volume>
-        <name>in</name>
       </link>
       <pose>8.0 0.0 0 0 0 0</pose>
       <static>true</static>
-      <name>bedroom</name>
     </model>
     <model name="dining_room" type="room">
       <link name="in">
@@ -58,13 +51,10 @@
             </box>
           </geometry>
           <pose>-0.48 1.045 0.005 0 0 0</pose>
-          <name>in</name>
         </virtual_volume>
-        <name>in</name>
       </link>
       <pose>3.0 0.0 0 0 0 0</pose>
       <static>true</static>
-      <name>dining_room</name>
     </model>
     <model name="kitchen" type="room">
       <link name="in">
@@ -75,88 +65,70 @@
             </box>
           </geometry>
           <pose>0.7 -0.25 0.005 0 0 0</pose>
-          <name>in</name>
         </virtual_volume>
-        <name>in</name>
       </link>
       <pose>6.0 6.0 0 0 0 0</pose>
       <static>true</static>
-      <name>kitchen</name>
     </model>
     <model name="initial_pose" type="waypoint">
       <pose>-1.0 0.0 0 0 0 0</pose>
       <static>true</static>
-      <name>initial_pose</name>
     </model>
     <model name="initial_pose_2" type="waypoint">
       <pose>9.5 -2.0 0 0 0 1.571</pose>
       <static>true</static>
-      <name>initial_pose_2</name>
     </model>
     <model name="registration_table1" type="waypoint">
       <pose>2.5 2.5 0 0 0 0</pose>
       <static>true</static>
-      <name>registration_table1</name>
     </model>
     <model name="registration_table2" type="waypoint">
       <pose>2.0 2.5 0 0 0 0</pose>
       <static>true</static>
-      <name>registration_table2</name>
     </model>
     <model name="registration_table3" type="waypoint">
       <pose>2.0 3.0 0 0 0 0</pose>
       <static>true</static>
-      <name>registration_table3</name>
     </model>
     <model name="exit_1_rips" type="waypoint">
       <pose>8.45 -2.8 0 0 0 -1.571</pose>
       <static>true</static>
-      <name>exit_1_rips</name>
     </model>
     <model name="exit_2_rips" type="waypoint">
       <pose>8.45 -2.24 0 0 0 -1.571</pose>
       <static>true</static>
-      <name>exit_2_rips</name>
     </model>
     <model name="exit_3_rips" type="waypoint">
       <pose>8.45 -1.4 0 0 0 -1.571</pose>
       <static>true</static>
-      <name>exit_3_rips</name>
     </model>
     <model name="exit_4_rips" type="waypoint">
       <pose>8.45 0.0 0 0 0 -1.571</pose>
       <static>true</static>
-      <name>exit_4_rips</name>
     </model>
     <model name="gpsr_meeting_point_1_old" type="waypoint">
       <pose>1.5 4.25 0 0 0 0</pose>
       <static>true</static>
-      <name>gpsr_meeting_point_1_old</name>
     </model>
     <model name="gpsr_exit_door_1" type="waypoint">
       <pose>8.45 -2.8 0 0 0 -1.571</pose>
       <static>true</static>
-      <name>gpsr_exit_door_1</name>
     </model>
     <model name="gpsr_meeting_point_2" type="waypoint">
       <pose>1.5 4.25 0 0 0 0</pose>
       <static>true</static>
-      <name>gpsr_meeting_point_2</name>
     </model>
     <model name="gpsr_exit_door_2" type="waypoint">
       <pose>-1.0 0.0 0 0 0 -3.1415</pose>
       <static>true</static>
-      <name>gpsr_exit_door_2</name>
     </model>
     <model name="gpsr_meeting_point_1" type="waypoint">
       <pose>0.8 2.6 0 0 0 -0.1745</pose>
       <static>true</static>
-      <name>gpsr_meeting_point_1</name>
     </model>
     <model name="challenge_open_ask_waypoint" type="waypoint">
       <pose>4.0 6.0 0 0 0 3.1415</pose>
       <static>true</static>
-      <name>challenge_open_ask_waypoint</name>
     </model>
     <model name="trashbin">
       <link name="1">
@@ -167,7 +139,6 @@
             </box>
           </geometry>
           <pose>0.0 0.0 0.165 0 0 0</pose>
-          <name>1</name>
         </collision>
         <visual name="1">
           <geometry>
@@ -176,101 +147,97 @@
             </box>
           </geometry>
           <pose>0.0 0.0 0.165 0 0 0</pose>
-          <name>1</name>
         </visual>
         <pose>0 0 0 0 0 0</pose>
-        <name>1</name>
       </link>
       <pose>6.4 7.15 0 0 0 0</pose>
       <static>true</static>
-      <name>trashbin</name>
     </model>
     <model name="final_meeting_point" type="waypoint">
       <pose>5.0 7.0 0 0 0 -1.57</pose>
       <static>true</static>
-      <name>final_meeting_point</name>
     </model>
-    <include name="floor">
+    <include>
       <pose>0 0 0 0 0 0</pose>
       <name>floor</name>
       <uri>model://floor</uri>
     </include>
-    <include name="walls">
+    <include>
       <pose>0 0 0 0 0 0</pose>
       <name>walls</name>
       <uri>model://rgo2017/walls</uri>
     </include>
-    <include name="dinner_table">
+    <include>
       <pose>2.447 1.1695 0.0 0 0 3.141592</pose>
       <name>dinner_table</name>
       <uri>model://rgo2017/table_dinner</uri>
     </include>
-    <include name="cabinet">
+    <include>
       <pose>2.271 -1.258 0.0 0 0 1.570796</pose>
       <name>cabinet</name>
       <uri>model://rgo2017/bookcase</uri>
     </include>
-    <include name="bookshelf">
+    <include>
       <pose>0.144 3.574 0.0 0 0 0</pose>
       <name>bookshelf</name>
       <uri>model://rgo2017/bookcase</uri>
     </include>
-    <include name="sofa">
+    <include>
       <pose>0.44 6.18 0.0 0 0 0</pose>
       <name>sofa</name>
       <uri>model://rgo2017/couch</uri>
     </include>
-    <include name="couch_table">
+    <include>
       <pose>1.688 6.23 0.0 0 0 -1.570796</pose>
       <name>couch_table</name>
       <uri>model://rgo2017/table_salon_double</uri>
     </include>
-    <include name="armchair3">
+    <include>
       <pose>9.331 3.696 0.0 0 0 -2</pose>
       <name>armchair3</name>
       <uri>model://rgo2017/armchair</uri>
     </include>
-    <include name="side_table">
+    <include>
       <pose>4.206 7.097 0.0 0 0 -1.570796</pose>
       <name>side_table</name>
       <uri>model://rgo2017/table_salon</uri>
     </include>
-    <include name="stove">
+    <include>
       <pose>4.955 3.903 0.0 0 0 1.570796</pose>
       <name>stove</name>
       <uri>model://rgo2017/kitchen_sink</uri>
     </include>
-    <include name="kitchencounter">
+    <include>
       <pose>3.447 3.903 0.0 0 0 1.570796</pose>
       <name>kitchencounter</name>
       <uri>model://rgo2017/kitchen_sink</uri>
     </include>
-    <include name="closet">
+    <include>
       <pose>6.562 -1.252 0.0 0 0 1.570796</pose>
       <name>closet</name>
       <uri>model://rgo2017/bookcase</uri>
     </include>
-    <include name="bar">
+    <include>
       <pose>8.545 6.759 0.0 0 0 -2</pose>
       <name>bar</name>
       <uri>model://rgo2017/table_party</uri>
     </include>
-    <include name="table_bedroom">
+    <include>
       <pose>5.352 -1.146 0.0 0 0 1.570796</pose>
       <name>table_bedroom</name>
       <uri>model://rgo2017/table_salon</uri>
     </include>
-    <include name="bed">
+    <include>
       <pose>6.209 2.175 0.0 0 0 -1.570796</pose>
       <name>bed</name>
       <uri>model://rgo2017/bed_frame</uri>
     </include>
-    <include name="desk">
+    <include>
       <pose>9.331 4.896 0.0 0 0 3.141592</pose>
       <name>desk</name>
       <uri>model://rgo2017/table_bureau</uri>
     </include>
-    <include name="tv">
+    <include>
       <pose>6.72 4.08 0.0 0 0 1.570796</pose>
       <name>tv</name>
       <uri>model://rgo2015/tv</uri>
@@ -287,6 +254,5 @@
         </solver>
       </ode>
     </physics>
-    <name>rgo2017</name>
   </world>
 </sdf>

--- a/models/rgo2017/table_bureau/model.sdf
+++ b/models/rgo2017/table_bureau/model.sdf
@@ -8,7 +8,6 @@
             <size>0.705 1.31 0.04</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -19,10 +18,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>1</name>
       </visual>
       <pose>0 0 0.73 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="2">
       <collision name="2">
@@ -31,7 +28,6 @@
             <size>0.04 0.04 0.699</size>
           </box>
         </geometry>
-        <name>2</name>
       </collision>
       <visual name="2">
         <geometry>
@@ -42,10 +38,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>2</name>
       </visual>
       <pose>0 0.565 0.3495 0 0 0</pose>
-      <name>2</name>
     </link>
     <link name="3">
       <collision name="3">
@@ -54,7 +48,6 @@
             <size>0.04 0.04 0.699</size>
           </box>
         </geometry>
-        <name>3</name>
       </collision>
       <visual name="3">
         <geometry>
@@ -65,10 +58,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>3</name>
       </visual>
       <pose>0.0 -0.565 0.3495 0 0 0</pose>
-      <name>3</name>
     </link>
     <link name="4">
       <collision name="4">
@@ -77,7 +68,6 @@
             <size>0.555 0.04 0.045</size>
           </box>
         </geometry>
-        <name>4</name>
       </collision>
       <visual name="4">
         <geometry>
@@ -88,10 +78,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>4</name>
       </visual>
       <pose>0.0 0.565 0.0225 0 0 0</pose>
-      <name>4</name>
     </link>
     <link name="5">
       <collision name="5">
@@ -100,7 +88,6 @@
             <size>0.555 0.04 0.045</size>
           </box>
         </geometry>
-        <name>5</name>
       </collision>
       <visual name="5">
         <geometry>
@@ -111,10 +98,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>5</name>
       </visual>
       <pose>0.0 -0.565 0.0225 0 0 0</pose>
-      <name>5</name>
     </link>
     <link name="on_top_of">
       <virtual_volume name="on_top_of">
@@ -124,9 +109,7 @@
           </box>
         </geometry>
         <pose>0.0 0.0 0.9 0 0 0</pose>
-        <name>on_top_of</name>
       </virtual_volume>
-      <name>on_top_of</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
@@ -136,11 +119,8 @@
           </box>
         </geometry>
         <pose>1.3 0.0 0.005 0 0 0</pose>
-        <name>in_front_of</name>
       </virtual_volume>
-      <name>in_front_of</name>
     </link>
     <static>true</static>
-    <name>rgo2017/table_bureau</name>
   </model>
 </sdf>

--- a/models/rgo2017/table_dinner/model.sdf
+++ b/models/rgo2017/table_dinner/model.sdf
@@ -8,7 +8,6 @@
             <size>1.83 0.76 0.018</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -19,10 +18,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>1</name>
       </visual>
       <pose>0 0 0.751 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="2">
       <collision name="2">
@@ -31,7 +28,6 @@
             <size>0.025 0.025 0.742</size>
           </box>
         </geometry>
-        <name>2</name>
       </collision>
       <visual name="2">
         <geometry>
@@ -42,10 +38,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>2</name>
       </visual>
       <pose>-0.7325 -0.2825 0.371 0 0 0</pose>
-      <name>2</name>
     </link>
     <link name="3">
       <collision name="3">
@@ -54,7 +48,6 @@
             <size>0.025 0.025 0.742</size>
           </box>
         </geometry>
-        <name>3</name>
       </collision>
       <visual name="3">
         <geometry>
@@ -65,10 +58,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>3</name>
       </visual>
       <pose>0.7325 -0.2825 0.371 0 0 0</pose>
-      <name>3</name>
     </link>
     <link name="4">
       <collision name="4">
@@ -77,7 +68,6 @@
             <size>0.025 0.025 0.742</size>
           </box>
         </geometry>
-        <name>4</name>
       </collision>
       <visual name="4">
         <geometry>
@@ -88,10 +78,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>4</name>
       </visual>
       <pose>-0.7325 0.2825 0.371 0 0 0</pose>
-      <name>4</name>
     </link>
     <link name="5">
       <collision name="5">
@@ -100,7 +88,6 @@
             <size>0.025 0.025 0.742</size>
           </box>
         </geometry>
-        <name>5</name>
       </collision>
       <visual name="5">
         <geometry>
@@ -111,10 +98,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>5</name>
       </visual>
       <pose>0.7325 0.2825 0.371 0 0 0</pose>
-      <name>5</name>
     </link>
     <link name="on_top_of">
       <virtual_volume name="on_top_of">
@@ -124,9 +109,7 @@
           </box>
         </geometry>
         <pose>0.0 0.0 0.905 0 0 0</pose>
-        <name>on_top_of</name>
       </virtual_volume>
-      <name>on_top_of</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
@@ -136,11 +119,8 @@
           </box>
         </geometry>
         <pose>1.715 0.0 0.005 0 0 0</pose>
-        <name>in_front_of</name>
       </virtual_volume>
-      <name>in_front_of</name>
     </link>
     <static>true</static>
-    <name>rgo2017/table_dinner</name>
   </model>
 </sdf>

--- a/models/rgo2017/table_party/model.sdf
+++ b/models/rgo2017/table_party/model.sdf
@@ -9,7 +9,6 @@
             <radius>0.4</radius>
           </cylinder>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -18,10 +17,8 @@
             <radius>0.4</radius>
           </cylinder>
         </geometry>
-        <name>1</name>
       </visual>
       <pose>0 0 1.085 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="2">
       <collision name="2">
@@ -31,7 +28,6 @@
             <radius>0.0725</radius>
           </cylinder>
         </geometry>
-        <name>2</name>
       </collision>
       <visual name="2">
         <geometry>
@@ -40,10 +36,8 @@
             <radius>0.0725</radius>
           </cylinder>
         </geometry>
-        <name>2</name>
       </visual>
       <pose>0 0 0.54 0 0 0</pose>
-      <name>2</name>
     </link>
     <link name="3">
       <collision name="3">
@@ -52,7 +46,6 @@
             <size>0.775 0.035 0.045</size>
           </box>
         </geometry>
-        <name>3</name>
       </collision>
       <visual name="3">
         <geometry>
@@ -60,10 +53,8 @@
             <size>0.775 0.035 0.045</size>
           </box>
         </geometry>
-        <name>3</name>
       </visual>
       <pose>0 0 0.0225 0 0 0</pose>
-      <name>3</name>
     </link>
     <link name="4">
       <collision name="4">
@@ -72,7 +63,6 @@
             <size>0.035 0.775 0.045</size>
           </box>
         </geometry>
-        <name>4</name>
       </collision>
       <visual name="4">
         <geometry>
@@ -80,10 +70,8 @@
             <size>0.035 0.775 0.045</size>
           </box>
         </geometry>
-        <name>4</name>
       </visual>
       <pose>0 0 0.0225 0 0 0</pose>
-      <name>4</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
@@ -93,9 +81,7 @@
           </box>
         </geometry>
         <pose>0.775 0.0 0.005 0 0 0</pose>
-        <name>in_front_of</name>
       </virtual_volume>
-      <name>in_front_of</name>
     </link>
     <link name="on_top_of">
       <virtual_volume name="on_top_of">
@@ -105,11 +91,8 @@
           </box>
         </geometry>
         <pose>0.0 0.0 1.195 0 0 0</pose>
-        <name>on_top_of</name>
       </virtual_volume>
-      <name>on_top_of</name>
     </link>
     <static>true</static>
-    <name>rgo2017/table_party</name>
   </model>
 </sdf>

--- a/models/rgo2017/table_salon/model.sdf
+++ b/models/rgo2017/table_salon/model.sdf
@@ -8,7 +8,6 @@
             <size>0.55 0.55 0.05</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -19,10 +18,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>1</name>
       </visual>
       <pose>0 0 0.425 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="2">
       <collision name="2">
@@ -31,7 +28,6 @@
             <size>0.05 0.05 0.4</size>
           </box>
         </geometry>
-        <name>2</name>
       </collision>
       <visual name="2">
         <geometry>
@@ -42,10 +38,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>2</name>
       </visual>
       <pose>-0.25 -0.25 0.2 0 0 0</pose>
-      <name>2</name>
     </link>
     <link name="3">
       <collision name="3">
@@ -54,7 +48,6 @@
             <size>0.05 0.05 0.4</size>
           </box>
         </geometry>
-        <name>3</name>
       </collision>
       <visual name="3">
         <geometry>
@@ -65,10 +58,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>3</name>
       </visual>
       <pose>0.25 -0.25 0.2 0 0 0</pose>
-      <name>3</name>
     </link>
     <link name="4">
       <collision name="4">
@@ -77,7 +68,6 @@
             <size>0.05 0.05 0.4</size>
           </box>
         </geometry>
-        <name>4</name>
       </collision>
       <visual name="4">
         <geometry>
@@ -88,10 +78,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>4</name>
       </visual>
       <pose>-0.25 0.25 0.2 0 0 0</pose>
-      <name>4</name>
     </link>
     <link name="5">
       <collision name="5">
@@ -100,7 +88,6 @@
             <size>0.05 0.05 0.4</size>
           </box>
         </geometry>
-        <name>5</name>
       </collision>
       <visual name="5">
         <geometry>
@@ -111,10 +98,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>5</name>
       </visual>
       <pose>0.25 0.25 0.2 0 0 0</pose>
-      <name>5</name>
     </link>
     <link name="on_top_of">
       <virtual_volume name="on_top_of">
@@ -124,9 +109,7 @@
           </box>
         </geometry>
         <pose>0.0 0.0 0.595 0 0 0</pose>
-        <name>on_top_of</name>
       </virtual_volume>
-      <name>on_top_of</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
@@ -136,11 +119,8 @@
           </box>
         </geometry>
         <pose>0.8 0.0 0.005 0 0 0</pose>
-        <name>in_front_of</name>
       </virtual_volume>
-      <name>in_front_of</name>
     </link>
     <static>true</static>
-    <name>rgo2017/table_salon</name>
   </model>
 </sdf>

--- a/models/rgo2017/table_salon_double/model.sdf
+++ b/models/rgo2017/table_salon_double/model.sdf
@@ -8,7 +8,6 @@
             <size>1.1 0.55 0.05</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -19,10 +18,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>1</name>
       </visual>
       <pose>0 0 0.425 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="2">
       <collision name="2">
@@ -31,7 +28,6 @@
             <size>0.05 0.05 0.4</size>
           </box>
         </geometry>
-        <name>2</name>
       </collision>
       <visual name="2">
         <geometry>
@@ -42,10 +38,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>2</name>
       </visual>
       <pose>-0.525 -0.25 0.2 0 0 0</pose>
-      <name>2</name>
     </link>
     <link name="3">
       <collision name="3">
@@ -54,7 +48,6 @@
             <size>0.05 0.05 0.4</size>
           </box>
         </geometry>
-        <name>3</name>
       </collision>
       <visual name="3">
         <geometry>
@@ -65,10 +58,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>3</name>
       </visual>
       <pose>0.525 -0.25 0.2 0 0 0</pose>
-      <name>3</name>
     </link>
     <link name="4">
       <collision name="4">
@@ -77,7 +68,6 @@
             <size>0.05 0.05 0.4</size>
           </box>
         </geometry>
-        <name>4</name>
       </collision>
       <visual name="4">
         <geometry>
@@ -88,10 +78,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>4</name>
       </visual>
       <pose>-0.525 0.25 0.2 0 0 0</pose>
-      <name>4</name>
     </link>
     <link name="5">
       <collision name="5">
@@ -100,7 +88,6 @@
             <size>0.05 0.05 0.4</size>
           </box>
         </geometry>
-        <name>5</name>
       </collision>
       <visual name="5">
         <geometry>
@@ -111,10 +98,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>5</name>
       </visual>
       <pose>0.525 0.25 0.2 0 0 0</pose>
-      <name>5</name>
     </link>
     <link name="6">
       <collision name="6">
@@ -123,7 +108,6 @@
             <size>0.1 0.05 0.4</size>
           </box>
         </geometry>
-        <name>6</name>
       </collision>
       <visual name="6">
         <geometry>
@@ -134,10 +118,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>6</name>
       </visual>
       <pose>0 0.25 0.2 0 0 0</pose>
-      <name>6</name>
     </link>
     <link name="7">
       <collision name="7">
@@ -146,7 +128,6 @@
             <size>0.1 0.05 0.4</size>
           </box>
         </geometry>
-        <name>7</name>
       </collision>
       <visual name="7">
         <geometry>
@@ -157,10 +138,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>7</name>
       </visual>
       <pose>0 -0.25 0.2 0 0 0</pose>
-      <name>7</name>
     </link>
     <link name="on_top_of">
       <virtual_volume name="on_top_of">
@@ -170,9 +149,7 @@
           </box>
         </geometry>
         <pose>0.0 0.0 0.595 0 0 0</pose>
-        <name>on_top_of</name>
       </virtual_volume>
-      <name>on_top_of</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
@@ -182,11 +159,8 @@
           </box>
         </geometry>
         <pose>1.4 0.0 0.005 0 0 0</pose>
-        <name>in_front_of</name>
       </virtual_volume>
-      <name>in_front_of</name>
     </link>
     <static>true</static>
-    <name>rgo2017/table_salon_double</name>
   </model>
 </sdf>

--- a/models/rgo2017/walls/model.sdf
+++ b/models/rgo2017/walls/model.sdf
@@ -8,7 +8,6 @@
             <uri>model://rgo2017/walls/rgo2017largecleaned.stl</uri>
           </mesh>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -16,12 +15,9 @@
             <uri>model://rgo2017/walls/rgo2017largecleaned.stl</uri>
           </mesh>
         </geometry>
-        <name>1</name>
       </visual>
       <pose>0 0 0 0 0 0</pose>
-      <name>1</name>
     </link>
     <static>true</static>
-    <name>rgo2017/walls</name>
   </model>
 </sdf>

--- a/models/rgo2018/armchair/model.sdf
+++ b/models/rgo2018/armchair/model.sdf
@@ -8,7 +8,6 @@
             <uri>model://rgo2018/armchair/heightmap.stl</uri>
           </mesh>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -16,12 +15,9 @@
             <uri>model://rgo2018/armchair/heightmap.stl</uri>
           </mesh>
         </geometry>
-        <name>1</name>
       </visual>
       <pose>0 0 0 0 0 -1.57</pose>
-      <name>1</name>
     </link>
     <static>true</static>
-    <name>rgo2018/armchair</name>
   </model>
 </sdf>

--- a/models/rgo2018/bar/model.sdf
+++ b/models/rgo2018/bar/model.sdf
@@ -9,7 +9,6 @@
             <radius>0.4</radius>
           </cylinder>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -18,10 +17,8 @@
             <radius>0.4</radius>
           </cylinder>
         </geometry>
-        <name>1</name>
       </visual>
       <pose>0 0 1.085 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="2">
       <collision name="2">
@@ -31,7 +28,6 @@
             <radius>0.0725</radius>
           </cylinder>
         </geometry>
-        <name>2</name>
       </collision>
       <visual name="2">
         <geometry>
@@ -40,10 +36,8 @@
             <radius>0.0725</radius>
           </cylinder>
         </geometry>
-        <name>2</name>
       </visual>
       <pose>0 0 0.54 0 0 0</pose>
-      <name>2</name>
     </link>
     <link name="3">
       <collision name="3">
@@ -52,7 +46,6 @@
             <size>0.775 0.035 0.045</size>
           </box>
         </geometry>
-        <name>3</name>
       </collision>
       <visual name="3">
         <geometry>
@@ -60,10 +53,8 @@
             <size>0.775 0.035 0.045</size>
           </box>
         </geometry>
-        <name>3</name>
       </visual>
       <pose>0 0 0.0225 0 0 0</pose>
-      <name>3</name>
     </link>
     <link name="4">
       <collision name="4">
@@ -72,7 +63,6 @@
             <size>0.035 0.775 0.045</size>
           </box>
         </geometry>
-        <name>4</name>
       </collision>
       <visual name="4">
         <geometry>
@@ -80,10 +70,8 @@
             <size>0.035 0.775 0.045</size>
           </box>
         </geometry>
-        <name>4</name>
       </visual>
       <pose>0 0 0.0225 0 0 0</pose>
-      <name>4</name>
     </link>
     <link name="5">
       <collision name="5">
@@ -93,7 +81,6 @@
             <radius>0.4</radius>
           </cylinder>
         </geometry>
-        <name>5</name>
       </collision>
       <visual name="5">
         <geometry>
@@ -102,10 +89,8 @@
             <radius>0.4</radius>
           </cylinder>
         </geometry>
-        <name>5</name>
       </visual>
       <pose>1 0 1.085 0 0 0</pose>
-      <name>5</name>
     </link>
     <link name="6">
       <collision name="6">
@@ -115,7 +100,6 @@
             <radius>0.0725</radius>
           </cylinder>
         </geometry>
-        <name>6</name>
       </collision>
       <visual name="6">
         <geometry>
@@ -124,10 +108,8 @@
             <radius>0.0725</radius>
           </cylinder>
         </geometry>
-        <name>6</name>
       </visual>
       <pose>1 0 0.54 0 0 0</pose>
-      <name>6</name>
     </link>
     <link name="7">
       <collision name="7">
@@ -136,7 +118,6 @@
             <size>0.775 0.035 0.045</size>
           </box>
         </geometry>
-        <name>7</name>
       </collision>
       <visual name="7">
         <geometry>
@@ -144,10 +125,8 @@
             <size>0.775 0.035 0.045</size>
           </box>
         </geometry>
-        <name>7</name>
       </visual>
       <pose>1 0 0.0225 0 0 0</pose>
-      <name>7</name>
     </link>
     <link name="8">
       <collision name="8">
@@ -156,7 +135,6 @@
             <size>0.035 0.775 0.045</size>
           </box>
         </geometry>
-        <name>8</name>
       </collision>
       <visual name="8">
         <geometry>
@@ -164,10 +142,8 @@
             <size>0.035 0.775 0.045</size>
           </box>
         </geometry>
-        <name>8</name>
       </visual>
       <pose>1 0 0.0225 0 0 0</pose>
-      <name>8</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
@@ -177,9 +153,7 @@
           </box>
         </geometry>
         <pose>0.5 0.775 0.005 0 0 0</pose>
-        <name>in_front_of</name>
       </virtual_volume>
-      <name>in_front_of</name>
     </link>
     <link name="on_top_of">
       <virtual_volume name="on_top_of">
@@ -189,11 +163,8 @@
           </box>
         </geometry>
         <pose>0.5 0.0 1.195 0 0 0</pose>
-        <name>on_top_of</name>
       </virtual_volume>
-      <name>on_top_of</name>
     </link>
     <static>true</static>
-    <name>rgo2018/bar</name>
   </model>
 </sdf>

--- a/models/rgo2018/bed_frame/model.sdf
+++ b/models/rgo2018/bed_frame/model.sdf
@@ -8,7 +8,6 @@
             <size>1.02 2.12 0.46</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -19,10 +18,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>1</name>
       </visual>
       <pose>0 0 0.23 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="2">
       <collision name="2">
@@ -31,7 +28,6 @@
             <size>1.02 0.075 0.19</size>
           </box>
         </geometry>
-        <name>2</name>
       </collision>
       <visual name="2">
         <geometry>
@@ -42,10 +38,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>2</name>
       </visual>
       <pose>0 -1.0225 0.555 0 0 0</pose>
-      <name>2</name>
     </link>
     <link name="3">
       <collision name="3">
@@ -54,7 +48,6 @@
             <size>1.02 0.075 0.19</size>
           </box>
         </geometry>
-        <name>3</name>
       </collision>
       <visual name="3">
         <geometry>
@@ -65,10 +58,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>3</name>
       </visual>
       <pose>0 1.0225 0.555 0 0 0</pose>
-      <name>3</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
@@ -78,11 +69,8 @@
           </box>
         </geometry>
         <pose>0.0 0.55 0.005 0 0 0</pose>
-        <name>in_front_of</name>
       </virtual_volume>
-      <name>in_front_of</name>
     </link>
     <static>true</static>
-    <name>rgo2018/bed_frame</name>
   </model>
 </sdf>

--- a/models/rgo2018/bookcase/model.sdf
+++ b/models/rgo2018/bookcase/model.sdf
@@ -8,7 +8,6 @@
             <size>0.28 0.018 2.015</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -19,10 +18,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>1</name>
       </visual>
       <pose>0 -0.39 1.0075 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="2">
       <collision name="2">
@@ -31,7 +28,6 @@
             <size>0.28 0.018 2.015</size>
           </box>
         </geometry>
-        <name>2</name>
       </collision>
       <visual name="2">
         <geometry>
@@ -42,10 +38,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>2</name>
       </visual>
       <pose>0 0.39 1.0075 0 0 0</pose>
-      <name>2</name>
     </link>
     <link name="3">
       <collision name="3">
@@ -54,7 +48,6 @@
             <size>0.018 0.798 2.015</size>
           </box>
         </geometry>
-        <name>3</name>
       </collision>
       <visual name="3">
         <geometry>
@@ -65,10 +58,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>3</name>
       </visual>
       <pose>-0.131 0 1.0075 0 0 0</pose>
-      <name>3</name>
     </link>
     <link name="4">
       <collision name="4">
@@ -77,7 +68,6 @@
             <size>0.262 0.762 0.018</size>
           </box>
         </geometry>
-        <name>4</name>
       </collision>
       <visual name="4">
         <geometry>
@@ -88,10 +78,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>4</name>
       </visual>
       <pose>0.009 0 2.006 0 0 0</pose>
-      <name>4</name>
     </link>
     <link name="5">
       <collision name="5">
@@ -100,7 +88,6 @@
             <size>0.262 0.762 0.097</size>
           </box>
         </geometry>
-        <name>5</name>
       </collision>
       <visual name="5">
         <geometry>
@@ -111,10 +98,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>5</name>
       </visual>
       <pose>0.009 0 0.0485 0 0 0</pose>
-      <name>5</name>
     </link>
     <link name="6">
       <collision name="6">
@@ -123,7 +108,6 @@
             <size>0.262 0.762 0.018</size>
           </box>
         </geometry>
-        <name>6</name>
       </collision>
       <visual name="6">
         <geometry>
@@ -134,10 +118,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>6</name>
       </visual>
       <pose>0.009 0 0.439 0 0 0</pose>
-      <name>6</name>
     </link>
     <link name="7">
       <collision name="7">
@@ -146,7 +128,6 @@
             <size>0.262 0.762 0.018</size>
           </box>
         </geometry>
-        <name>7</name>
       </collision>
       <visual name="7">
         <geometry>
@@ -157,10 +138,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>7</name>
       </visual>
       <pose>0.009 0 0.726 0 0 0</pose>
-      <name>7</name>
     </link>
     <link name="8">
       <collision name="8">
@@ -169,7 +148,6 @@
             <size>0.262 0.762 0.018</size>
           </box>
         </geometry>
-        <name>8</name>
       </collision>
       <visual name="8">
         <geometry>
@@ -180,10 +158,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>8</name>
       </visual>
       <pose>0.009 0 1.044 0 0 0</pose>
-      <name>8</name>
     </link>
     <link name="9">
       <collision name="9">
@@ -192,7 +168,6 @@
             <size>0.262 0.762 0.018</size>
           </box>
         </geometry>
-        <name>9</name>
       </collision>
       <visual name="9">
         <geometry>
@@ -203,10 +178,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>9</name>
       </visual>
       <pose>0.009 0 1.43 0 0 0</pose>
-      <name>9</name>
     </link>
     <link name="10">
       <collision name="10">
@@ -215,7 +188,6 @@
             <size>0.262 0.762 0.018</size>
           </box>
         </geometry>
-        <name>10</name>
       </collision>
       <visual name="10">
         <geometry>
@@ -226,10 +198,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>10</name>
       </visual>
       <pose>0.009 0 1.718 0 0 0</pose>
-      <name>10</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
@@ -239,9 +209,7 @@
           </box>
         </geometry>
         <pose>0.64 0.0 0.005 0 0 0</pose>
-        <name>in_front_of</name>
       </virtual_volume>
-      <name>in_front_of</name>
     </link>
     <link name="on_top_of">
       <virtual_volume name="on_top_of">
@@ -251,9 +219,7 @@
           </box>
         </geometry>
         <pose>0.009 0.0 0.88 0 0 0</pose>
-        <name>on_top_of</name>
       </virtual_volume>
-      <name>on_top_of</name>
     </link>
     <link name="shelf1">
       <virtual_volume name="shelf1">
@@ -263,9 +229,7 @@
           </box>
         </geometry>
         <pose>0.009 0.0 0.242 0 0 0</pose>
-        <name>shelf1</name>
       </virtual_volume>
-      <name>shelf1</name>
     </link>
     <link name="shelf2">
       <virtual_volume name="shelf2">
@@ -275,9 +239,7 @@
           </box>
         </geometry>
         <pose>0.009 0.0 0.574 0 0 0</pose>
-        <name>shelf2</name>
       </virtual_volume>
-      <name>shelf2</name>
     </link>
     <link name="shelf3">
       <virtual_volume name="shelf3">
@@ -287,9 +249,7 @@
           </box>
         </geometry>
         <pose>0.009 0.0 0.88 0 0 0</pose>
-        <name>shelf3</name>
       </virtual_volume>
-      <name>shelf3</name>
     </link>
     <link name="shelf4">
       <virtual_volume name="shelf4">
@@ -299,9 +259,7 @@
           </box>
         </geometry>
         <pose>0.009 0.0 1.198 0 0 0</pose>
-        <name>shelf4</name>
       </virtual_volume>
-      <name>shelf4</name>
     </link>
     <link name="shelf5">
       <virtual_volume name="shelf5">
@@ -311,9 +269,7 @@
           </box>
         </geometry>
         <pose>0.009 0.0 1.5695 0 0 0</pose>
-        <name>shelf5</name>
       </virtual_volume>
-      <name>shelf5</name>
     </link>
     <link name="shelf6">
       <virtual_volume name="shelf6">
@@ -323,11 +279,8 @@
           </box>
         </geometry>
         <pose>0.009 0.0 1.8585 0 0 0</pose>
-        <name>shelf6</name>
       </virtual_volume>
-      <name>shelf6</name>
     </link>
     <static>true</static>
-    <name>rgo2018/bookcase</name>
   </model>
 </sdf>

--- a/models/rgo2018/couch/model.sdf
+++ b/models/rgo2018/couch/model.sdf
@@ -8,7 +8,6 @@
             <size>0.85 1.8 0.42</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -19,10 +18,8 @@
         <material>
           <ambient>0.1 0.1 0.1 1</ambient>
         </material>
-        <name>1</name>
       </visual>
       <pose>0.0 0.0 0.21 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="2">
       <collision name="2">
@@ -31,7 +28,6 @@
             <size>0.3 1.8 0.225</size>
           </box>
         </geometry>
-        <name>2</name>
       </collision>
       <visual name="2">
         <geometry>
@@ -42,10 +38,8 @@
         <material>
           <ambient>0.1 0.1 0.1 1</ambient>
         </material>
-        <name>2</name>
       </visual>
       <pose>-0.275 0.0 0.5325 0 0 0</pose>
-      <name>2</name>
     </link>
     <link name="3">
       <collision name="3">
@@ -54,7 +48,6 @@
             <size>0.85 0.175 0.225</size>
           </box>
         </geometry>
-        <name>3</name>
       </collision>
       <visual name="3">
         <geometry>
@@ -65,10 +58,8 @@
         <material>
           <ambient>0.1 0.1 0.1 1</ambient>
         </material>
-        <name>3</name>
       </visual>
       <pose>0.0 -0.812 0.5325 0 0 0</pose>
-      <name>3</name>
     </link>
     <link name="4">
       <collision name="4">
@@ -77,7 +68,6 @@
             <size>0.85 0.175 0.225</size>
           </box>
         </geometry>
-        <name>4</name>
       </collision>
       <visual name="4">
         <geometry>
@@ -88,10 +78,8 @@
         <material>
           <ambient>0.1 0.1 0.1 1</ambient>
         </material>
-        <name>4</name>
       </visual>
       <pose>0.0 0.812 0.5325 0 0 0</pose>
-      <name>4</name>
     </link>
     <link name="on_top_of">
       <virtual_volume name="on_top_of">
@@ -101,9 +89,7 @@
           </box>
         </geometry>
         <pose>0.175 0.0 0.6 0 0 0</pose>
-        <name>on_top_of</name>
       </virtual_volume>
-      <name>on_top_of</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
@@ -113,11 +99,8 @@
           </box>
         </geometry>
         <pose>1.05 0.0 0.005 0 0 0</pose>
-        <name>in_front_of</name>
       </virtual_volume>
-      <name>in_front_of</name>
     </link>
     <static>true</static>
-    <name>rgo2018/couch</name>
   </model>
 </sdf>

--- a/models/rgo2018/kitchen_counter/model.sdf
+++ b/models/rgo2018/kitchen_counter/model.sdf
@@ -8,7 +8,6 @@
             <size>0.59 0.018 1.02</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -19,10 +18,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>1</name>
       </visual>
       <pose>0.078 -0.5935 0.51 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="2">
       <collision name="2">
@@ -31,7 +28,6 @@
             <size>0.59 0.018 1.02</size>
           </box>
         </geometry>
-        <name>2</name>
       </collision>
       <visual name="2">
         <geometry>
@@ -42,10 +38,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>2</name>
       </visual>
       <pose>0.078 0.5935 0.51 0 0 0</pose>
-      <name>2</name>
     </link>
     <link name="3">
       <collision name="3">
@@ -54,7 +48,6 @@
             <size>0.078 1.205 2.002</size>
           </box>
         </geometry>
-        <name>3</name>
       </collision>
       <visual name="3">
         <geometry>
@@ -65,10 +58,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>3</name>
       </visual>
       <pose>-0.256 0 1.001 0 0 0</pose>
-      <name>3</name>
     </link>
     <link name="4">
       <collision name="4">
@@ -77,7 +68,6 @@
             <size>0.6 1.169 0.038</size>
           </box>
         </geometry>
-        <name>4</name>
       </collision>
       <visual name="4">
         <geometry>
@@ -88,10 +78,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>4</name>
       </visual>
       <pose>0.083 0 1.001 0 0 0</pose>
-      <name>4</name>
     </link>
     <link name="5">
       <collision name="5">
@@ -100,7 +88,6 @@
             <size>0.59 1.169 0.138</size>
           </box>
         </geometry>
-        <name>5</name>
       </collision>
       <visual name="5">
         <geometry>
@@ -111,10 +98,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>5</name>
       </visual>
       <pose>0.078 0 0.069 0 0 0</pose>
-      <name>5</name>
     </link>
     <link name="6">
       <collision name="6">
@@ -123,7 +108,6 @@
             <size>0.572 1.169 0.018</size>
           </box>
         </geometry>
-        <name>6</name>
       </collision>
       <visual name="6">
         <geometry>
@@ -134,10 +118,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>6</name>
       </visual>
       <pose>0.069 0 0.544 0 0 0</pose>
-      <name>6</name>
     </link>
     <link name="7">
       <collision name="7">
@@ -146,7 +128,6 @@
             <size>0.572 0.018 1.0</size>
           </box>
         </geometry>
-        <name>7</name>
       </collision>
       <visual name="7">
         <geometry>
@@ -157,10 +138,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>7</name>
       </visual>
       <pose>0.069 0 0.5 0 0 0</pose>
-      <name>7</name>
     </link>
     <link name="8">
       <collision name="8">
@@ -169,7 +148,6 @@
             <size>0.35 0.018 0.482</size>
           </box>
         </geometry>
-        <name>8</name>
       </collision>
       <visual name="8">
         <geometry>
@@ -180,10 +158,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>8</name>
       </visual>
       <pose>-0.042 -0.5935 1.76 0 0 0</pose>
-      <name>8</name>
     </link>
     <link name="9">
       <collision name="9">
@@ -192,7 +168,6 @@
             <size>0.35 0.018 0.482</size>
           </box>
         </geometry>
-        <name>9</name>
       </collision>
       <visual name="9">
         <geometry>
@@ -203,10 +178,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>9</name>
       </visual>
       <pose>-0.042 0.5935 1.76 0 0 0</pose>
-      <name>9</name>
     </link>
     <link name="10">
       <collision name="10">
@@ -215,7 +188,6 @@
             <size>0.35 1.169 0.018</size>
           </box>
         </geometry>
-        <name>10</name>
       </collision>
       <visual name="10">
         <geometry>
@@ -226,10 +198,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>10</name>
       </visual>
       <pose>-0.042 0 1.993 0 0 0</pose>
-      <name>10</name>
     </link>
     <link name="11">
       <collision name="11">
@@ -238,7 +208,6 @@
             <size>0.35 1.169 0.018</size>
           </box>
         </geometry>
-        <name>11</name>
       </collision>
       <visual name="11">
         <geometry>
@@ -249,10 +218,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>11</name>
       </visual>
       <pose>-0.042 0 1.529 0 0 0</pose>
-      <name>11</name>
     </link>
     <link name="12">
       <collision name="12">
@@ -261,7 +228,6 @@
             <size>0.35 1.169 0.018</size>
           </box>
         </geometry>
-        <name>12</name>
       </collision>
       <visual name="12">
         <geometry>
@@ -272,10 +238,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>12</name>
       </visual>
       <pose>-0.042 0 1.754 0 0 0</pose>
-      <name>12</name>
     </link>
     <link name="13">
       <collision name="13">
@@ -284,7 +248,6 @@
             <size>0.35 0.036 0.482</size>
           </box>
         </geometry>
-        <name>13</name>
       </collision>
       <visual name="13">
         <geometry>
@@ -295,10 +258,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>13</name>
       </visual>
       <pose>-0.042 0 1.76 0 0 0</pose>
-      <name>13</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
@@ -308,9 +269,7 @@
           </box>
         </geometry>
         <pose>1.3 0.0 0.005 0 0 0</pose>
-        <name>in_front_of</name>
       </virtual_volume>
-      <name>in_front_of</name>
     </link>
     <link name="on_top_of">
       <virtual_volume name="on_top_of">
@@ -320,11 +279,8 @@
           </box>
         </geometry>
         <pose>0.078 0.0 1.19 0 0 0</pose>
-        <name>on_top_of</name>
       </virtual_volume>
-      <name>on_top_of</name>
     </link>
     <static>true</static>
-    <name>rgo2018/kitchen_counter</name>
   </model>
 </sdf>

--- a/models/rgo2018/kitchen_sink/model.sdf
+++ b/models/rgo2018/kitchen_sink/model.sdf
@@ -8,7 +8,6 @@
             <size>0.6 1.169 1.02</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -19,10 +18,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>1</name>
       </visual>
       <pose>0.083 0 0.51 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="2">
       <collision name="2">
@@ -31,7 +28,6 @@
             <size>0.078 1.205 2.002</size>
           </box>
         </geometry>
-        <name>2</name>
       </collision>
       <visual name="2">
         <geometry>
@@ -42,10 +38,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>2</name>
       </visual>
       <pose>-0.256 0 1.001 0 0 0</pose>
-      <name>2</name>
     </link>
     <link name="3">
       <collision name="3">
@@ -54,7 +48,6 @@
             <size>0.35 0.018 0.482</size>
           </box>
         </geometry>
-        <name>3</name>
       </collision>
       <visual name="3">
         <geometry>
@@ -65,10 +58,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>3</name>
       </visual>
       <pose>-0.042 -0.5935 1.76 0 0 0</pose>
-      <name>3</name>
     </link>
     <link name="4">
       <collision name="4">
@@ -77,7 +68,6 @@
             <size>0.35 0.018 0.482</size>
           </box>
         </geometry>
-        <name>4</name>
       </collision>
       <visual name="4">
         <geometry>
@@ -88,10 +78,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>4</name>
       </visual>
       <pose>-0.042 0.5935 1.76 0 0 0</pose>
-      <name>4</name>
     </link>
     <link name="5">
       <collision name="5">
@@ -100,7 +88,6 @@
             <size>0.35 1.169 0.018</size>
           </box>
         </geometry>
-        <name>5</name>
       </collision>
       <visual name="5">
         <geometry>
@@ -111,10 +98,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>5</name>
       </visual>
       <pose>-0.042 0 1.993 0 0 0</pose>
-      <name>5</name>
     </link>
     <link name="6">
       <collision name="6">
@@ -123,7 +108,6 @@
             <size>0.35 1.169 0.018</size>
           </box>
         </geometry>
-        <name>6</name>
       </collision>
       <visual name="6">
         <geometry>
@@ -134,10 +118,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>6</name>
       </visual>
       <pose>-0.042 0 1.529 0 0 0</pose>
-      <name>6</name>
     </link>
     <link name="7">
       <collision name="7">
@@ -146,7 +128,6 @@
             <size>0.35 1.169 0.018</size>
           </box>
         </geometry>
-        <name>7</name>
       </collision>
       <visual name="7">
         <geometry>
@@ -157,10 +138,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>7</name>
       </visual>
       <pose>-0.042 0 1.754 0 0 0</pose>
-      <name>7</name>
     </link>
     <link name="8">
       <collision name="8">
@@ -169,7 +148,6 @@
             <size>0.35 0.036 0.482</size>
           </box>
         </geometry>
-        <name>8</name>
       </collision>
       <visual name="8">
         <geometry>
@@ -180,10 +158,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>8</name>
       </visual>
       <pose>-0.042 0 1.76 0 0 0</pose>
-      <name>8</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
@@ -193,9 +169,7 @@
           </box>
         </geometry>
         <pose>1.3 0.0 0.005 0 0 0</pose>
-        <name>in_front_of</name>
       </virtual_volume>
-      <name>in_front_of</name>
     </link>
     <link name="on_top_of">
       <virtual_volume name="on_top_of">
@@ -205,11 +179,8 @@
           </box>
         </geometry>
         <pose>0.078 0.0 1.19 0 0 0</pose>
-        <name>on_top_of</name>
       </virtual_volume>
-      <name>on_top_of</name>
     </link>
     <static>true</static>
-    <name>rgo2018/kitchen_sink</name>
   </model>
 </sdf>

--- a/models/rgo2018/model.sdf
+++ b/models/rgo2018/model.sdf
@@ -4,7 +4,6 @@
     <light name="sun" type="directional">
       <direction>0.5 0.1 -0.9</direction>
       <pose>0 0 10 0 0 0</pose>
-      <name>sun</name>
       <specular>0.2 0.2 0.2 1</specular>
       <cast_shadows>true</cast_shadows>
       <diffuse>0.8 0.8 0.8 1</diffuse>
@@ -24,9 +23,7 @@
             </box>
           </geometry>
           <pose>2.5 -1.25 0.005 0 0 0</pose>
-          <name>in1</name>
         </virtual_volume>
-        <name>in</name>
       </link>
       <link name="in">
         <virtual_volume name="in1">
@@ -36,13 +33,10 @@
             </box>
           </geometry>
           <pose>2.5 -1.25 0.005 0 0 0</pose>
-          <name>in1</name>
         </virtual_volume>
-        <name>in</name>
       </link>
       <pose>3.0 6.0 0 0 0 0</pose>
       <static>true</static>
-      <name>living_room</name>
     </model>
     <model name="bedroom" type="room">
       <link name="in">
@@ -53,13 +47,10 @@
             </box>
           </geometry>
           <pose>-0.5 0.0 0.005 0 0 0</pose>
-          <name>in</name>
         </virtual_volume>
-        <name>in</name>
       </link>
       <pose>8.0 1.0 0 0 0 0</pose>
       <static>true</static>
-      <name>bedroom</name>
     </model>
     <model name="dining_room" type="room">
       <link name="in">
@@ -70,13 +61,10 @@
             </box>
           </geometry>
           <pose>-0.5 1.05 0.005 0 0 0</pose>
-          <name>in</name>
         </virtual_volume>
-        <name>in</name>
       </link>
       <pose>3.0 0.0 0 0 0 0</pose>
       <static>true</static>
-      <name>dining_room</name>
     </model>
     <model name="kitchen" type="room">
       <link name="in">
@@ -87,9 +75,7 @@
             </box>
           </geometry>
           <pose>-0.15 0.25 0.005 0 0 0</pose>
-          <name>in1</name>
         </virtual_volume>
-        <name>in</name>
       </link>
       <link name="in">
         <virtual_volume name="in1">
@@ -99,235 +85,206 @@
             </box>
           </geometry>
           <pose>-0.15 0.25 0.005 0 0 0</pose>
-          <name>in1</name>
         </virtual_volume>
-        <name>in</name>
       </link>
       <pose>7.0 7.0 0 0 0 0</pose>
       <static>true</static>
-      <name>kitchen</name>
     </model>
     <model name="initial_pose" type="waypoint">
       <pose>-0.4 0.0 0 0 0 0</pose>
       <static>true</static>
-      <name>initial_pose</name>
     </model>
     <model name="initial_pose_2">
       <pose>8.48 -1.9 0 0 0 1.571</pose>
       <static>true</static>
-      <name>initial_pose_2</name>
     </model>
     <model name="lars" type="waypoint">
       <pose>8.0 6.5 0 0 0 1.5708</pose>
       <static>true</static>
-      <name>lars</name>
     </model>
     <model name="waypoint_door_final" type="waypoint">
       <pose>1.0 0.0 0 0 0 3.141592</pose>
       <static>true</static>
-      <name>waypoint_door_final</name>
     </model>
     <model name="bedroom_waypoint" type="waypoint">
       <pose>8.0 3.0 0 0 0 -2.3562</pose>
       <static>true</static>
-      <name>bedroom_waypoint</name>
     </model>
     <model name="kitchen_waypoint" type="waypoint">
       <pose>8.0 5.0 0 0 0 2.3562</pose>
       <static>true</static>
-      <name>kitchen_waypoint</name>
     </model>
     <model name="living_room_waypoint" type="waypoint">
       <pose>1.0 5.0 0 0 0 0.7854</pose>
       <static>true</static>
-      <name>living_room_waypoint</name>
     </model>
     <model name="dining_room_waypoint" type="waypoint">
       <pose>1.5 3.0 0 0 0 -0.7854</pose>
       <static>true</static>
-      <name>dining_room_waypoint</name>
     </model>
     <model name="registration_table1" type="waypoint">
       <pose>5.0 7.0 0 0 0 0</pose>
       <static>true</static>
-      <name>registration_table1</name>
     </model>
     <model name="registration_table2" type="waypoint">
       <pose>3.0 7.0 0 0 0 0</pose>
       <static>true</static>
-      <name>registration_table2</name>
     </model>
     <model name="registration_table3" type="waypoint">
       <pose>7.0 7.0 0 0 0 0</pose>
       <static>true</static>
-      <name>registration_table3</name>
     </model>
     <model name="exit_1_rips" type="waypoint">
       <pose>8.45 -2.8 0 0 0 -1.571</pose>
       <static>true</static>
-      <name>exit_1_rips</name>
     </model>
     <model name="exit_2_rips" type="waypoint">
       <pose>8.45 -2.24 0 0 0 -1.571</pose>
       <static>true</static>
-      <name>exit_2_rips</name>
     </model>
     <model name="exit_3_rips" type="waypoint">
       <pose>8.45 -1.4 0 0 0 -1.571</pose>
       <static>true</static>
-      <name>exit_3_rips</name>
     </model>
     <model name="exit_4_rips" type="waypoint">
       <pose>8.45 0.0 0 0 0 -1.571</pose>
       <static>true</static>
-      <name>exit_4_rips</name>
     </model>
     <model name="gpsr_meeting_point" type="waypoint">
       <pose>5.0 6.6 0 0 0 -3.141592</pose>
       <static>true</static>
-      <name>gpsr_meeting_point</name>
     </model>
     <model name="gpsr_exit_door_1" type="waypoint">
       <pose>8.45 -2.8 0 0 0 -1.571</pose>
       <static>true</static>
-      <name>gpsr_exit_door_1</name>
     </model>
     <model name="gpsr_meeting_point_2" type="waypoint">
       <pose>1.5 4.25 0 0 0 0</pose>
       <static>true</static>
-      <name>gpsr_meeting_point_2</name>
     </model>
     <model name="gpsr_exit_door_2" type="waypoint">
       <pose>-1.0 0.0 0 0 0 -3.1415</pose>
       <static>true</static>
-      <name>gpsr_exit_door_2</name>
     </model>
     <model name="challenge_open_ask_waypoint" type="waypoint">
       <pose>4.0 6.0 0 0 0 3.1415</pose>
       <static>true</static>
-      <name>challenge_open_ask_waypoint</name>
     </model>
     <model name="final_meeting_point" type="waypoint">
       <pose>5.0 7.0 0 0 0 -1.57</pose>
       <static>true</static>
-      <name>final_meeting_point</name>
     </model>
     <model name="help_me_carry_starting_point" type="waypoint">
       <pose>8.0 4.5 0 0 0 1.5708</pose>
       <static>true</static>
-      <name>help_me_carry_starting_point</name>
     </model>
     <model name="eegpsr_pose_1" type="waypoint">
       <pose>0.4 4.5 0 0 0 0.0</pose>
       <static>true</static>
-      <name>eegpsr_pose_1</name>
     </model>
     <model name="eegpsr_exit_door_1" type="waypoint">
       <pose>-1.0 0.0 0 0 0 3.1415</pose>
       <static>true</static>
-      <name>eegpsr_exit_door_1</name>
     </model>
     <model name="eegpsr_pose_2" type="waypoint">
       <pose>6.6 4.2 0 0 0 1.571</pose>
       <static>true</static>
-      <name>eegpsr_pose_2</name>
     </model>
     <model name="eegpsr_exit_door_2" type="waypoint">
       <pose>8.45 -2.8 0 0 0 -1.571</pose>
       <static>true</static>
-      <name>eegpsr_exit_door_2</name>
     </model>
-    <include name="floor">
+    <include>
       <pose>0 0 0 0 0 0</pose>
       <name>floor</name>
       <uri>model://floor</uri>
     </include>
-    <include name="walls">
+    <include>
       <pose>0 0 0 0 0 0</pose>
       <name>walls</name>
       <uri>model://rgo2018/walls</uri>
     </include>
-    <include name="dining_table">
+    <include>
       <pose>2.53 1.08 0.0 0 0 3.141585</pose>
       <name>dining_table</name>
       <uri>model://rgo2018/table_dinner</uri>
     </include>
-    <include name="display_case">
+    <include>
       <pose>3.02732 -1.283567 0.0 0 0 1.5708</pose>
       <name>display_case</name>
       <uri>model://rgo2018/bookcase</uri>
     </include>
-    <include name="cabinet">
+    <include>
       <pose>0.144 3.274 0.0 0 0 0.0</pose>
       <name>cabinet</name>
       <uri>model://rgo2018/bookcase</uri>
     </include>
-    <include name="storage_shelf">
+    <include>
       <pose>4.8 2.5 0.0 0 0 3.141592</pose>
       <name>storage_shelf</name>
       <uri>model://rgo2018/bookcase</uri>
     </include>
-    <include name="couch">
+    <include>
       <pose>0.930263 7.469865 0.0 0 0 -0.7854</pose>
       <name>couch</name>
       <uri>model://rgo2018/couch</uri>
     </include>
-    <include name="couch_table">
+    <include>
       <pose>1.630305 6.87455 0.0 0 0 -2.35619265359</pose>
       <name>couch_table</name>
       <uri>model://rgo2018/table_salon_double</uri>
     </include>
-    <include name="cupboard">
+    <include>
       <pose>3.262123 8.183156 0.0 0 0 -1.5708</pose>
       <name>cupboard</name>
       <uri>model://rgo2018/table_salon</uri>
     </include>
-    <include name="tv">
+    <include>
       <pose>5.0 4.08 0.0 0 0 1.570796</pose>
       <name>tv</name>
       <uri>model://rgo2015/tv</uri>
     </include>
-    <include name="tv_table">
+    <include>
       <pose>5.045754 5.106661 0.0 0 0 0.7854</pose>
       <name>tv_table</name>
       <uri>model://rgo2018/table_salon</uri>
     </include>
-    <include name="kitchen_table">
+    <include>
       <pose>5.922403 8.027883 0.0 0 0 3.14159</pose>
       <name>kitchen_table</name>
       <uri>model://rgo2018/table_dinner2</uri>
     </include>
-    <include name="bar">
+    <include>
       <pose>9.22352 7.158925 0.0 0 0 2.3562</pose>
       <name>bar</name>
       <uri>model://rgo2018/bar</uri>
     </include>
-    <include name="kitchen_cabinet">
+    <include>
       <pose>9.53186 4.334334 0.0 0 0 3.141585</pose>
       <name>kitchen_cabinet</name>
       <uri>model://rgo2018/kitchen_sink</uri>
     </include>
-    <include name="sink">
+    <include>
       <pose>9.537166 5.509867 0.0 0 0 3.141585</pose>
       <name>sink</name>
       <uri>model://rgo2018/kitchen_sink</uri>
     </include>
-    <include name="bed">
+    <include>
       <pose>6.076955 -0.96774 0.0 0 0 -1.5708</pose>
       <name>bed</name>
       <uri>model://rgo2018/bed_frame</uri>
     </include>
-    <include name="side_table">
+    <include>
       <pose>5.334368 -0.139128 0.0 0 0 1.5708</pose>
       <name>side_table</name>
       <uri>model://rgo2018/table_salon</uri>
     </include>
-    <include name="bookcase">
+    <include>
       <pose>9.7 2.0 0.0 0 0 3.141592</pose>
       <name>bookcase</name>
       <uri>model://rgo2018/bookcase</uri>
     </include>
-    <include name="desk">
+    <include>
       <pose>5.768366 2.87248 0.0 0 0 -0.7854</pose>
       <name>desk</name>
       <uri>model://rgo2018/table_party</uri>
@@ -344,6 +301,5 @@
         </solver>
       </ode>
     </physics>
-    <name>rgo2018</name>
   </world>
 </sdf>

--- a/models/rgo2018/table_bureau/model.sdf
+++ b/models/rgo2018/table_bureau/model.sdf
@@ -8,7 +8,6 @@
             <size>0.705 1.31 0.04</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -19,10 +18,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>1</name>
       </visual>
       <pose>0 0 0.73 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="2">
       <collision name="2">
@@ -31,7 +28,6 @@
             <size>0.04 0.04 0.699</size>
           </box>
         </geometry>
-        <name>2</name>
       </collision>
       <visual name="2">
         <geometry>
@@ -42,10 +38,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>2</name>
       </visual>
       <pose>0 0.565 0.3495 0 0 0</pose>
-      <name>2</name>
     </link>
     <link name="3">
       <collision name="3">
@@ -54,7 +48,6 @@
             <size>0.04 0.04 0.699</size>
           </box>
         </geometry>
-        <name>3</name>
       </collision>
       <visual name="3">
         <geometry>
@@ -65,10 +58,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>3</name>
       </visual>
       <pose>0.0 -0.565 0.3495 0 0 0</pose>
-      <name>3</name>
     </link>
     <link name="4">
       <collision name="4">
@@ -77,7 +68,6 @@
             <size>0.555 0.04 0.045</size>
           </box>
         </geometry>
-        <name>4</name>
       </collision>
       <visual name="4">
         <geometry>
@@ -88,10 +78,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>4</name>
       </visual>
       <pose>0.0 0.565 0.0225 0 0 0</pose>
-      <name>4</name>
     </link>
     <link name="5">
       <collision name="5">
@@ -100,7 +88,6 @@
             <size>0.555 0.04 0.045</size>
           </box>
         </geometry>
-        <name>5</name>
       </collision>
       <visual name="5">
         <geometry>
@@ -111,10 +98,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>5</name>
       </visual>
       <pose>0.0 -0.565 0.0225 0 0 0</pose>
-      <name>5</name>
     </link>
     <link name="on_top_of">
       <virtual_volume name="on_top_of">
@@ -124,9 +109,7 @@
           </box>
         </geometry>
         <pose>0.0 0.0 0.9 0 0 0</pose>
-        <name>on_top_of</name>
       </virtual_volume>
-      <name>on_top_of</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
@@ -136,11 +119,8 @@
           </box>
         </geometry>
         <pose>1.3 0.0 0.005 0 0 0</pose>
-        <name>in_front_of</name>
       </virtual_volume>
-      <name>in_front_of</name>
     </link>
     <static>true</static>
-    <name>rgo2018/table_bureau</name>
   </model>
 </sdf>

--- a/models/rgo2018/table_dinner/model.sdf
+++ b/models/rgo2018/table_dinner/model.sdf
@@ -8,7 +8,6 @@
             <size>1.83 0.76 0.018</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -19,10 +18,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>1</name>
       </visual>
       <pose>0 0 0.751 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="2">
       <collision name="2">
@@ -31,7 +28,6 @@
             <size>1.83 0.01 0.66</size>
           </box>
         </geometry>
-        <name>2</name>
       </collision>
       <visual name="2">
         <geometry>
@@ -42,10 +38,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>2</name>
       </visual>
       <pose>0 0.375 0.43 0 0 0</pose>
-      <name>2</name>
     </link>
     <link name="3">
       <collision name="3">
@@ -54,7 +48,6 @@
             <size>1.83 0.01 0.66</size>
           </box>
         </geometry>
-        <name>3</name>
       </collision>
       <visual name="3">
         <geometry>
@@ -65,10 +58,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>3</name>
       </visual>
       <pose>0 -0.375 0.43 0 0 0</pose>
-      <name>3</name>
     </link>
     <link name="4">
       <collision name="4">
@@ -77,7 +68,6 @@
             <size>0.025 0.025 0.742</size>
           </box>
         </geometry>
-        <name>4</name>
       </collision>
       <visual name="4">
         <geometry>
@@ -88,10 +78,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>4</name>
       </visual>
       <pose>-0.7325 -0.2825 0.371 0 0 0</pose>
-      <name>4</name>
     </link>
     <link name="5">
       <collision name="5">
@@ -100,7 +88,6 @@
             <size>0.025 0.025 0.742</size>
           </box>
         </geometry>
-        <name>5</name>
       </collision>
       <visual name="5">
         <geometry>
@@ -111,10 +98,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>5</name>
       </visual>
       <pose>0.7325 -0.2825 0.371 0 0 0</pose>
-      <name>5</name>
     </link>
     <link name="6">
       <collision name="6">
@@ -123,7 +108,6 @@
             <size>0.025 0.025 0.742</size>
           </box>
         </geometry>
-        <name>6</name>
       </collision>
       <visual name="6">
         <geometry>
@@ -134,10 +118,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>6</name>
       </visual>
       <pose>-0.7325 0.2825 0.371 0 0 0</pose>
-      <name>6</name>
     </link>
     <link name="7">
       <collision name="7">
@@ -146,7 +128,6 @@
             <size>0.025 0.025 0.742</size>
           </box>
         </geometry>
-        <name>7</name>
       </collision>
       <visual name="7">
         <geometry>
@@ -157,10 +138,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>7</name>
       </visual>
       <pose>0.7325 0.2825 0.371 0 0 0</pose>
-      <name>7</name>
     </link>
     <link name="on_top_of">
       <virtual_volume name="on_top_of">
@@ -170,9 +149,7 @@
           </box>
         </geometry>
         <pose>0.0 0.0 0.905 0 0 0</pose>
-        <name>on_top_of</name>
       </virtual_volume>
-      <name>on_top_of</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
@@ -182,11 +159,8 @@
           </box>
         </geometry>
         <pose>0.0 0.0 0.005 0 0 0</pose>
-        <name>in_front_of</name>
       </virtual_volume>
-      <name>in_front_of</name>
     </link>
     <static>true</static>
-    <name>rgo2018/table_dinner</name>
   </model>
 </sdf>

--- a/models/rgo2018/table_dinner2/model.sdf
+++ b/models/rgo2018/table_dinner2/model.sdf
@@ -8,7 +8,6 @@
             <size>1.83 0.76 0.018</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -19,10 +18,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>1</name>
       </visual>
       <pose>0 0 0.751 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="2">
       <collision name="2">
@@ -31,7 +28,6 @@
             <size>1.83 0.01 0.66</size>
           </box>
         </geometry>
-        <name>2</name>
       </collision>
       <visual name="2">
         <geometry>
@@ -42,10 +38,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>2</name>
       </visual>
       <pose>0 0.375 0.43 0 0 0</pose>
-      <name>2</name>
     </link>
     <link name="3">
       <collision name="3">
@@ -54,7 +48,6 @@
             <size>1.83 0.01 0.66</size>
           </box>
         </geometry>
-        <name>3</name>
       </collision>
       <visual name="3">
         <geometry>
@@ -65,10 +58,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>3</name>
       </visual>
       <pose>0 -0.375 0.43 0 0 0</pose>
-      <name>3</name>
     </link>
     <link name="4">
       <collision name="4">
@@ -77,7 +68,6 @@
             <size>0.025 0.025 0.742</size>
           </box>
         </geometry>
-        <name>4</name>
       </collision>
       <visual name="4">
         <geometry>
@@ -88,10 +78,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>4</name>
       </visual>
       <pose>-0.7325 -0.2825 0.371 0 0 0</pose>
-      <name>4</name>
     </link>
     <link name="5">
       <collision name="5">
@@ -100,7 +88,6 @@
             <size>0.025 0.025 0.742</size>
           </box>
         </geometry>
-        <name>5</name>
       </collision>
       <visual name="5">
         <geometry>
@@ -111,10 +98,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>5</name>
       </visual>
       <pose>0.7325 -0.2825 0.371 0 0 0</pose>
-      <name>5</name>
     </link>
     <link name="6">
       <collision name="6">
@@ -123,7 +108,6 @@
             <size>0.025 0.025 0.742</size>
           </box>
         </geometry>
-        <name>6</name>
       </collision>
       <visual name="6">
         <geometry>
@@ -134,10 +118,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>6</name>
       </visual>
       <pose>-0.7325 0.2825 0.371 0 0 0</pose>
-      <name>6</name>
     </link>
     <link name="7">
       <collision name="7">
@@ -146,7 +128,6 @@
             <size>0.025 0.025 0.742</size>
           </box>
         </geometry>
-        <name>7</name>
       </collision>
       <visual name="7">
         <geometry>
@@ -157,10 +138,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>7</name>
       </visual>
       <pose>0.7325 0.2825 0.371 0 0 0</pose>
-      <name>7</name>
     </link>
     <link name="on_top_of">
       <virtual_volume name="on_top_of">
@@ -170,9 +149,7 @@
           </box>
         </geometry>
         <pose>0.0 0.0 0.905 0 0 0</pose>
-        <name>on_top_of</name>
       </virtual_volume>
-      <name>on_top_of</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
@@ -182,11 +159,8 @@
           </box>
         </geometry>
         <pose>0.0 0.75 0.005 0 0 0</pose>
-        <name>in_front_of</name>
       </virtual_volume>
-      <name>in_front_of</name>
     </link>
     <static>true</static>
-    <name>rgo2018/table_dinner2</name>
   </model>
 </sdf>

--- a/models/rgo2018/table_party/model.sdf
+++ b/models/rgo2018/table_party/model.sdf
@@ -9,7 +9,6 @@
             <radius>0.4</radius>
           </cylinder>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -18,10 +17,8 @@
             <radius>0.4</radius>
           </cylinder>
         </geometry>
-        <name>1</name>
       </visual>
       <pose>0 0 1.085 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="2">
       <collision name="2">
@@ -31,7 +28,6 @@
             <radius>0.0725</radius>
           </cylinder>
         </geometry>
-        <name>2</name>
       </collision>
       <visual name="2">
         <geometry>
@@ -40,10 +36,8 @@
             <radius>0.0725</radius>
           </cylinder>
         </geometry>
-        <name>2</name>
       </visual>
       <pose>0 0 0.54 0 0 0</pose>
-      <name>2</name>
     </link>
     <link name="3">
       <collision name="3">
@@ -52,7 +46,6 @@
             <size>0.775 0.035 0.045</size>
           </box>
         </geometry>
-        <name>3</name>
       </collision>
       <visual name="3">
         <geometry>
@@ -60,10 +53,8 @@
             <size>0.775 0.035 0.045</size>
           </box>
         </geometry>
-        <name>3</name>
       </visual>
       <pose>0 0 0.0225 0 0 0</pose>
-      <name>3</name>
     </link>
     <link name="4">
       <collision name="4">
@@ -72,7 +63,6 @@
             <size>0.035 0.775 0.045</size>
           </box>
         </geometry>
-        <name>4</name>
       </collision>
       <visual name="4">
         <geometry>
@@ -80,10 +70,8 @@
             <size>0.035 0.775 0.045</size>
           </box>
         </geometry>
-        <name>4</name>
       </visual>
       <pose>0 0 0.0225 0 0 0</pose>
-      <name>4</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
@@ -93,9 +81,7 @@
           </box>
         </geometry>
         <pose>0.775 0.0 0.005 0 0 0</pose>
-        <name>in_front_of</name>
       </virtual_volume>
-      <name>in_front_of</name>
     </link>
     <link name="on_top_of">
       <virtual_volume name="on_top_of">
@@ -105,11 +91,8 @@
           </box>
         </geometry>
         <pose>0.0 0.0 1.195 0 0 0</pose>
-        <name>on_top_of</name>
       </virtual_volume>
-      <name>on_top_of</name>
     </link>
     <static>true</static>
-    <name>rgo2018/table_party</name>
   </model>
 </sdf>

--- a/models/rgo2018/table_salon/model.sdf
+++ b/models/rgo2018/table_salon/model.sdf
@@ -8,7 +8,6 @@
             <size>0.55 0.55 0.05</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -19,10 +18,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>1</name>
       </visual>
       <pose>0 0 0.425 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="2">
       <collision name="2">
@@ -31,7 +28,6 @@
             <size>0.05 0.05 0.4</size>
           </box>
         </geometry>
-        <name>2</name>
       </collision>
       <visual name="2">
         <geometry>
@@ -42,10 +38,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>2</name>
       </visual>
       <pose>-0.25 -0.25 0.2 0 0 0</pose>
-      <name>2</name>
     </link>
     <link name="3">
       <collision name="3">
@@ -54,7 +48,6 @@
             <size>0.05 0.05 0.4</size>
           </box>
         </geometry>
-        <name>3</name>
       </collision>
       <visual name="3">
         <geometry>
@@ -65,10 +58,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>3</name>
       </visual>
       <pose>0.25 -0.25 0.2 0 0 0</pose>
-      <name>3</name>
     </link>
     <link name="4">
       <collision name="4">
@@ -77,7 +68,6 @@
             <size>0.05 0.05 0.4</size>
           </box>
         </geometry>
-        <name>4</name>
       </collision>
       <visual name="4">
         <geometry>
@@ -88,10 +78,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>4</name>
       </visual>
       <pose>-0.25 0.25 0.2 0 0 0</pose>
-      <name>4</name>
     </link>
     <link name="5">
       <collision name="5">
@@ -100,7 +88,6 @@
             <size>0.05 0.05 0.4</size>
           </box>
         </geometry>
-        <name>5</name>
       </collision>
       <visual name="5">
         <geometry>
@@ -111,10 +98,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>5</name>
       </visual>
       <pose>0.25 0.25 0.2 0 0 0</pose>
-      <name>5</name>
     </link>
     <link name="on_top_of">
       <virtual_volume name="on_top_of">
@@ -124,9 +109,7 @@
           </box>
         </geometry>
         <pose>0.0 0.0 0.595 0 0 0</pose>
-        <name>on_top_of</name>
       </virtual_volume>
-      <name>on_top_of</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
@@ -136,11 +119,8 @@
           </box>
         </geometry>
         <pose>0.8 0.0 0.005 0 0 0</pose>
-        <name>in_front_of</name>
       </virtual_volume>
-      <name>in_front_of</name>
     </link>
     <static>true</static>
-    <name>rgo2018/table_salon</name>
   </model>
 </sdf>

--- a/models/rgo2018/table_salon_double/model.sdf
+++ b/models/rgo2018/table_salon_double/model.sdf
@@ -8,7 +8,6 @@
             <size>1.1 0.55 0.05</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -19,10 +18,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>1</name>
       </visual>
       <pose>0 0 0.425 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="2">
       <collision name="2">
@@ -31,7 +28,6 @@
             <size>0.05 0.05 0.4</size>
           </box>
         </geometry>
-        <name>2</name>
       </collision>
       <visual name="2">
         <geometry>
@@ -42,10 +38,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>2</name>
       </visual>
       <pose>-0.525 -0.25 0.2 0 0 0</pose>
-      <name>2</name>
     </link>
     <link name="3">
       <collision name="3">
@@ -54,7 +48,6 @@
             <size>0.05 0.05 0.4</size>
           </box>
         </geometry>
-        <name>3</name>
       </collision>
       <visual name="3">
         <geometry>
@@ -65,10 +58,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>3</name>
       </visual>
       <pose>0.525 -0.25 0.2 0 0 0</pose>
-      <name>3</name>
     </link>
     <link name="4">
       <collision name="4">
@@ -77,7 +68,6 @@
             <size>0.05 0.05 0.4</size>
           </box>
         </geometry>
-        <name>4</name>
       </collision>
       <visual name="4">
         <geometry>
@@ -88,10 +78,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>4</name>
       </visual>
       <pose>-0.525 0.25 0.2 0 0 0</pose>
-      <name>4</name>
     </link>
     <link name="5">
       <collision name="5">
@@ -100,7 +88,6 @@
             <size>0.05 0.05 0.4</size>
           </box>
         </geometry>
-        <name>5</name>
       </collision>
       <visual name="5">
         <geometry>
@@ -111,10 +98,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>5</name>
       </visual>
       <pose>0.525 0.25 0.2 0 0 0</pose>
-      <name>5</name>
     </link>
     <link name="6">
       <collision name="6">
@@ -123,7 +108,6 @@
             <size>0.1 0.05 0.4</size>
           </box>
         </geometry>
-        <name>6</name>
       </collision>
       <visual name="6">
         <geometry>
@@ -134,10 +118,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>6</name>
       </visual>
       <pose>0 0.25 0.2 0 0 0</pose>
-      <name>6</name>
     </link>
     <link name="7">
       <collision name="7">
@@ -146,7 +128,6 @@
             <size>0.1 0.05 0.4</size>
           </box>
         </geometry>
-        <name>7</name>
       </collision>
       <visual name="7">
         <geometry>
@@ -157,10 +138,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>7</name>
       </visual>
       <pose>0 -0.25 0.2 0 0 0</pose>
-      <name>7</name>
     </link>
     <link name="on_top_of">
       <virtual_volume name="on_top_of">
@@ -170,9 +149,7 @@
           </box>
         </geometry>
         <pose>0.0 0.0 0.595 0 0 0</pose>
-        <name>on_top_of</name>
       </virtual_volume>
-      <name>on_top_of</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
@@ -182,11 +159,8 @@
           </box>
         </geometry>
         <pose>0.0 0.8 0.005 0 0 0</pose>
-        <name>in_front_of</name>
       </virtual_volume>
-      <name>in_front_of</name>
     </link>
     <static>true</static>
-    <name>rgo2018/table_salon_double</name>
   </model>
 </sdf>

--- a/models/rgo2018/walls/model.sdf
+++ b/models/rgo2018/walls/model.sdf
@@ -8,7 +8,6 @@
             <uri>model://rgo2018/walls/rgo2018largecleaned.stl</uri>
           </mesh>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -16,12 +15,9 @@
             <uri>model://rgo2018/walls/rgo2018largecleaned.stl</uri>
           </mesh>
         </geometry>
-        <name>1</name>
       </visual>
       <pose>0 0 0 0 0 0</pose>
-      <name>1</name>
     </link>
     <static>true</static>
-    <name>rgo2018/walls</name>
   </model>
 </sdf>

--- a/models/rgo2019/armchair/model.sdf
+++ b/models/rgo2019/armchair/model.sdf
@@ -8,7 +8,6 @@
             <uri>model://rgo2019/armchair/heightmap.stl</uri>
           </mesh>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -16,12 +15,10 @@
             <uri>model://rgo2019/armchair/heightmap.stl</uri>
           </mesh>
         </geometry>
-        <name>1</name>
       </visual>
       <pose>0 0 0 0 0 -1.57</pose>
-      <name>1</name>
     </link>
-     <link name="on_top_of">
+    <link name="on_top_of">
       <virtual_volume name="on_top_of">
         <geometry>
           <box>
@@ -29,9 +26,7 @@
           </box>
         </geometry>
         <pose>-0.07 0.0 0.51 0 0 0</pose>
-        <name>on_top_of</name>
       </virtual_volume>
-      <name>on_top_of</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
@@ -41,11 +36,8 @@
           </box>
         </geometry>
         <pose>-0.60 0.0 0.005 0 0 0</pose>
-        <name>in_front_of</name>
       </virtual_volume>
-      <name>in_front_of</name>
-   </link>
+    </link>
     <static>true</static>
-    <name>rgo2019/armchair</name>
   </model>
 </sdf>

--- a/models/rgo2019/bed_frame/model.sdf
+++ b/models/rgo2019/bed_frame/model.sdf
@@ -8,7 +8,6 @@
             <size>1.02 2.12 0.46</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -19,10 +18,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>1</name>
       </visual>
       <pose>0 0 0.23 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="2">
       <collision name="2">
@@ -31,7 +28,6 @@
             <size>1.02 0.075 0.19</size>
           </box>
         </geometry>
-        <name>2</name>
       </collision>
       <visual name="2">
         <geometry>
@@ -42,10 +38,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>2</name>
       </visual>
       <pose>0 -1.0225 0.555 0 0 0</pose>
-      <name>2</name>
     </link>
     <link name="3">
       <collision name="3">
@@ -54,7 +48,6 @@
             <size>1.02 0.075 0.19</size>
           </box>
         </geometry>
-        <name>3</name>
       </collision>
       <visual name="3">
         <geometry>
@@ -65,10 +58,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>3</name>
       </visual>
       <pose>0 1.0225 0.555 0 0 0</pose>
-      <name>3</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
@@ -78,11 +69,8 @@
           </box>
         </geometry>
         <pose>0.0 0.55 0.005 0 0 0</pose>
-        <name>in_front_of</name>
       </virtual_volume>
-      <name>in_front_of</name>
     </link>
     <static>true</static>
-    <name>rgo2019/bed_frame</name>
   </model>
 </sdf>

--- a/models/rgo2019/coathanger/model.sdf
+++ b/models/rgo2019/coathanger/model.sdf
@@ -8,7 +8,6 @@
             <size>0.1 0.1 1.4</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -16,10 +15,8 @@
             <size>0.1 0.1 1.4</size>
           </box>
         </geometry>
-        <name>1</name>
       </visual>
       <pose>0.0 0.0 0.7 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
@@ -29,11 +26,8 @@
           </box>
         </geometry>
         <pose>0.45 0.0 0.005 0 0 0</pose>
-        <name>in_front_of</name>
       </virtual_volume>
-      <name>in_front_of</name>
     </link>
     <static>true</static>
-    <name>rgo2019/coathanger</name>
   </model>
 </sdf>

--- a/models/rgo2019/couch/model.sdf
+++ b/models/rgo2019/couch/model.sdf
@@ -8,7 +8,6 @@
             <size>0.85 1.8 0.42</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -19,10 +18,8 @@
         <material>
           <ambient>0.1 0.1 0.1 1</ambient>
         </material>
-        <name>1</name>
       </visual>
       <pose>0.0 0.0 0.21 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="2">
       <collision name="2">
@@ -31,7 +28,6 @@
             <size>0.3 1.8 0.225</size>
           </box>
         </geometry>
-        <name>2</name>
       </collision>
       <visual name="2">
         <geometry>
@@ -42,10 +38,8 @@
         <material>
           <ambient>0.1 0.1 0.1 1</ambient>
         </material>
-        <name>2</name>
       </visual>
       <pose>-0.275 0.0 0.5325 0 0 0</pose>
-      <name>2</name>
     </link>
     <link name="3">
       <collision name="3">
@@ -54,7 +48,6 @@
             <size>0.85 0.175 0.225</size>
           </box>
         </geometry>
-        <name>3</name>
       </collision>
       <visual name="3">
         <geometry>
@@ -65,10 +58,8 @@
         <material>
           <ambient>0.1 0.1 0.1 1</ambient>
         </material>
-        <name>3</name>
       </visual>
       <pose>0.0 -0.812 0.5325 0 0 0</pose>
-      <name>3</name>
     </link>
     <link name="4">
       <collision name="4">
@@ -77,7 +68,6 @@
             <size>0.85 0.175 0.225</size>
           </box>
         </geometry>
-        <name>4</name>
       </collision>
       <visual name="4">
         <geometry>
@@ -88,12 +78,10 @@
         <material>
           <ambient>0.1 0.1 0.1 1</ambient>
         </material>
-        <name>4</name>
       </visual>
       <pose>0.0 0.812 0.5325 0 0 0</pose>
-      <name>4</name>
     </link>
-     <link name="on_top_of">
+    <link name="on_top_of">
       <virtual_volume name="on_top_of">
         <geometry>
           <box>
@@ -101,9 +89,7 @@
           </box>
         </geometry>
         <pose>0.175 0.0 0.6 0 0 0</pose>
-        <name>on_top_of</name>
       </virtual_volume>
-      <name>on_top_of</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
@@ -113,11 +99,8 @@
           </box>
         </geometry>
         <pose>1.05 0.0 0.005 0 0 0</pose>
-        <name>in_front_of</name>
       </virtual_volume>
-      <name>in_front_of</name>
-   </link>
+    </link>
     <static>true</static>
-    <name>rgo2019/couch</name>
   </model>
 </sdf>

--- a/models/rgo2019/desk/model.sdf
+++ b/models/rgo2019/desk/model.sdf
@@ -8,7 +8,6 @@
             <size>1.8 0.8 0.02</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -16,10 +15,8 @@
             <size>1.8 0.8 0.02</size>
           </box>
         </geometry>
-        <name>1</name>
       </visual>
       <pose>0.0 0.0 0.73 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="2">
       <collision name="2">
@@ -28,7 +25,6 @@
             <size>0.05 0.05 0.72</size>
           </box>
         </geometry>
-        <name>2</name>
       </collision>
       <visual name="2">
         <geometry>
@@ -36,10 +32,8 @@
             <size>0.05 0.05 0.72</size>
           </box>
         </geometry>
-        <name>2</name>
       </visual>
       <pose>-0.515 -0.275 0.36 0 0 0</pose>
-      <name>2</name>
     </link>
     <link name="3">
       <collision name="3">
@@ -48,7 +42,6 @@
             <size>0.05 0.05 0.72</size>
           </box>
         </geometry>
-        <name>3</name>
       </collision>
       <visual name="3">
         <geometry>
@@ -56,10 +49,8 @@
             <size>0.05 0.05 0.72</size>
           </box>
         </geometry>
-        <name>3</name>
       </visual>
       <pose>0.515 -0.275 0.36 0 0 0</pose>
-      <name>3</name>
     </link>
     <link name="4">
       <collision name="4">
@@ -68,7 +59,6 @@
             <size>0.05 0.05 0.72</size>
           </box>
         </geometry>
-        <name>4</name>
       </collision>
       <visual name="4">
         <geometry>
@@ -76,10 +66,8 @@
             <size>0.05 0.05 0.72</size>
           </box>
         </geometry>
-        <name>4</name>
       </visual>
       <pose>-0.515 0.275 0.36 0 0 0</pose>
-      <name>4</name>
     </link>
     <link name="5">
       <collision name="5">
@@ -88,7 +76,6 @@
             <size>0.05 0.05 0.72</size>
           </box>
         </geometry>
-        <name>5</name>
       </collision>
       <visual name="5">
         <geometry>
@@ -96,10 +83,8 @@
             <size>0.05 0.05 0.72</size>
           </box>
         </geometry>
-        <name>5</name>
       </visual>
       <pose>0.515 0.275 0.36 0 0 0</pose>
-      <name>5</name>
     </link>
     <link name="on_top_of">
       <virtual_volume name="on_top_of">
@@ -109,9 +94,7 @@
           </box>
         </geometry>
         <pose>0.0 0.0 0.885 0 0 0</pose>
-        <name>on_top_of</name>
       </virtual_volume>
-      <name>on_top_of</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
@@ -121,11 +104,8 @@
           </box>
         </geometry>
         <pose>0.0 0.85 0.005 0 0 0</pose>
-        <name>in_front_of</name>
       </virtual_volume>
-      <name>in_front_of</name>
     </link>
     <static>true</static>
-    <name>rgo2019/desk</name>
   </model>
 </sdf>

--- a/models/rgo2019/dishwasher/model.sdf
+++ b/models/rgo2019/dishwasher/model.sdf
@@ -8,7 +8,6 @@
             <size>0.6 0.6 0.85</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -16,10 +15,8 @@
             <size>0.6 0.6 0.85</size>
           </box>
         </geometry>
-        <name>1</name>
       </visual>
       <pose>0.0 0.0 0.425 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="on_top_of">
       <virtual_volume name="on_top_of">
@@ -29,9 +26,7 @@
           </box>
         </geometry>
         <pose>0.0 0.0 0.995 0 0 0</pose>
-        <name>on_top_of</name>
       </virtual_volume>
-      <name>on_top_of</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
@@ -41,11 +36,8 @@
           </box>
         </geometry>
         <pose>0.8 0.0 0.005 0 0 0</pose>
-        <name>in_front_of</name>
       </virtual_volume>
-      <name>in_front_of</name>
     </link>
     <static>true</static>
-    <name>rgo2019/dishwasher</name>
   </model>
 </sdf>

--- a/models/rgo2019/drop_area/model.sdf
+++ b/models/rgo2019/drop_area/model.sdf
@@ -8,7 +8,6 @@
             <size>0.001 0.001 0.001</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -16,10 +15,8 @@
             <size>0.001 0.001 0.001</size>
           </box>
         </geometry>
-        <name>1</name>
       </visual>
       <pose>0.0 0.0 0.0005 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="on_top_of">
       <virtual_volume name="on_top_of">
@@ -29,9 +26,7 @@
           </box>
         </geometry>
         <pose>0.0 0.0 1.0 0 0 0</pose>
-        <name>on_top_of</name>
       </virtual_volume>
-      <name>on_top_of</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
@@ -41,11 +36,8 @@
           </box>
         </geometry>
         <pose>0.65 0.0 0.005 0 0 0</pose>
-        <name>in_front_of</name>
       </virtual_volume>
-      <name>in_front_of</name>
     </link>
     <static>true</static>
-    <name>rgo2019/drop_area</name>
   </model>
 </sdf>

--- a/models/rgo2019/kitchen_counter/model.sdf
+++ b/models/rgo2019/kitchen_counter/model.sdf
@@ -8,7 +8,6 @@
             <size>0.59 0.018 1.02</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -19,10 +18,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>1</name>
       </visual>
       <pose>0.078 -0.5935 0.51 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="2">
       <collision name="2">
@@ -31,7 +28,6 @@
             <size>0.59 0.018 1.02</size>
           </box>
         </geometry>
-        <name>2</name>
       </collision>
       <visual name="2">
         <geometry>
@@ -42,10 +38,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>2</name>
       </visual>
       <pose>0.078 0.5935 0.51 0 0 0</pose>
-      <name>2</name>
     </link>
     <link name="3">
       <collision name="3">
@@ -54,7 +48,6 @@
             <size>0.078 1.205 2.002</size>
           </box>
         </geometry>
-        <name>3</name>
       </collision>
       <visual name="3">
         <geometry>
@@ -65,10 +58,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>3</name>
       </visual>
       <pose>-0.256 0 1.001 0 0 0</pose>
-      <name>3</name>
     </link>
     <link name="4">
       <collision name="4">
@@ -77,7 +68,6 @@
             <size>0.6 1.169 0.038</size>
           </box>
         </geometry>
-        <name>4</name>
       </collision>
       <visual name="4">
         <geometry>
@@ -88,10 +78,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>4</name>
       </visual>
       <pose>0.083 0 1.001 0 0 0</pose>
-      <name>4</name>
     </link>
     <link name="5">
       <collision name="5">
@@ -100,7 +88,6 @@
             <size>0.59 1.169 0.138</size>
           </box>
         </geometry>
-        <name>5</name>
       </collision>
       <visual name="5">
         <geometry>
@@ -111,10 +98,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>5</name>
       </visual>
       <pose>0.078 0 0.069 0 0 0</pose>
-      <name>5</name>
     </link>
     <link name="6">
       <collision name="6">
@@ -123,7 +108,6 @@
             <size>0.572 1.169 0.018</size>
           </box>
         </geometry>
-        <name>6</name>
       </collision>
       <visual name="6">
         <geometry>
@@ -134,10 +118,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>6</name>
       </visual>
       <pose>0.069 0 0.544 0 0 0</pose>
-      <name>6</name>
     </link>
     <link name="7">
       <collision name="7">
@@ -146,7 +128,6 @@
             <size>0.572 0.018 1.0</size>
           </box>
         </geometry>
-        <name>7</name>
       </collision>
       <visual name="7">
         <geometry>
@@ -157,10 +138,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>7</name>
       </visual>
       <pose>0.069 0 0.5 0 0 0</pose>
-      <name>7</name>
     </link>
     <link name="8">
       <collision name="8">
@@ -169,7 +148,6 @@
             <size>0.35 0.018 0.482</size>
           </box>
         </geometry>
-        <name>8</name>
       </collision>
       <visual name="8">
         <geometry>
@@ -180,10 +158,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>8</name>
       </visual>
       <pose>-0.042 -0.5935 1.76 0 0 0</pose>
-      <name>8</name>
     </link>
     <link name="9">
       <collision name="9">
@@ -192,7 +168,6 @@
             <size>0.35 0.018 0.482</size>
           </box>
         </geometry>
-        <name>9</name>
       </collision>
       <visual name="9">
         <geometry>
@@ -203,10 +178,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>9</name>
       </visual>
       <pose>-0.042 0.5935 1.76 0 0 0</pose>
-      <name>9</name>
     </link>
     <link name="10">
       <collision name="10">
@@ -215,7 +188,6 @@
             <size>0.35 1.169 0.018</size>
           </box>
         </geometry>
-        <name>10</name>
       </collision>
       <visual name="10">
         <geometry>
@@ -226,10 +198,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>10</name>
       </visual>
       <pose>-0.042 0 1.993 0 0 0</pose>
-      <name>10</name>
     </link>
     <link name="11">
       <collision name="11">
@@ -238,7 +208,6 @@
             <size>0.35 1.169 0.018</size>
           </box>
         </geometry>
-        <name>11</name>
       </collision>
       <visual name="11">
         <geometry>
@@ -249,10 +218,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>11</name>
       </visual>
       <pose>-0.042 0 1.529 0 0 0</pose>
-      <name>11</name>
     </link>
     <link name="12">
       <collision name="12">
@@ -261,7 +228,6 @@
             <size>0.35 1.169 0.018</size>
           </box>
         </geometry>
-        <name>12</name>
       </collision>
       <visual name="12">
         <geometry>
@@ -272,10 +238,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>12</name>
       </visual>
       <pose>-0.042 0 1.754 0 0 0</pose>
-      <name>12</name>
     </link>
     <link name="13">
       <collision name="13">
@@ -284,7 +248,6 @@
             <size>0.35 0.036 0.482</size>
           </box>
         </geometry>
-        <name>13</name>
       </collision>
       <visual name="13">
         <geometry>
@@ -295,10 +258,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>13</name>
       </visual>
       <pose>-0.042 0 1.76 0 0 0</pose>
-      <name>13</name>
     </link>
     <link name="14">
       <collision name="14">
@@ -307,7 +268,6 @@
             <size>0.018 1.2 1.0</size>
           </box>
         </geometry>
-        <name>14</name>
       </collision>
       <visual name="14">
         <geometry>
@@ -318,10 +278,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>14</name>
       </visual>
       <pose>0.365 0.0 0.50 0 0 0</pose>
-      <name>14</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
@@ -331,9 +289,7 @@
           </box>
         </geometry>
         <pose>1.3 0.0 0.005 0 0 0</pose>
-        <name>in_front_of</name>
       </virtual_volume>
-      <name>in_front_of</name>
     </link>
     <link name="on_top_of">
       <virtual_volume name="on_top_of">
@@ -343,11 +299,8 @@
           </box>
         </geometry>
         <pose>0.078 0.0 1.19 0 0 0</pose>
-        <name>on_top_of</name>
       </virtual_volume>
-      <name>on_top_of</name>
     </link>
     <static>true</static>
-    <name>rgo2019/kitchen_counter</name>
   </model>
 </sdf>

--- a/models/rgo2019/kitchentable/model.sdf
+++ b/models/rgo2019/kitchentable/model.sdf
@@ -8,7 +8,6 @@
             <size>1.8 0.8 0.5</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -16,10 +15,8 @@
             <size>1.8 0.8 0.5</size>
           </box>
         </geometry>
-        <name>1</name>
       </visual>
       <pose>0.0 0.0 0.49 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="2">
       <collision name="2">
@@ -28,7 +25,6 @@
             <size>0.06 0.06 0.24</size>
           </box>
         </geometry>
-        <name>2</name>
       </collision>
       <visual name="2">
         <geometry>
@@ -36,10 +32,8 @@
             <size>0.06 0.06 0.24</size>
           </box>
         </geometry>
-        <name>2</name>
       </visual>
       <pose>-0.51 -0.27 0.12 0 0 0</pose>
-      <name>2</name>
     </link>
     <link name="3">
       <collision name="3">
@@ -48,7 +42,6 @@
             <size>0.06 0.06 0.24</size>
           </box>
         </geometry>
-        <name>3</name>
       </collision>
       <visual name="3">
         <geometry>
@@ -56,10 +49,8 @@
             <size>0.06 0.06 0.24</size>
           </box>
         </geometry>
-        <name>3</name>
       </visual>
       <pose>0.51 -0.27 0.12 0 0 0</pose>
-      <name>3</name>
     </link>
     <link name="4">
       <collision name="4">
@@ -68,7 +59,6 @@
             <size>0.06 0.06 0.24</size>
           </box>
         </geometry>
-        <name>4</name>
       </collision>
       <visual name="4">
         <geometry>
@@ -76,10 +66,8 @@
             <size>0.06 0.06 0.24</size>
           </box>
         </geometry>
-        <name>4</name>
       </visual>
       <pose>-0.51 0.27 0.12 0 0 0</pose>
-      <name>4</name>
     </link>
     <link name="5">
       <collision name="5">
@@ -88,7 +76,6 @@
             <size>0.06 0.06 0.24</size>
           </box>
         </geometry>
-        <name>5</name>
       </collision>
       <visual name="5">
         <geometry>
@@ -96,10 +83,8 @@
             <size>0.06 0.06 0.24</size>
           </box>
         </geometry>
-        <name>5</name>
       </visual>
       <pose>0.51 0.27 0.12 0 0 0</pose>
-      <name>5</name>
     </link>
     <link name="on_top_of">
       <virtual_volume name="on_top_of">
@@ -109,9 +94,7 @@
           </box>
         </geometry>
         <pose>0.0 0.0 0.885 0 0 0</pose>
-        <name>on_top_of</name>
       </virtual_volume>
-      <name>on_top_of</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
@@ -121,11 +104,8 @@
           </box>
         </geometry>
         <pose>1.4 0.0 0.005 0 0 0</pose>
-        <name>in_front_of</name>
       </virtual_volume>
-      <name>in_front_of</name>
     </link>
     <static>true</static>
-    <name>rgo2019/kitchentable</name>
   </model>
 </sdf>

--- a/models/rgo2019/model.sdf
+++ b/models/rgo2019/model.sdf
@@ -4,7 +4,6 @@
     <light name="sun" type="directional">
       <direction>0.5 0.1 -0.9</direction>
       <pose>0 0 10 0 0 0</pose>
-      <name>sun</name>
       <specular>0.2 0.2 0.2 1</specular>
       <cast_shadows>true</cast_shadows>
       <diffuse>0.8 0.8 0.8 1</diffuse>
@@ -18,67 +17,54 @@
     <model name="initial_pose" type="waypoint">
       <pose>-0.4 0.0 0 0 0 0</pose>
       <static>true</static>
-      <name>initial_pose</name>
     </model>
     <model name="registration_table1" type="waypoint">
       <pose>6.5 -1.0 0 0 0 -0.8</pose>
       <static>true</static>
-      <name>registration_table1</name>
     </model>
     <model name="registration_table2" type="waypoint">
       <pose>6.0 -0.5 0 0 0 -0.4</pose>
       <static>true</static>
-      <name>registration_table2</name>
     </model>
     <model name="registration_table3" type="waypoint">
       <pose>5.0 -0.5 0 0 0 0</pose>
       <static>true</static>
-      <name>registration_table3</name>
     </model>
     <model name="exit_1_rips" type="waypoint">
       <pose>6.95 -6.75 0 0 0 -1.571</pose>
       <static>true</static>
-      <name>exit_1_rips</name>
     </model>
     <model name="exit_2_rips" type="waypoint">
       <pose>6.95 -6.15 0 0 0 -1.571</pose>
       <static>true</static>
-      <name>exit_2_rips</name>
     </model>
     <model name="exit_3_rips" type="waypoint">
       <pose>6.95 -5.65 0 0 0 -1.571</pose>
       <static>true</static>
-      <name>exit_3_rips</name>
     </model>
     <model name="find_my_mates_initial" type="waypoint">
       <pose>4.0 -0.5 0 0 0 0.0</pose>
       <static>true</static>
-      <name>find_my_mates_initial</name>
     </model>
     <model name="find_my_mates_1" type="waypoint">
       <pose>7.5 0.4 0 0 0 -1.571</pose>
       <static>true</static>
-      <name>find_my_mates_1</name>
     </model>
     <model name="serving_drinks_initial" type="waypoint">
       <pose>2.5 -0.5 0 0 0 0.0</pose>
       <static>true</static>
-      <name>serving_drinks_initial</name>
     </model>
     <model name="cleanup_initial" type="waypoint">
       <pose>2.5 -0.5 0 0 0 0.0</pose>
       <static>true</static>
-      <name>cleanup_initial</name>
     </model>
     <model name="receptionist_initial" type="waypoint">
       <pose>1.5 -0.5 0 0 0 -1.571</pose>
       <static>true</static>
-      <name>receptionist_initial</name>
     </model>
     <model name="gpsr_meeting_point" type="waypoint">
       <pose>7.5 -2.5 0 0 0 0</pose>
       <static>true</static>
-      <name>gpsr_meeting_point</name>
     </model>
     <model name="hallway" type="room">
       <link name="in">
@@ -89,13 +75,10 @@
             </box>
           </geometry>
           <pose>0.0 0.025 1.0 0 0 0</pose>
-          <name>in</name>
         </virtual_volume>
-        <name>in</name>
       </link>
       <pose>2.05 -0.5 0 0 0 0</pose>
       <static>true</static>
-      <name>hallway</name>
     </model>
     <model name="bedroom" type="room">
       <link name="in">
@@ -106,13 +89,10 @@
             </box>
           </geometry>
           <pose>-0.1 0.075 1.0 0 0 0</pose>
-          <name>in</name>
         </virtual_volume>
-        <name>in</name>
       </link>
       <pose>2.6 2.5 0 0 0 0</pose>
       <static>true</static>
-      <name>bedroom</name>
     </model>
     <model name="living_room" type="room">
       <link name="in">
@@ -123,13 +103,10 @@
             </box>
           </geometry>
           <pose>0.01 0.525 1.0 0 0 0</pose>
-          <name>in</name>
         </virtual_volume>
-        <name>in</name>
       </link>
       <pose>7.0 -3.0 0 0 0 0</pose>
       <static>true</static>
-      <name>living_room</name>
     </model>
     <model name="kitchen" type="room">
       <link name="in">
@@ -140,13 +117,10 @@
             </box>
           </geometry>
           <pose>-0.065 0.075 1.0 0 0 0</pose>
-          <name>in</name>
         </virtual_volume>
-        <name>in</name>
       </link>
       <pose>7.55 2.5 0 0 0 0</pose>
       <static>true</static>
-      <name>kitchen</name>
     </model>
     <model name="bar" type="room">
       <link name="in">
@@ -157,145 +131,142 @@
             </box>
           </geometry>
           <pose>0.025 0.025 1.0 0 0 0</pose>
-          <name>in</name>
         </virtual_volume>
-        <name>in</name>
       </link>
       <pose>2.0 -3.5 0 0 0 0</pose>
       <static>true</static>
-      <name>bar</name>
     </model>
-    <include name="floor">
+    <include>
       <pose>0 0 0 0 0 0</pose>
       <name>floor</name>
       <uri>model://floor</uri>
     </include>
-    <include name="walls">
+    <include>
       <pose>0 0 0 0 0 0</pose>
       <name>walls</name>
       <uri>model://rgo2019/walls</uri>
     </include>
-    <include name="bed">
+    <include>
       <pose>1.1 3.07 0 0 0 -1.571</pose>
       <name>bed</name>
       <uri>model://rgo2019/bed_frame</uri>
     </include>
-    <include name="side_table">
+    <include>
       <pose>0.315 2.285 0 0 0 0</pose>
       <name>side_table</name>
       <uri>model://rgo2019/sidetable</uri>
     </include>
-    <include name="desk">
+    <include>
       <pose>3.26 4.15 0 0 0 3.141592</pose>
       <name>desk</name>
       <uri>model://rgo2019/desk</uri>
     </include>
-    <include name="couch">
+    <include>
       <pose>8.9 -4.2 0 0 0 2.4</pose>
       <name>couch</name>
       <uri>model://rgo2019/couch</uri>
     </include>
-    <include name="right_armchair">
+    <include>
       <pose>8.78 -2.73 0 0 0 0.75</pose>
       <name>right_armchair</name>
       <uri>model://rgo2019/armchair</uri>
     </include>
-    <include name="side_table">
+    <include>
       <pose>0.315 2.285 0 0 0 0</pose>
       <name>side_table</name>
       <uri>model://rgo2019/sidetable</uri>
     </include>
-    <include name="bookcase">
+    <include>
       <pose>4.54 0.39 0 0 0 -1.571</pose>
       <name>bookcase</name>
       <uri>model://rgo2018/bookcase</uri>
     </include>
-    <include name="tv">
+    <include>
       <pose>4.4 -3.45 0 0 0 0</pose>
       <name>tv</name>
       <uri>model://rgo2019/tv</uri>
     </include>
-    <include name="trash_bin">
+    <include>
       <pose>4.45 -5.1 0 0 0 0</pose>
       <name>trash_bin</name>
       <uri>model://rgo2019/trashbin_small</uri>
     </include>
-    <include name="coffee_table">
+    <include>
       <pose>8.1 -3.5 0 0 0 2.321</pose>
       <name>coffee_table</name>
       <uri>model://rgo2018/table_salon</uri>
     </include>
-    <include name="tv_table">
+    <include>
       <pose>4.35 -4.5 0 0 0 0.0</pose>
       <name>tv_table</name>
       <uri>model://rgo2018/table_salon</uri>
     </include>
-    <include name="sideboard">
+    <include>
       <pose>4.35 -2.0 0 0 0 0.0</pose>
       <name>sideboard</name>
       <uri>model://rgo2018/table_salon</uri>
     </include>
-    <include name="left_armchair">
+    <include>
       <pose>7.5 -4.2 0 0 0 -2.321</pose>
       <name>left_armchair</name>
       <uri>model://rgo2019/armchair</uri>
     </include>
-    <include name="high_table">
+    <include>
       <pose>9.0 -0.39 0 0 0 -1.571</pose>
       <name>high_table</name>
       <uri>model://rgo2017/table_party</uri>
     </include>
-    <include name="coathanger">
+    <include>
       <pose>6.0 -5.2 0 0 0 1.571</pose>
       <name>coathanger</name>
       <uri>model://rgo2019/coathanger</uri>
     </include>
-    <include name="kitchen_table">
+    <include>
       <pose>7.92 2.45 0 0 0 3.141592</pose>
       <name>kitchen_table</name>
       <uri>model://rgo2019/kitchentable</uri>
     </include>
-    <include name="kitchen_cabinet">
+    <include>
       <pose>5.63 4.21 0 0 0 -1.571</pose>
       <name>kitchen_cabinet</name>
       <uri>model://rgo2019/kitchen_counter</uri>
     </include>
-    <include name="trash_can">
+    <include>
       <pose>5.41 1.0 0 0 0 0</pose>
       <name>trash_can</name>
       <uri>model://rgo2019/trashbin_large</uri>
     </include>
-    <include name="dishwasher">
+    <include>
       <pose>6.55 4.21 0 0 0 -1.571</pose>
       <name>dishwasher</name>
       <uri>model://rgo2019/dishwasher</uri>
     </include>
-    <include name="white_drawer">
+    <include>
       <pose>9.79 1.25 0 0 0 -3.141592</pose>
       <name>white_drawer</name>
       <uri>model://rgo2019/white_drawer</uri>
     </include>
-    <include name="cabinet">
+    <include>
       <pose>9.79 3.5 0 0 0 3.141592</pose>
       <name>cabinet</name>
       <uri>model://rgo2019/cabinet</uri>
     </include>
-    <include name="cupboard">
+    <include>
       <pose>0.18 -2.05 0 0 0 0</pose>
       <name>cupboard</name>
       <uri>model://rgo2018/bookcase</uri>
     </include>
-    <include name="sofa">
+    <include>
       <pose>0.74 -3.5 0 0 0 3.141592</pose>
       <name>sofa</name>
       <uri>model://rgo2019/armchair</uri>
     </include>
-    <include name="bar_table">
+    <include>
       <pose>2.54 -4.0 0 0 0 1.571</pose>
       <name>bar_table</name>
       <uri>model://rgo2017/table_party</uri>
     </include>
-    <include name="drop_area">
+    <include>
       <pose>0.5 -1.0 0 0 0 0</pose>
       <name>drop_area</name>
       <uri>model://rgo2019/drop_area</uri>
@@ -312,6 +283,5 @@
         </solver>
       </ode>
     </physics>
-    <name>rgo2019</name>
   </world>
 </sdf>

--- a/models/rgo2019/sidetable/model.sdf
+++ b/models/rgo2019/sidetable/model.sdf
@@ -8,7 +8,6 @@
             <size>0.55 0.55 0.05</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -16,10 +15,8 @@
             <size>0.55 0.55 0.05</size>
           </box>
         </geometry>
-        <name>1</name>
       </visual>
       <pose>0.0 0.0 0.425 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="2">
       <collision name="2">
@@ -28,7 +25,6 @@
             <size>0.05 0.05 0.4</size>
           </box>
         </geometry>
-        <name>2</name>
       </collision>
       <visual name="2">
         <geometry>
@@ -36,10 +32,8 @@
             <size>0.05 0.05 0.4</size>
           </box>
         </geometry>
-        <name>2</name>
       </visual>
       <pose>-0.25 -0.25 0.2 0 0 0</pose>
-      <name>2</name>
     </link>
     <link name="3">
       <collision name="3">
@@ -48,7 +42,6 @@
             <size>0.05 0.05 0.4</size>
           </box>
         </geometry>
-        <name>3</name>
       </collision>
       <visual name="3">
         <geometry>
@@ -56,10 +49,8 @@
             <size>0.05 0.05 0.4</size>
           </box>
         </geometry>
-        <name>3</name>
       </visual>
       <pose>0.25 -0.25 0.2 0 0 0</pose>
-      <name>3</name>
     </link>
     <link name="4">
       <collision name="4">
@@ -68,7 +59,6 @@
             <size>0.05 0.05 0.4</size>
           </box>
         </geometry>
-        <name>4</name>
       </collision>
       <visual name="4">
         <geometry>
@@ -76,10 +66,8 @@
             <size>0.05 0.05 0.4</size>
           </box>
         </geometry>
-        <name>4</name>
       </visual>
       <pose>-0.25 0.25 0.2 0 0 0</pose>
-      <name>4</name>
     </link>
     <link name="5">
       <collision name="5">
@@ -88,7 +76,6 @@
             <size>0.05 0.05 0.4</size>
           </box>
         </geometry>
-        <name>5</name>
       </collision>
       <visual name="5">
         <geometry>
@@ -96,10 +83,8 @@
             <size>0.05 0.05 0.4</size>
           </box>
         </geometry>
-        <name>5</name>
       </visual>
       <pose>0.25 0.25 0.2 0 0 0</pose>
-      <name>5</name>
     </link>
     <link name="on_top_of">
       <virtual_volume name="on_top_of">
@@ -109,9 +94,7 @@
           </box>
         </geometry>
         <pose>0.0 0.0 0.595 0 0 0</pose>
-        <name>on_top_of</name>
       </virtual_volume>
-      <name>on_top_of</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
@@ -121,11 +104,8 @@
           </box>
         </geometry>
         <pose>0.75 0.0 0.005 0 0 0</pose>
-        <name>in_front_of</name>
       </virtual_volume>
-      <name>in_front_of</name>
     </link>
     <static>true</static>
-    <name>rgo2019/sidetable</name>
   </model>
 </sdf>

--- a/models/rgo2019/table_party/model.sdf
+++ b/models/rgo2019/table_party/model.sdf
@@ -9,7 +9,6 @@
             <radius>0.4</radius>
           </cylinder>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -18,10 +17,8 @@
             <radius>0.4</radius>
           </cylinder>
         </geometry>
-        <name>1</name>
       </visual>
       <pose>0 0 1.085 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="2">
       <collision name="2">
@@ -31,7 +28,6 @@
             <radius>0.0725</radius>
           </cylinder>
         </geometry>
-        <name>2</name>
       </collision>
       <visual name="2">
         <geometry>
@@ -40,10 +36,8 @@
             <radius>0.0725</radius>
           </cylinder>
         </geometry>
-        <name>2</name>
       </visual>
       <pose>0 0 0.54 0 0 0</pose>
-      <name>2</name>
     </link>
     <link name="3">
       <collision name="3">
@@ -52,7 +46,6 @@
             <size>0.775 0.035 0.045</size>
           </box>
         </geometry>
-        <name>3</name>
       </collision>
       <visual name="3">
         <geometry>
@@ -60,10 +53,8 @@
             <size>0.775 0.035 0.045</size>
           </box>
         </geometry>
-        <name>3</name>
       </visual>
       <pose>0 0 0.0225 0 0 0</pose>
-      <name>3</name>
     </link>
     <link name="4">
       <collision name="4">
@@ -72,7 +63,6 @@
             <size>0.035 0.775 0.045</size>
           </box>
         </geometry>
-        <name>4</name>
       </collision>
       <visual name="4">
         <geometry>
@@ -80,10 +70,8 @@
             <size>0.035 0.775 0.045</size>
           </box>
         </geometry>
-        <name>4</name>
       </visual>
       <pose>0 0 0.0225 0 0 0</pose>
-      <name>4</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
@@ -93,9 +81,7 @@
           </box>
         </geometry>
         <pose>0.775 0.0 0.005 0 0 0</pose>
-        <name>in_front_of</name>
       </virtual_volume>
-      <name>in_front_of</name>
     </link>
     <link name="on_top_of">
       <virtual_volume name="on_top_of">
@@ -105,11 +91,8 @@
           </box>
         </geometry>
         <pose>0.0 0.0 1.195 0 0 0</pose>
-        <name>on_top_of</name>
       </virtual_volume>
-      <name>on_top_of</name>
     </link>
     <static>true</static>
-    <name>rgo2019/table_party</name>
   </model>
 </sdf>

--- a/models/rgo2019/trashbin_large/model.sdf
+++ b/models/rgo2019/trashbin_large/model.sdf
@@ -9,7 +9,6 @@
             <radius>0.195</radius>
           </cylinder>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -18,10 +17,8 @@
             <radius>0.195</radius>
           </cylinder>
         </geometry>
-        <name>1</name>
       </visual>
       <pose>0 0 0.225 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="on_top_of">
       <virtual_volume name="on_top_of">
@@ -31,10 +28,8 @@
             <radius>0.19</radius>
           </cylinder>
         </geometry>
-        <name>on_top_of</name>
       </virtual_volume>
       <pose>0 0 0.585 0 0 0</pose>
-      <name>on_top_of</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
@@ -43,12 +38,9 @@
             <size>1.0 1.0 0.01</size>
           </box>
         </geometry>
-        <name>in_front_of</name>
       </virtual_volume>
       <pose>0 0 0 0 0 0</pose>
-      <name>in_front_of</name>
     </link>
     <static>true</static>
-    <name>rgo2019/trashbin_large</name>
   </model>
 </sdf>

--- a/models/rgo2019/trashbin_small/model.sdf
+++ b/models/rgo2019/trashbin_small/model.sdf
@@ -9,7 +9,6 @@
             <radius>0.1575</radius>
           </cylinder>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -18,10 +17,8 @@
             <radius>0.1575</radius>
           </cylinder>
         </geometry>
-        <name>1</name>
       </visual>
       <pose>0 0 0.1475 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="on_top_of">
       <virtual_volume name="on_top_of">
@@ -31,10 +28,8 @@
             <radius>0.15</radius>
           </cylinder>
         </geometry>
-        <name>on_top_of</name>
       </virtual_volume>
       <pose>0 0 0.435 0 0 0</pose>
-      <name>on_top_of</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
@@ -43,12 +38,9 @@
             <size>0.05 0.05 0.01</size>
           </box>
         </geometry>
-        <name>in_front_of</name>
       </virtual_volume>
       <pose>0.6 0 0 0 0 0</pose>
-      <name>in_front_of</name>
     </link>
     <static>true</static>
-    <name>rgo2019/trashbin_small</name>
   </model>
 </sdf>

--- a/models/rgo2019/tv/model.sdf
+++ b/models/rgo2019/tv/model.sdf
@@ -8,7 +8,6 @@
             <size>0.54 0.9 0.03</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -16,10 +15,8 @@
             <size>0.54 0.9 0.03</size>
           </box>
         </geometry>
-        <name>1</name>
       </visual>
       <pose>0 0 0.015 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="2">
       <collision name="2">
@@ -28,7 +25,6 @@
             <size>0.1 0.06 1.8</size>
           </box>
         </geometry>
-        <name>2</name>
       </collision>
       <visual name="2">
         <geometry>
@@ -36,10 +32,8 @@
             <size>0.1 0.06 1.8</size>
           </box>
         </geometry>
-        <name>2</name>
       </visual>
       <pose>-0.11 -0.085 0.9 0 0 0</pose>
-      <name>2</name>
     </link>
     <link name="3">
       <collision name="3">
@@ -48,7 +42,6 @@
             <size>0.1 0.06 1.8</size>
           </box>
         </geometry>
-        <name>3</name>
       </collision>
       <visual name="3">
         <geometry>
@@ -56,10 +49,8 @@
             <size>0.1 0.06 1.8</size>
           </box>
         </geometry>
-        <name>3</name>
       </visual>
       <pose>-0.11 0.085 0.9 0 0 0</pose>
-      <name>3</name>
     </link>
     <link name="4">
       <collision name="4">
@@ -68,7 +59,6 @@
             <size>0.1 1.55 0.82</size>
           </box>
         </geometry>
-        <name>4</name>
       </collision>
       <visual name="4">
         <geometry>
@@ -76,10 +66,8 @@
             <size>0.1 1.55 0.82</size>
           </box>
         </geometry>
-        <name>4</name>
       </visual>
       <pose>0.06 0.0 1.67 0 0.04 0</pose>
-      <name>4</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
@@ -89,11 +77,8 @@
           </box>
         </geometry>
         <pose>0.6 0.0 0.005 0 0 0</pose>
-        <name>in_front_of</name>
       </virtual_volume>
-      <name>in_front_of</name>
     </link>
     <static>true</static>
-    <name>rgo2019/tv</name>
   </model>
 </sdf>

--- a/models/rgo2019/walls/model.sdf
+++ b/models/rgo2019/walls/model.sdf
@@ -8,7 +8,6 @@
             <uri>model://rgo2019/walls/shape/heightmap.stl</uri>
           </mesh>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -16,12 +15,9 @@
             <uri>model://rgo2019/walls/shape/heightmap.stl</uri>
           </mesh>
         </geometry>
-        <name>1</name>
       </visual>
       <pose>0 0 0 0 0 0</pose>
-      <name>1</name>
     </link>
     <static>true</static>
-    <name>rgo2019/walls</name>
   </model>
 </sdf>

--- a/models/rgo2019/white_drawer/model.sdf
+++ b/models/rgo2019/white_drawer/model.sdf
@@ -8,7 +8,6 @@
             <size>0.3 0.35 0.43</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -16,10 +15,8 @@
             <size>0.3 0.35 0.43</size>
           </box>
         </geometry>
-        <name>1</name>
       </visual>
       <pose>0.0 0.0 0.345 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="2">
       <collision name="2">
@@ -28,7 +25,6 @@
             <size>0.015 0.015 0.13</size>
           </box>
         </geometry>
-        <name>2</name>
       </collision>
       <visual name="2">
         <geometry>
@@ -36,10 +32,8 @@
             <size>0.015 0.015 0.13</size>
           </box>
         </geometry>
-        <name>2</name>
       </visual>
       <pose>-0.1425 -0.1675 0.065 0 0 0</pose>
-      <name>2</name>
     </link>
     <link name="3">
       <collision name="3">
@@ -48,7 +42,6 @@
             <size>0.015 0.015 0.13</size>
           </box>
         </geometry>
-        <name>3</name>
       </collision>
       <visual name="3">
         <geometry>
@@ -56,10 +49,8 @@
             <size>0.015 0.015 0.13</size>
           </box>
         </geometry>
-        <name>3</name>
       </visual>
       <pose>0.1425 -0.1675 0.065 0 0 0</pose>
-      <name>3</name>
     </link>
     <link name="4">
       <collision name="4">
@@ -68,7 +59,6 @@
             <size>0.015 0.015 0.13</size>
           </box>
         </geometry>
-        <name>4</name>
       </collision>
       <visual name="4">
         <geometry>
@@ -76,10 +66,8 @@
             <size>0.015 0.015 0.13</size>
           </box>
         </geometry>
-        <name>4</name>
       </visual>
       <pose>-0.1425 0.1675 0.065 0 0 0</pose>
-      <name>4</name>
     </link>
     <link name="5">
       <collision name="5">
@@ -88,7 +76,6 @@
             <size>0.015 0.015 0.13</size>
           </box>
         </geometry>
-        <name>5</name>
       </collision>
       <visual name="5">
         <geometry>
@@ -96,10 +83,8 @@
             <size>0.015 0.015 0.13</size>
           </box>
         </geometry>
-        <name>5</name>
       </visual>
       <pose>0.1425 0.1675 0.065 0 0 0</pose>
-      <name>5</name>
     </link>
     <link name="on_top_of">
       <virtual_volume name="on_top_of">
@@ -109,9 +94,7 @@
           </box>
         </geometry>
         <pose>0.0 0.0 0.705 0 0 0</pose>
-        <name>on_top_of</name>
       </virtual_volume>
-      <name>on_top_of</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
@@ -121,11 +104,8 @@
           </box>
         </geometry>
         <pose>0.65 0.0 0.005 0 0 0</pose>
-        <name>in_front_of</name>
       </virtual_volume>
-      <name>in_front_of</name>
     </link>
     <static>true</static>
-    <name>rgo2019/white_drawer</name>
   </model>
 </sdf>

--- a/models/right_door/model.sdf
+++ b/models/right_door/model.sdf
@@ -2,6 +2,5 @@
 <sdf version="1.6">
   <model name="right_door">
     <static>true</static>
-    <name>right_door</name>
   </model>
 </sdf>

--- a/models/robotics_testlab_B/bed/model.sdf
+++ b/models/robotics_testlab_B/bed/model.sdf
@@ -8,7 +8,6 @@
             <size>2.1 0.9 0.2</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -19,10 +18,8 @@
         <material>
           <ambient>0.7 0.7 0.5 1</ambient>
         </material>
-        <name>1</name>
       </visual>
       <pose>0.0 0.0 0.6 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="2">
       <collision name="2">
@@ -31,7 +28,6 @@
             <size>1.42 0.65 0.28</size>
           </box>
         </geometry>
-        <name>2</name>
       </collision>
       <visual name="2">
         <geometry>
@@ -42,10 +38,8 @@
         <material>
           <ambient>0.7 0.7 0.5 1</ambient>
         </material>
-        <name>2</name>
       </visual>
       <pose>0.0 0.0 0.14 0 0 0</pose>
-      <name>2</name>
     </link>
     <link name="3">
       <collision name="3">
@@ -54,7 +48,6 @@
             <size>0.06 1.0 0.45</size>
           </box>
         </geometry>
-        <name>3</name>
       </collision>
       <visual name="3">
         <geometry>
@@ -65,10 +58,8 @@
         <material>
           <ambient>0.7 0.7 0.5 1</ambient>
         </material>
-        <name>3</name>
       </visual>
       <pose>1.08 0.0 0.7 0 0 0</pose>
-      <name>3</name>
     </link>
     <link name="4">
       <collision name="4">
@@ -77,7 +68,6 @@
             <size>0.06 1.0 0.45</size>
           </box>
         </geometry>
-        <name>4</name>
       </collision>
       <visual name="4">
         <geometry>
@@ -88,10 +78,8 @@
         <material>
           <ambient>0.7 0.7 0.5 1</ambient>
         </material>
-        <name>4</name>
       </visual>
       <pose>-1.08 0.0 0.7 0 0 0</pose>
-      <name>4</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
@@ -101,11 +89,8 @@
           </box>
         </geometry>
         <pose>0.0 -0.9 0.005 0 0 0</pose>
-        <name>in_front_of</name>
       </virtual_volume>
-      <name>in_front_of</name>
     </link>
     <static>true</static>
-    <name>robotics_testlab_B/bed</name>
   </model>
 </sdf>

--- a/models/robotics_testlab_B/bed_cabinet/model.sdf
+++ b/models/robotics_testlab_B/bed_cabinet/model.sdf
@@ -8,7 +8,6 @@
             <size>0.48 0.48 0.73</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -16,12 +15,9 @@
             <size>0.48 0.48 0.73</size>
           </box>
         </geometry>
-        <name>1</name>
       </visual>
       <pose>0 0 0.365 0 0 0</pose>
-      <name>1</name>
     </link>
     <static>true</static>
-    <name>robotics_testlab_B/bed_cabinet</name>
   </model>
 </sdf>

--- a/models/robotics_testlab_B/black_cabinet/model.sdf
+++ b/models/robotics_testlab_B/black_cabinet/model.sdf
@@ -8,7 +8,6 @@
             <size>0.42 0.92 1.0</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -16,10 +15,8 @@
             <size>0.42 0.92 1.0</size>
           </box>
         </geometry>
-        <name>1</name>
       </visual>
       <pose>0 0 0.5 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
@@ -29,11 +26,8 @@
           </box>
         </geometry>
         <pose>0.6 0.0 0.005 0 0 0</pose>
-        <name>in_front_of</name>
       </virtual_volume>
-      <name>in_front_of</name>
     </link>
     <static>true</static>
-    <name>robotics_testlab_B/black_cabinet</name>
   </model>
 </sdf>

--- a/models/robotics_testlab_B/corridor_cabinet/model.sdf
+++ b/models/robotics_testlab_B/corridor_cabinet/model.sdf
@@ -8,7 +8,6 @@
             <size>0.395 0.05 0.79</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -19,10 +18,8 @@
         <material>
           <ambient>0.1 0.1 0.1 1</ambient>
         </material>
-        <name>1</name>
       </visual>
       <pose>0 -0.37 0.395 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="2">
       <collision name="2">
@@ -31,7 +28,6 @@
             <size>0.395 0.05 0.79</size>
           </box>
         </geometry>
-        <name>2</name>
       </collision>
       <visual name="2">
         <geometry>
@@ -42,10 +38,8 @@
         <material>
           <ambient>0.1 0.1 0.1 1</ambient>
         </material>
-        <name>2</name>
       </visual>
       <pose>0 0.37 0.395 0 0 0</pose>
-      <name>2</name>
     </link>
     <link name="3">
       <collision name="3">
@@ -54,7 +48,6 @@
             <size>0.395 0.69 0.05</size>
           </box>
         </geometry>
-        <name>3</name>
       </collision>
       <visual name="3">
         <geometry>
@@ -65,10 +58,8 @@
         <material>
           <ambient>0.1 0.1 0.1 1</ambient>
         </material>
-        <name>3</name>
       </visual>
       <pose>0 0 0.765 0 0 0</pose>
-      <name>3</name>
     </link>
     <link name="4">
       <collision name="4">
@@ -77,7 +68,6 @@
             <size>0.395 0.69 0.05</size>
           </box>
         </geometry>
-        <name>4</name>
       </collision>
       <visual name="4">
         <geometry>
@@ -88,10 +78,8 @@
         <material>
           <ambient>0.1 0.1 0.1 1</ambient>
         </material>
-        <name>4</name>
       </visual>
       <pose>0 0 0.025 0 0 0</pose>
-      <name>4</name>
     </link>
     <link name="5">
       <collision name="5">
@@ -100,7 +88,6 @@
             <size>0.395 0.69 0.02</size>
           </box>
         </geometry>
-        <name>5</name>
       </collision>
       <visual name="5">
         <geometry>
@@ -111,10 +98,8 @@
         <material>
           <ambient>0.1 0.1 0.1 1</ambient>
         </material>
-        <name>5</name>
       </visual>
       <pose>0 0 0.395 0 0 0</pose>
-      <name>5</name>
     </link>
     <link name="6">
       <collision name="6">
@@ -123,7 +108,6 @@
             <size>0.395 0.02 0.69</size>
           </box>
         </geometry>
-        <name>6</name>
       </collision>
       <visual name="6">
         <geometry>
@@ -134,10 +118,8 @@
         <material>
           <ambient>0.1 0.1 0.1 1</ambient>
         </material>
-        <name>6</name>
       </visual>
       <pose>0 0 0.395 0 0 0</pose>
-      <name>6</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
@@ -147,9 +129,7 @@
           </box>
         </geometry>
         <pose>0.35 0.0 0.0 0 0 0</pose>
-        <name>in_front_of</name>
       </virtual_volume>
-      <name>in_front_of</name>
     </link>
     <link name="on_top_of">
       <virtual_volume name="on_top_of">
@@ -159,11 +139,8 @@
           </box>
         </geometry>
         <pose>0.0 0.0 1.005 0 0 0</pose>
-        <name>on_top_of</name>
       </virtual_volume>
-      <name>on_top_of</name>
     </link>
     <static>true</static>
-    <name>robotics_testlab_B/corridor_cabinet</name>
   </model>
 </sdf>

--- a/models/robotics_testlab_B/hallway_cabinet/model.sdf
+++ b/models/robotics_testlab_B/hallway_cabinet/model.sdf
@@ -9,7 +9,6 @@
           </box>
         </geometry>
         <pose>0.0 0.0 0.405 0 0 0</pose>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -18,10 +17,8 @@
           </box>
         </geometry>
         <pose>0.0 0.0 0.405 0 0 0</pose>
-        <name>1</name>
       </visual>
       <pose>0 0 0 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="on_top_of">
       <virtual_volume name="on_top_of">
@@ -31,11 +28,8 @@
           </box>
         </geometry>
         <pose>0.0 0.0 1.01 0 0 0</pose>
-        <name>on_top_of</name>
       </virtual_volume>
-      <name>on_top_of</name>
     </link>
     <static>true</static>
-    <name>robotics_testlab_B/hallway_cabinet</name>
   </model>
 </sdf>

--- a/models/robotics_testlab_B/model.sdf
+++ b/models/robotics_testlab_B/model.sdf
@@ -4,7 +4,6 @@
     <light name="sun" type="directional">
       <direction>0.5 0.1 -0.9</direction>
       <pose>0 0 10 0 0 0</pose>
-      <name>sun</name>
       <specular>0.2 0.2 0.2 1</specular>
       <cast_shadows>true</cast_shadows>
       <diffuse>0.8 0.8 0.8 1</diffuse>
@@ -18,184 +17,164 @@
     <model name="living_room" type="waypoint">
       <pose>4 0.7 0 0 0 0</pose>
       <static>true</static>
-      <name>living_room</name>
     </model>
     <model name="corridor" type="waypoint">
       <pose>0.5 1.5 0 0 0 0</pose>
       <static>true</static>
-      <name>corridor</name>
     </model>
     <model name="bedroom" type="waypoint">
       <pose>5.3 -2.4 0 0 0 0</pose>
       <static>true</static>
-      <name>bedroom</name>
     </model>
     <model name="test_person" type="waypoint">
       <pose>3.7 -0.448 0 0 0 0</pose>
       <static>true</static>
-      <name>test_person</name>
     </model>
     <model name="operator" type="waypoint">
       <pose>0.05 -2.445 0 0 0 0</pose>
       <static>true</static>
-      <name>operator</name>
     </model>
     <model name="wait" type="waypoint">
       <pose>2.638 1.951 0 0 0 0</pose>
       <static>true</static>
-      <name>wait</name>
     </model>
     <model name="initial_pose" type="waypoint">
       <pose>0.9 0 0 0 0 1.57</pose>
       <static>true</static>
-      <name>initial_pose</name>
     </model>
     <model name="exit" type="waypoint">
       <pose>5.269 -2.139 0 0 0 -1.57</pose>
       <static>true</static>
-      <name>exit</name>
     </model>
     <model name="registration_table1" type="waypoint">
       <pose>0 0 0 0 0 0</pose>
       <static>true</static>
-      <name>registration_table1</name>
     </model>
     <model name="registration_table2" type="waypoint">
       <pose>3.13 0.665 0 0 0 0</pose>
       <static>true</static>
-      <name>registration_table2</name>
     </model>
     <model name="registration_table3" type="waypoint">
       <pose>3.13 0.665 0 0 0 0</pose>
       <static>true</static>
-      <name>registration_table3</name>
     </model>
     <model name="exit_1_rips" type="waypoint">
       <pose>5 -2 0 0 0 0</pose>
       <static>true</static>
-      <name>exit_1_rips</name>
     </model>
     <model name="exit_2_rips" type="waypoint">
       <pose>5 -2 0 0 0 0</pose>
       <static>true</static>
-      <name>exit_2_rips</name>
     </model>
     <model name="exit_3_rips" type="waypoint">
       <pose>5 -2 0 0 0 0</pose>
       <static>true</static>
-      <name>exit_3_rips</name>
     </model>
     <model name="exit_4_rips" type="waypoint">
       <pose>5 -2 0 0 0 0</pose>
       <static>true</static>
-      <name>exit_4_rips</name>
     </model>
     <model name="avoid_that_start" type="waypoint">
       <pose>2.684 1.969 0 0 0 0</pose>
       <static>true</static>
-      <name>avoid_that_start</name>
     </model>
     <model name="avoid_that_wp1" type="waypoint">
       <pose>5.595 1.99 0 0 0 0</pose>
       <static>true</static>
-      <name>avoid_that_wp1</name>
     </model>
     <model name="avoid_that_wp2" type="waypoint">
       <pose>5.834 -0.498 0 0 0 0</pose>
       <static>true</static>
-      <name>avoid_that_wp2</name>
     </model>
     <model name="avoid_that_wp3" type="waypoint">
       <pose>5.595 1.99 0 0 0 0</pose>
       <static>true</static>
-      <name>avoid_that_wp3</name>
     </model>
     <model name="what_did_you_say_start" type="waypoint">
       <pose>5.834 -0.498 0 0 0 0</pose>
       <static>true</static>
-      <name>what_did_you_say_start</name>
     </model>
-    <include name="walls">
+    <include>
       <pose>0 0 0 0 0 0</pose>
       <name>walls</name>
       <uri>model://robotics_testlab_B/walls</uri>
     </include>
-    <include name="floor">
+    <include>
       <pose>0 0 0 0 0 0</pose>
       <name>floor</name>
       <uri>model://floor</uri>
     </include>
-    <include name="pico_case">
+    <include>
       <pose>4.05 2 0 0 0 0</pose>
       <name>pico_case</name>
       <uri>model://robotics_testlab_B/pico_case</uri>
     </include>
-    <include name="black_cabinet1">
+    <include>
       <pose>6.6 2.2 0 0 0 0</pose>
       <name>black_cabinet1</name>
       <uri>model://robotics_testlab_B/black_cabinet</uri>
     </include>
-    <include name="black_cabinet2">
+    <include>
       <pose>6.6 1.27 0 0 0 0</pose>
       <name>black_cabinet2</name>
       <uri>model://robotics_testlab_B/black_cabinet</uri>
     </include>
-    <include name="black_cabinet3">
+    <include>
       <pose>6.6 0.34 0 0 0 0</pose>
       <name>black_cabinet3</name>
       <uri>model://robotics_testlab_B/black_cabinet</uri>
     </include>
-    <include name="black_cabinet4">
+    <include>
       <pose>6.6 -0.59 0 0 0 0</pose>
       <name>black_cabinet4</name>
       <uri>model://robotics_testlab_B/black_cabinet</uri>
     </include>
-    <include name="black_cabinet5">
+    <include>
       <pose>6.6 -1.77 0 0 0 0</pose>
       <name>black_cabinet5</name>
       <uri>model://robotics_testlab_B/black_cabinet</uri>
     </include>
-    <include name="hallway_cabinet">
+    <include>
       <pose>1.55 0.05 0 0 0 0</pose>
       <name>hallway_cabinet</name>
       <uri>model://robotics_testlab_B/hallway_cabinet</uri>
     </include>
-    <include name="corridor_cabinet">
+    <include>
       <pose>0.7 2.4 0 0 0 0</pose>
       <name>corridor_cabinet</name>
       <uri>model://robotics_testlab_B/corridor_cabinet</uri>
     </include>
-    <include name="bed_cabinet">
+    <include>
       <pose>6.6 -2.77 0 0 0 0</pose>
       <name>bed_cabinet</name>
       <uri>model://robotics_testlab_B/bed_cabinet</uri>
     </include>
-    <include name="bed">
+    <include>
       <pose>5.5 -4 0 0 0 0</pose>
       <name>bed</name>
       <uri>model://bed</uri>
     </include>
-    <include name="operator_table1">
+    <include>
       <pose>1.15 -2.752 0 0 0 1.57</pose>
       <name>operator_table1</name>
       <uri>model://table_120x80x76</uri>
     </include>
-    <include name="operator_table2">
+    <include>
       <pose>1.15 -3.958 0 0 0 1.57</pose>
       <name>operator_table2</name>
       <uri>model://table_120x80x76</uri>
     </include>
-    <include name="dinner_table">
+    <include>
       <pose>3.174 -0.523 0 0 0 1.57</pose>
       <name>dinner_table</name>
       <uri>model://table_120x80x76</uri>
     </include>
-    <include name="workbench">
+    <include>
       <pose>2.12 -3.01 0 0 0 1.57</pose>
       <name>workbench</name>
       <uri>model://table_120x80x76</uri>
     </include>
-    <include name="supply_table">
+    <include>
       <pose>2.16 -4.16 0 0 0 0</pose>
       <name>supply_table</name>
       <uri>model://table_120x80x76</uri>
@@ -212,6 +191,5 @@
         </solver>
       </ode>
     </physics>
-    <name>robotics_testlab_B</name>
   </world>
 </sdf>

--- a/models/robotics_testlab_B/pico_case/model.sdf
+++ b/models/robotics_testlab_B/pico_case/model.sdf
@@ -8,7 +8,6 @@
             <size>0.51 1.31 0.45</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -19,12 +18,9 @@
         <material>
           <ambient>0.05 0.05 0.05 1</ambient>
         </material>
-        <name>1</name>
       </visual>
       <pose>0 0 0.225 0 0 0</pose>
-      <name>1</name>
     </link>
     <static>true</static>
-    <name>robotics_testlab_B/pico_case</name>
   </model>
 </sdf>

--- a/models/robotics_testlab_B/plastic_cabinet.frame/model.sdf
+++ b/models/robotics_testlab_B/plastic_cabinet.frame/model.sdf
@@ -8,7 +8,6 @@
             <size>0.41 0.03 1.755</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -19,10 +18,8 @@
         <material>
           <ambient>0.6 0.6 0.6 1</ambient>
         </material>
-        <name>1</name>
       </visual>
       <pose>0 -0.325 0.8775 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="2">
       <collision name="2">
@@ -31,7 +28,6 @@
             <size>0.41 0.02 1.755</size>
           </box>
         </geometry>
-        <name>2</name>
       </collision>
       <visual name="2">
         <geometry>
@@ -42,10 +38,8 @@
         <material>
           <ambient>0.6 0.6 0.6 1</ambient>
         </material>
-        <name>2</name>
       </visual>
       <pose>0 0.325 0.8775 0 0 0</pose>
-      <name>2</name>
     </link>
     <link name="3">
       <collision name="3">
@@ -54,7 +48,6 @@
             <size>0.02 0.65 1.755</size>
           </box>
         </geometry>
-        <name>3</name>
       </collision>
       <visual name="3">
         <geometry>
@@ -65,12 +58,9 @@
         <material>
           <ambient>0.6 0.6 0.6 1</ambient>
         </material>
-        <name>3</name>
       </visual>
       <pose>0.205 0 0.8775 0 0 0</pose>
-      <name>3</name>
     </link>
     <static>true</static>
-    <name>robotics_testlab_B/plastic_cabinet.frame</name>
   </model>
 </sdf>

--- a/models/robotics_testlab_B/plastic_cabinet.shelf/model.sdf
+++ b/models/robotics_testlab_B/plastic_cabinet.shelf/model.sdf
@@ -8,7 +8,6 @@
             <size>0.39 0.65 0.04</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -19,10 +18,8 @@
         <material>
           <ambient>0.6 0.6 0.6 1</ambient>
         </material>
-        <name>1</name>
       </visual>
       <pose>0 0 0 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
@@ -32,9 +29,7 @@
           </box>
         </geometry>
         <pose>-0.91 0.0 0.88 0 0 0</pose>
-        <name>in_front_of</name>
       </virtual_volume>
-      <name>in_front_of</name>
     </link>
     <link name="in">
       <virtual_volume name="in">
@@ -44,9 +39,7 @@
           </box>
         </geometry>
         <pose>0.0 0.0 0.88 0 0 0</pose>
-        <name>in</name>
       </virtual_volume>
-      <name>in</name>
     </link>
     <link name="on_top_of">
       <virtual_volume name="on_top_of">
@@ -56,11 +49,8 @@
           </box>
         </geometry>
         <pose>-0.02 0.0 0.175 0 0 0</pose>
-        <name>on_top_of</name>
       </virtual_volume>
-      <name>on_top_of</name>
     </link>
     <static>true</static>
-    <name>robotics_testlab_B/plastic_cabinet.shelf</name>
   </model>
 </sdf>

--- a/models/robotics_testlab_B/plastic_cabinet/model.sdf
+++ b/models/robotics_testlab_B/plastic_cabinet/model.sdf
@@ -4,7 +4,6 @@
     <light name="sun" type="directional">
       <direction>0.5 0.1 -0.9</direction>
       <pose>0 0 10 0 0 0</pose>
-      <name>sun</name>
       <specular>0.2 0.2 0.2 1</specular>
       <cast_shadows>true</cast_shadows>
       <diffuse>0.8 0.8 0.8 1</diffuse>
@@ -15,37 +14,37 @@
         <linear>0.01</linear>
       </attenuation>
     </light>
-    <include name="frame">
+    <include>
       <pose>0 0 0 0 0 0</pose>
       <name>frame</name>
       <uri>model://robotics_testlab_B.plastic_cabinet.frame</uri>
     </include>
-    <include name="bottom">
+    <include>
       <pose>0 0 0 0 0 0</pose>
       <name>bottom</name>
       <uri>model://robotics_testlab_B.plastic_cabinet.shelf</uri>
     </include>
-    <include name="shelf1">
+    <include>
       <pose>0 0 0.35 0 0 0</pose>
       <name>shelf1</name>
       <uri>model://robotics_testlab_B.plastic_cabinet.shelf</uri>
     </include>
-    <include name="shelf2">
+    <include>
       <pose>0 0 0.7 0 0 0</pose>
       <name>shelf2</name>
       <uri>model://robotics_testlab_B.plastic_cabinet.shelf</uri>
     </include>
-    <include name="shelf3">
+    <include>
       <pose>0 0 1.055 0 0 0</pose>
       <name>shelf3</name>
       <uri>model://robotics_testlab_B.plastic_cabinet.shelf</uri>
     </include>
-    <include name="shelf4">
+    <include>
       <pose>0 0 1.41 0 0 0</pose>
       <name>shelf4</name>
       <uri>model://robotics_testlab_B.plastic_cabinet.shelf</uri>
     </include>
-    <include name="top">
+    <include>
       <pose>0 0 1.74 0 0 0</pose>
       <name>top</name>
       <uri>model://robotics_testlab_B.plastic_cabinet.shelf</uri>
@@ -62,6 +61,5 @@
         </solver>
       </ode>
     </physics>
-    <name>robotics_testlab_B/plastic_cabinet</name>
   </world>
 </sdf>

--- a/models/robotics_testlab_B/tubing/model.sdf
+++ b/models/robotics_testlab_B/tubing/model.sdf
@@ -8,7 +8,6 @@
             <size>1.8 0.36 0.36</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -19,10 +18,8 @@
         <material>
           <ambient>0.5 0.5 0.5 1</ambient>
         </material>
-        <name>1</name>
       </visual>
       <pose>0.0 0.0 1.04 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="2">
       <collision name="2">
@@ -31,7 +28,6 @@
             <size>0.36 0.36 1.0</size>
           </box>
         </geometry>
-        <name>2</name>
       </collision>
       <visual name="2">
         <geometry>
@@ -42,10 +38,8 @@
         <material>
           <ambient>0.5 0.5 0.5 1</ambient>
         </material>
-        <name>2</name>
       </visual>
       <pose>0.72 0.0 1.72 0 0 0</pose>
-      <name>2</name>
     </link>
     <link name="3">
       <collision name="3">
@@ -54,7 +48,6 @@
             <size>0.36 0.36 1.44</size>
           </box>
         </geometry>
-        <name>3</name>
       </collision>
       <visual name="3">
         <geometry>
@@ -65,10 +58,8 @@
         <material>
           <ambient>0.5 0.5 0.5 1</ambient>
         </material>
-        <name>3</name>
       </visual>
       <pose>1.16 0.0 1.5 0 0 0</pose>
-      <name>3</name>
     </link>
     <link name="4">
       <collision name="4">
@@ -77,7 +68,6 @@
             <size>1.4 0.36 0.8</size>
           </box>
         </geometry>
-        <name>4</name>
       </collision>
       <visual name="4">
         <geometry>
@@ -88,10 +78,8 @@
         <material>
           <ambient>0.5 0.5 0.5 1</ambient>
         </material>
-        <name>4</name>
       </visual>
       <pose>0.64 0.0 0.4 0 0 0</pose>
-      <name>4</name>
     </link>
     <link name="5">
       <collision name="5">
@@ -100,7 +88,6 @@
             <size>0.36 0.36 1.0</size>
           </box>
         </geometry>
-        <name>5</name>
       </collision>
       <visual name="5">
         <geometry>
@@ -111,24 +98,9 @@
         <material>
           <ambient>0.5 0.5 0.5 1</ambient>
         </material>
-        <name>5</name>
       </visual>
       <pose>0.72 0.0 0.5 0 0 0</pose>
-      <name>5</name>
     </link>
-<!--    <link name="in_front_of">
-      <virtual_volume name="in_front_of">
-        <geometry>
-          <box>
-            <size>1.2 0.6 1</size>
-          </box>
-        </geometry>
-        <pose>0.6 0.0 0.5 0 0 0</pose>
-        <name>in_front_of</name>
-      </virtual_volume>
-      <name>in_front_of</name>
-    </link> -->
     <static>true</static>
-    <name>robotics_testlab_B/tubing</name>
   </model>
 </sdf>

--- a/models/robotics_testlab_B/walls/model.sdf
+++ b/models/robotics_testlab_B/walls/model.sdf
@@ -8,7 +8,6 @@
             <uri>model://robotics_testlab_B/walls/shape/heightmap.stl</uri>
           </mesh>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -16,12 +15,9 @@
             <uri>model://robotics_testlab_B/walls/shape/heightmap.stl</uri>
           </mesh>
         </geometry>
-        <name>1</name>
       </visual>
       <pose>0 0 0 0 0 0</pose>
-      <name>1</name>
     </link>
     <static>true</static>
-    <name>robotics_testlab_B/walls</name>
   </model>
 </sdf>

--- a/models/robotics_testlabs/battery_table/model.sdf
+++ b/models/robotics_testlabs/battery_table/model.sdf
@@ -8,7 +8,6 @@
             <size>0.55 0.8 0.7</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -19,12 +18,9 @@
         <material>
           <ambient>0.4 0.3 0.2 1</ambient>
         </material>
-        <name>1</name>
       </visual>
       <pose>0 0 0.35 0 0 0</pose>
-      <name>1</name>
     </link>
     <static>true</static>
-    <name>robotics_testlabs/battery_table</name>
   </model>
 </sdf>

--- a/models/robotics_testlabs/blue_door_left/model.sdf
+++ b/models/robotics_testlabs/blue_door_left/model.sdf
@@ -8,7 +8,6 @@
             <size>0.04 0.926 2.12</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -19,12 +18,9 @@
         <material>
           <ambient>0 0 1 1</ambient>
         </material>
-        <name>1</name>
       </visual>
       <pose>0.025 0.473 1.06 0 0 0</pose>
-      <name>1</name>
     </link>
     <static>true</static>
-    <name>robotics_testlabs/blue_door_left</name>
   </model>
 </sdf>

--- a/models/robotics_testlabs/blue_door_right/model.sdf
+++ b/models/robotics_testlabs/blue_door_right/model.sdf
@@ -8,7 +8,6 @@
             <size>0.04 0.926 2.12</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -19,12 +18,9 @@
         <material>
           <ambient>0 0 1 1</ambient>
         </material>
-        <name>1</name>
       </visual>
       <pose>0.025 -0.473 1.06 0 0 0</pose>
-      <name>1</name>
     </link>
     <static>true</static>
-    <name>robotics_testlabs/blue_door_right</name>
   </model>
 </sdf>

--- a/models/robotics_testlabs/couch/model.sdf
+++ b/models/robotics_testlabs/couch/model.sdf
@@ -8,7 +8,6 @@
             <size>0.27 1.73 0.75</size>
           </box>
         </geometry>
-        <name>back</name>
       </collision>
       <visual name="back">
         <geometry>
@@ -16,10 +15,8 @@
             <size>0.27 1.73 0.75</size>
           </box>
         </geometry>
-        <name>back</name>
       </visual>
       <pose>-0.4 0 0.37 0 0 0</pose>
-      <name>back</name>
     </link>
     <link name="side_left">
       <collision name="side_left">
@@ -28,7 +25,6 @@
             <size>0.57 0.18 0.57</size>
           </box>
         </geometry>
-        <name>side_left</name>
       </collision>
       <visual name="side_left">
         <geometry>
@@ -36,10 +32,8 @@
             <size>0.57 0.18 0.57</size>
           </box>
         </geometry>
-        <name>side_left</name>
       </visual>
       <pose>0 -0.77 0.28 0 0 0</pose>
-      <name>side_left</name>
     </link>
     <link name="side_right">
       <collision name="side_right">
@@ -48,7 +42,6 @@
             <size>0.57 0.18 0.57</size>
           </box>
         </geometry>
-        <name>side_right</name>
       </collision>
       <visual name="side_right">
         <geometry>
@@ -56,10 +49,8 @@
             <size>0.57 0.18 0.57</size>
           </box>
         </geometry>
-        <name>side_right</name>
       </visual>
       <pose>0 0.77 0.28 0 0 0</pose>
-      <name>side_right</name>
     </link>
     <link name="seat">
       <collision name="seat">
@@ -68,7 +59,6 @@
             <size>0.62 1.36 0.17</size>
           </box>
         </geometry>
-        <name>seat</name>
       </collision>
       <visual name="seat">
         <geometry>
@@ -76,10 +66,8 @@
             <size>0.62 1.36 0.17</size>
           </box>
         </geometry>
-        <name>seat</name>
       </visual>
       <pose>0.05 0 0.26 0 0 0</pose>
-      <name>seat</name>
     </link>
     <link name="on_top_of">
       <virtual_volume name="on_top_of">
@@ -89,9 +77,7 @@
           </box>
         </geometry>
         <pose>0.02 0.0 0.44 0 0 0</pose>
-        <name>on_top_of</name>
       </virtual_volume>
-      <name>on_top_of</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
@@ -101,11 +87,8 @@
           </box>
         </geometry>
         <pose>0.75 0.0 0.005 0 0 0</pose>
-        <name>in_front_of</name>
       </virtual_volume>
-      <name>in_front_of</name>
     </link>
     <static>true</static>
-    <name>couch</name>
   </model>
 </sdf>

--- a/models/robotics_testlabs/door/model.sdf
+++ b/models/robotics_testlabs/door/model.sdf
@@ -8,7 +8,6 @@
             <size>1.0 0.06 2.0</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -16,12 +15,9 @@
             <size>1.0 0.06 2.0</size>
           </box>
         </geometry>
-        <name>1</name>
       </visual>
       <pose>0.5 0.03 1.0 0 0 0</pose>
-      <name>1</name>
     </link>
     <static>true</static>
-    <name>robotics_testlabs/door</name>
   </model>
 </sdf>

--- a/models/robotics_testlabs/electro_bar_1/model.sdf
+++ b/models/robotics_testlabs/electro_bar_1/model.sdf
@@ -8,7 +8,6 @@
             <size>0.095 5.085 0.15</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -19,10 +18,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>1</name>
       </visual>
       <pose>0.015 0 0.075 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="2">
       <collision name="2">
@@ -31,7 +28,6 @@
             <size>0.91 0.095 0.15</size>
           </box>
         </geometry>
-        <name>2</name>
       </collision>
       <visual name="2">
         <geometry>
@@ -42,12 +38,9 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>2</name>
       </visual>
       <pose>0.4225 2.495 0.075 0 0 0</pose>
-      <name>2</name>
     </link>
     <static>true</static>
-    <name>robotics_testlabs/electro_bar_1</name>
   </model>
 </sdf>

--- a/models/robotics_testlabs/electro_bar_2/model.sdf
+++ b/models/robotics_testlabs/electro_bar_2/model.sdf
@@ -8,7 +8,6 @@
             <size>0.095 7.07 0.15</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -19,12 +18,9 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>1</name>
       </visual>
       <pose>0.0 -0.9925 0.075 0 0 0</pose>
-      <name>1</name>
     </link>
     <static>true</static>
-    <name>robotics_testlabs/electro_bar_2</name>
   </model>
 </sdf>

--- a/models/robotics_testlabs/flight_case/model.sdf
+++ b/models/robotics_testlabs/flight_case/model.sdf
@@ -8,7 +8,6 @@
             <size>0.75 0.7 1.33</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -19,12 +18,9 @@
         <material>
           <ambient>0.1 0.1 0.1 1</ambient>
         </material>
-        <name>1</name>
       </visual>
       <pose>0 0 0.665 0 0 0</pose>
-      <name>1</name>
     </link>
     <static>true</static>
-    <name>robotics_testlabs/flight_case</name>
   </model>
 </sdf>

--- a/models/robotics_testlabs/model.sdf
+++ b/models/robotics_testlabs/model.sdf
@@ -4,7 +4,6 @@
     <light name="sun" type="directional">
       <direction>0.5 0.1 -0.9</direction>
       <pose>0 0 10 0 0 0</pose>
-      <name>sun</name>
       <specular>0.2 0.2 0.2 1</specular>
       <cast_shadows>true</cast_shadows>
       <diffuse>0.8 0.8 0.8 1</diffuse>
@@ -18,237 +17,190 @@
     <model name="operator">
       <pose>-2.798 -1.499 1.0 0 0 0</pose>
       <static>true</static>
-      <name>operator</name>
     </model>
     <model name="corridor" type="waypoint">
       <pose>2.7 5 0 0 0 0</pose>
       <static>true</static>
-      <name>corridor</name>
     </model>
     <model name="hallway" type="waypoint">
       <pose>0 5.5 0 0 0 0</pose>
       <static>true</static>
-      <name>hallway</name>
     </model>
     <model name="bedroom" type="waypoint">
       <pose>-2.0 -1.0 0 0 0 0</pose>
       <static>true</static>
-      <name>bedroom</name>
     </model>
     <model name="battery_point" type="waypoint">
       <pose>-2.8 2.0 0 0 0 0</pose>
       <static>true</static>
-      <name>battery_point</name>
     </model>
     <model name="initial_pose" type="waypoint">
       <pose>0.586 4.259 0 0 0 0</pose>
       <static>true</static>
-      <name>initial_pose</name>
     </model>
     <model name="robonurse_initial" type="waypoint">
       <pose>0.586 4.259 0 0 0 0</pose>
       <static>true</static>
-      <name>robonurse_initial</name>
     </model>
     <model name="bookcase_waypoint" type="waypoint">
       <pose>2.58 2.66 0 0 0 0</pose>
       <static>true</static>
-      <name>bookcase_waypoint</name>
     </model>
     <model name="entry_point" type="waypoint">
       <pose>1.897 4.295 0 0 0 0</pose>
       <static>true</static>
-      <name>entry_point</name>
     </model>
     <model name="exit" type="waypoint">
       <pose>-1.48 -0.031 0 0 0 3.1415</pose>
       <static>true</static>
-      <name>exit</name>
     </model>
     <model name="exit_pre" type="waypoint">
       <pose>0 0 0 0 0 3.1415</pose>
       <static>true</static>
-      <name>exit_pre</name>
     </model>
     <model name="registration_table1" type="waypoint">
       <pose>2.0 1.5 0 0 0 3.1415</pose>
       <static>true</static>
-      <name>registration_table1</name>
     </model>
     <model name="registration_table2" type="waypoint">
       <pose>2.0 1.5 0 0 0 3.1415</pose>
       <static>true</static>
-      <name>registration_table2</name>
     </model>
     <model name="registration_table3" type="waypoint">
       <pose>2.0 1.5 0 0 0 3.1415</pose>
       <static>true</static>
-      <name>registration_table3</name>
     </model>
     <model name="exit_1_rips" type="waypoint">
       <pose>-1.48 -0.031 0 0 0 3.1415</pose>
       <static>true</static>
-      <name>exit_1_rips</name>
     </model>
     <model name="exit_2_rips" type="waypoint">
       <pose>-1.48 -0.031 0 0 0 3.1415</pose>
       <static>true</static>
-      <name>exit_2_rips</name>
     </model>
     <model name="exit_3_rips" type="waypoint">
       <pose>-1.48 -0.031 0 0 0 3.1415</pose>
       <static>true</static>
-      <name>exit_3_rips</name>
     </model>
     <model name="exit_4_rips" type="waypoint">
       <pose>-1.48 -0.031 0 0 0 3.1415</pose>
       <static>true</static>
-      <name>exit_4_rips</name>
     </model>
     <model name="door_navigation" type="waypoint">
       <pose>-0.168 6.216 0 0 0 -1.5708</pose>
       <static>true</static>
-      <name>door_navigation</name>
     </model>
     <model name="door_opening_left_dest" type="waypoint">
       <pose>-0.168 6.216 0 0 0 1.5708</pose>
       <static>true</static>
-      <name>door_opening_left_dest</name>
     </model>
     <model name="door_opening_right_dest" type="waypoint">
       <pose>0.862 6.216 0 0 0 1.5708</pose>
       <static>true</static>
-      <name>door_opening_right_dest</name>
     </model>
     <model name="door_opening_left_start" type="waypoint">
       <pose>-0.168 4.8 0 0 0 1.5708</pose>
       <static>true</static>
-      <name>door_opening_left_start</name>
     </model>
     <model name="door_opening_right_start" type="waypoint">
       <pose>0.862 4.8 0 0 0 1.5708</pose>
       <static>true</static>
-      <name>door_opening_right_start</name>
     </model>
     <model name="help_me_carry_starting_point" type="waypoint">
       <pose>1.65 2.0 0 0 0 1.5708</pose>
       <static>true</static>
-      <name>help_me_carry_starting_point</name>
     </model>
     <model name="serving_drinks_initial" type="waypoint">
       <pose>0.586 4.259 0 0 0 0</pose>
       <static>true</static>
-      <name>serving_drinks_initial</name>
     </model>
     <model name="avoid_that_start" type="waypoint">
       <pose>2.2 2.2 0 0 0 -2.459</pose>
       <static>true</static>
-      <name>avoid_that_start</name>
     </model>
     <model name="avoid_that_wp1" type="waypoint">
       <pose>2.648 -0.579 0 0 0 -3.137</pose>
       <static>true</static>
-      <name>avoid_that_wp1</name>
     </model>
     <model name="avoid_that_wp2" type="waypoint">
       <pose>0.347 -0.665 0 0 0 1.008</pose>
       <static>true</static>
-      <name>avoid_that_wp2</name>
     </model>
     <model name="avoid_that_wp3" type="waypoint">
       <pose>2.648 -0.579 0 0 0 -3.137</pose>
       <static>true</static>
-      <name>avoid_that_wp3</name>
     </model>
     <model name="what_did_you_say_start" type="waypoint">
       <pose>0.347 -0.665 0 0 0 1.008</pose>
       <static>true</static>
-      <name>what_did_you_say_start</name>
     </model>
     <model name="person_rec_learning" type="waypoint">
       <pose>2.661 4.052 0 0 0 3.139</pose>
       <static>true</static>
-      <name>person_rec_learning</name>
     </model>
     <model name="person_rec_living_room_1" type="waypoint">
       <pose>2.016 3.025 0 0 0 -1.572</pose>
       <static>true</static>
-      <name>person_rec_living_room_1</name>
     </model>
     <model name="person_rec_living_room_2" type="waypoint">
       <pose>2.482 2.27 0 0 0 -1.899</pose>
       <static>true</static>
-      <name>person_rec_living_room_2</name>
     </model>
     <model name="person_rec_living_room_3" type="waypoint">
       <pose>1.51 2.22 0 0 0 -0.971</pose>
       <static>true</static>
-      <name>person_rec_living_room_3</name>
     </model>
     <model name="gpsr_meeting_point" type="waypoint">
       <pose>2.2 1.5 0 0 0 3.1415</pose>
       <static>true</static>
-      <name>gpsr_meeting_point</name>
     </model>
     <model name="operator_pose" type="waypoint">
       <pose>0.0 0.0 0 0 0 0.0</pose>
       <static>true</static>
-      <name>operator_pose</name>
     </model>
     <model name="explore1" type="waypoint">
       <pose>2.0 4.0 0 0 0 0.0</pose>
       <static>true</static>
-      <name>explore1</name>
     </model>
     <model name="explore2" type="waypoint">
       <pose>2.0 2.5 0 0 0 0.0</pose>
       <static>true</static>
-      <name>explore2</name>
     </model>
     <model name="explore3" type="waypoint">
       <pose>2.0 2.0 0 0 0 3.14</pose>
       <static>true</static>
-      <name>explore3</name>
     </model>
     <model name="explore4" type="waypoint">
       <pose>2.0 1.5 0 0 0 0.0</pose>
       <static>true</static>
-      <name>explore4</name>
     </model>
     <model name="explore5" type="waypoint">
       <pose>1.0 0.3 0 0 0 0.0</pose>
       <static>true</static>
-      <name>explore5</name>
     </model>
     <model name="explore6" type="waypoint">
       <pose>1.5 -0.5 0 0 0 -1.57</pose>
       <static>true</static>
-      <name>explore6</name>
     </model>
     <model name="explore7" type="waypoint">
       <pose>-1.5 0.0 0 0 0 3.14</pose>
       <static>true</static>
-      <name>explore7</name>
     </model>
     <model name="explore8" type="waypoint">
       <pose>-1.5 2.0 0 0 0 2.36</pose>
       <static>true</static>
-      <name>explore8</name>
     </model>
     <model name="explore9" type="waypoint">
       <pose>-0.5 4.0 0 0 0 3.14</pose>
       <static>true</static>
-      <name>explore9</name>
     </model>
     <model name="explore10" type="waypoint">
       <pose>0.5 4.5 0 0 0 -1.57</pose>
       <static>true</static>
-      <name>explore10</name>
     </model>
     <model name="wp_test_nav1" type="waypoint">
       <pose>2.032 1.03 0 0 0 3.138</pose>
       <static>true</static>
-      <name>wp_test_nav1</name>
     </model>
     <model name="livingroom" type="room">
       <link name="in">
@@ -259,13 +211,10 @@
             </box>
           </geometry>
           <pose>0.135 -0.335 1.25 0 0 0</pose>
-          <name>in</name>
         </virtual_volume>
-        <name>in</name>
       </link>
       <pose>1.5 1.0 0.0 0 0 0</pose>
       <static>true</static>
-      <name>livingroom</name>
     </model>
     <model name="kitchen" type="room">
       <link name="in">
@@ -276,13 +225,10 @@
             </box>
           </geometry>
           <pose>0.365 -0.145 1.25 0 0 0</pose>
-          <name>in</name>
         </virtual_volume>
-        <name>in</name>
       </link>
       <pose>2.2 4.5 0.0 0 0 0</pose>
       <static>true</static>
-      <name>kitchen</name>
     </model>
     <model name="bedroom" type="room">
       <link name="in">
@@ -293,13 +239,10 @@
             </box>
           </geometry>
           <pose>-0.085 -0.04 1.25 0 0 0</pose>
-          <name>in</name>
         </virtual_volume>
-        <name>in</name>
       </link>
       <pose>-2.0 -0.5 0.0 0 0 0</pose>
       <static>true</static>
-      <name>bedroom</name>
     </model>
     <model name="workshop" type="room">
       <link name="in">
@@ -310,13 +253,10 @@
             </box>
           </geometry>
           <pose>-0.09 0.15 1.25 0 0 0</pose>
-          <name>in</name>
         </virtual_volume>
-        <name>in</name>
       </link>
       <pose>-2.0 3.0 0.0 0 0 0</pose>
       <static>true</static>
-      <name>workshop</name>
     </model>
     <model name="hallway" type="room">
       <link name="in">
@@ -327,150 +267,142 @@
             </box>
           </geometry>
           <pose>0.445 -0.135 1.25 0 0 0</pose>
-          <name>in</name>
         </virtual_volume>
-        <name>in</name>
       </link>
       <pose>0.0 4.5 0.0 0 0 0</pose>
       <static>true</static>
-      <name>hallway</name>
     </model>
-    <include name="walls">
+    <include>
       <pose>0 0 0 0 0 0</pose>
       <name>walls</name>
       <uri>model://robotics_testlabs/walls</uri>
     </include>
-    <include name="door2">
+    <include>
       <pose>1.31 5.585 0 0 0 -1.57079632679</pose>
       <name>door2</name>
       <uri>model://robotics_testlabs/blue_door_right</uri>
     </include>
-    <include name="floor">
+    <include>
       <pose>0 0 0 0 0 0</pose>
       <name>floor</name>
       <uri>model://floor</uri>
     </include>
-    <include name="trashbin">
+    <include>
       <pose>1.32 5.3 0 0 0 0</pose>
       <name>trashbin</name>
       <uri>model://robotics_testlabs/trashbin</uri>
     </include>
-    <include name="paperbin">
+    <include>
       <pose>-0.26 3.45 0 0 0 3.14159</pose>
       <name>paperbin</name>
       <uri>model://robotics_testlabs/paperbin</uri>
     </include>
-    <include name="flight_case">
+    <include>
       <pose>-3.28 1.23 0 0 0 0</pose>
       <name>flight_case</name>
       <uri>model://robotics_testlabs/flight_case</uri>
     </include>
-<!--    <include name="sergio">
-      <pose>-3.36 1.99 0 0 0 0</pose>
-      <name>sergio</name>
-      <uri>model://robotics_testlabs/sergio</uri>
-    </include> -->
-    <include name="black_cabinet1">
+    <include>
       <pose>-0.19 -1.48 0 0 0 1.57079632679</pose>
       <name>black_cabinet4</name>
       <uri>model://robotics_testlab_B/black_cabinet</uri>
     </include>
-    <include name="black_cabinet2">
+    <include>
       <pose>-1.31 -1.48 0 0 0 1.57079632679</pose>
       <name>black_cabinet5</name>
       <uri>model://robotics_testlab_B/black_cabinet</uri>
     </include>
-    <include name="black_cabinet3">
+    <include>
       <pose>-2.23 -1.48 0 0 0 1.57079632679</pose>
       <name>black_cabinet1</name>
       <uri>model://robotics_testlab_B/black_cabinet</uri>
     </include>
-    <include name="black_cabinet4">
+    <include>
       <pose>-2.9 -0.81 0 0 0 0.0</pose>
       <name>black_cabinet2</name>
       <uri>model://robotics_testlab_B/black_cabinet</uri>
     </include>
-    <include name="black_cabinet5">
+    <include>
       <pose>-2.9 0.11 0 0 0 0.0</pose>
       <name>black_cabinet3</name>
       <uri>model://robotics_testlab_B/black_cabinet</uri>
     </include>
-    <include name="bar">
+    <include>
       <pose>0.6 3.45 0 0 0 1.57079632679</pose>
       <name>bar</name>
       <uri>model://ddw/table</uri>
     </include>
-    <include name="hallway_table">
+    <include>
       <pose>-0.65 1.45 0 0 0 3.14159265359</pose>
       <name>hallway_table</name>
       <uri>model://ddw/couch</uri>
     </include>
-    <include name="cabinet">
+    <include>
       <pose>3.28 4.15 0 0 0 3.14159265359</pose>
       <name>cabinet</name>
       <uri>model://robotics_testlab_B/corridor_cabinet</uri>
     </include>
-    <include name="rack">
+    <include>
       <pose>3.37 5.15 0 0 0 0</pose>
       <name>rack</name>
       <uri>model://robotics_testlabs/rack</uri>
     </include>
-    <include name="couch">
+    <include>
       <pose>2.35 5.0 0 0 0 -1.5707963267948966</pose>
       <name>couch</name>
       <uri>model://robotics_testlabs/couch</uri>
     </include>
-    <include name="tubing">
+    <include>
       <pose>-3.4 -0.34 0 0 0 -1.57079632679</pose>
       <name>tubing</name>
       <uri>model://robotics_testlab_B/tubing</uri>
     </include>
-    <include name="operator_table">
+    <include>
       <pose>-1.91 4.05 0.0 0 0 0</pose>
       <name>operator_table</name>
       <uri>model://table_120x80x76</uri>
     </include>
-    <include name="operator_table2">
+    <include>
       <pose>-3.11 4.05 0 0 0 0</pose>
       <name>operator_table2</name>
       <uri>model://table_120x80x76</uri>
     </include>
-    <include name="dinner_table">
+    <include>
       <pose>0.4 1.92 0 0 0 0</pose>
       <name>dinner_table</name>
       <uri>model://table_120x80x76</uri>
     </include>
-    <include name="workbench">
+    <include>
       <pose>-3.31 3.03 0 0 0 1.57079632679</pose>
       <name>workbench</name>
       <uri>model://table_120x80x76</uri>
     </include>
-    <include name="bookcase">
+    <include>
       <pose>3.24 2.713 0 0 0 3.1415</pose>
       <name>bookcase</name>
       <uri>model://robotics_testlabs/plastic_cabinet</uri>
     </include>
-    <include name="chair">
+    <include>
       <pose>3.24 2.19 0 0 0 3.1415</pose>
       <name>chair</name>
       <uri>model://ddw/chair</uri>
     </include>
-    <include name="couch_table">
+    <include>
       <pose>3.34 1.39 0 0 0 3.14159265359</pose>
       <name>couch_table</name>
       <uri>model://ddw/salon</uri>
     </include>
-    <include name="panda_table">
+    <include>
       <pose>2.0 -0.3 0 0 0 3.14159265359</pose>
       <name>panda_table</name>
       <uri>model://table_205x105x76</uri>
     </include>
-    <include name="electro_bar_1">
+    <include>
       <pose>-3.72 2.96 0.94 0 0 0</pose>
       <name>electro_bar_1</name>
       <uri>model://robotics_testlabs/electro_bar_1</uri>
     </include>
-    <include name="electro_bar_2">
+    <include>
       <pose>3.5 2.96 0.94 0 0 0</pose>
       <name>electro_bar_2</name>
       <uri>model://robotics_testlabs/electro_bar_2</uri>
@@ -487,6 +419,5 @@
         </solver>
       </ode>
     </physics>
-    <name>robotics_testlabs</name>
   </world>
 </sdf>

--- a/models/robotics_testlabs/paperbin/model.sdf
+++ b/models/robotics_testlabs/paperbin/model.sdf
@@ -8,7 +8,6 @@
             <size>0.2 0.33 0.02</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -19,10 +18,8 @@
         <material>
           <ambient>0 0.3 0 1</ambient>
         </material>
-        <name>1</name>
       </visual>
       <pose>0 0 0 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="2">
       <collision name="2">
@@ -31,7 +28,6 @@
             <size>0.2 0.005 0.34</size>
           </box>
         </geometry>
-        <name>2</name>
       </collision>
       <visual name="2">
         <geometry>
@@ -42,10 +38,8 @@
         <material>
           <ambient>0 0.3 0 1</ambient>
         </material>
-        <name>2</name>
       </visual>
       <pose>0.0 0.165 0.17 0 0 0</pose>
-      <name>2</name>
     </link>
     <link name="3">
       <collision name="3">
@@ -54,7 +48,6 @@
             <size>0.005 0.33 0.34</size>
           </box>
         </geometry>
-        <name>3</name>
       </collision>
       <visual name="3">
         <geometry>
@@ -65,10 +58,8 @@
         <material>
           <ambient>0 0.3 0 1</ambient>
         </material>
-        <name>3</name>
       </visual>
       <pose>-0.1 0 0.17 0 0 0</pose>
-      <name>3</name>
     </link>
     <link name="4">
       <collision name="4">
@@ -77,7 +68,6 @@
             <size>0.2 0.005 0.34</size>
           </box>
         </geometry>
-        <name>4</name>
       </collision>
       <visual name="4">
         <geometry>
@@ -88,10 +78,8 @@
         <material>
           <ambient>0 0.3 0 1</ambient>
         </material>
-        <name>4</name>
       </visual>
       <pose>0.0 -0.165 0.17 0 0 0</pose>
-      <name>4</name>
     </link>
     <link name="5">
       <collision name="5">
@@ -100,7 +88,6 @@
             <size>0.005 0.33 0.34</size>
           </box>
         </geometry>
-        <name>5</name>
       </collision>
       <visual name="5">
         <geometry>
@@ -111,10 +98,8 @@
         <material>
           <ambient>0 0.3 0 1</ambient>
         </material>
-        <name>5</name>
       </visual>
       <pose>0.1 0.0 0.17 0 0 0</pose>
-      <name>5</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
@@ -124,9 +109,7 @@
           </box>
         </geometry>
         <pose>0.5 0.0 0.01 0 0 0</pose>
-        <name>in_front_of</name>
       </virtual_volume>
-      <name>in_front_of</name>
     </link>
     <link name="on_top_of">
       <virtual_volume name="on_top_of">
@@ -136,11 +119,8 @@
           </box>
         </geometry>
         <pose>0.0 0.0 0.475 0 0 0</pose>
-        <name>on_top_of</name>
       </virtual_volume>
-      <name>on_top_of</name>
     </link>
     <static>true</static>
-    <name>robotics_testlabs/paperbin</name>
   </model>
 </sdf>

--- a/models/robotics_testlabs/plant/model.sdf
+++ b/models/robotics_testlabs/plant/model.sdf
@@ -9,7 +9,6 @@
             <radius>0.2</radius>
           </cylinder>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -18,12 +17,9 @@
             <radius>0.2</radius>
           </cylinder>
         </geometry>
-        <name>1</name>
       </visual>
       <pose>0 0 0.1875 0 0 0</pose>
-      <name>1</name>
     </link>
     <static>true</static>
-    <name>robotics_testlabs/plant</name>
   </model>
 </sdf>

--- a/models/robotics_testlabs/plastic_cabinet/model.sdf
+++ b/models/robotics_testlabs/plastic_cabinet/model.sdf
@@ -8,7 +8,6 @@
             <size>0.414 0.043 1.761</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -19,10 +18,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>1</name>
       </visual>
       <pose>0 -0.3035 0.8805 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="2">
       <collision name="2">
@@ -31,7 +28,6 @@
             <size>0.414 0.043 1.761</size>
           </box>
         </geometry>
-        <name>2</name>
       </collision>
       <visual name="2">
         <geometry>
@@ -42,10 +38,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>2</name>
       </visual>
       <pose>0 0.3035 0.8805 0 0 0</pose>
-      <name>2</name>
     </link>
     <link name="3">
       <collision name="3">
@@ -54,7 +48,6 @@
             <size>0.043 0.65 1.761</size>
           </box>
         </geometry>
-        <name>3</name>
       </collision>
       <visual name="3">
         <geometry>
@@ -65,10 +58,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>3</name>
       </visual>
       <pose>-0.1855 0 0.8805 0 0 0</pose>
-      <name>3</name>
     </link>
     <link name="4">
       <collision name="4">
@@ -77,7 +68,6 @@
             <size>0.371 0.564 0.034</size>
           </box>
         </geometry>
-        <name>4</name>
       </collision>
       <visual name="4">
         <geometry>
@@ -88,10 +78,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>4</name>
       </visual>
       <pose>0.0215 0 1.744 0 0 0</pose>
-      <name>4</name>
     </link>
     <link name="5">
       <collision name="5">
@@ -100,7 +88,6 @@
             <size>0.371 0.564 0.031</size>
           </box>
         </geometry>
-        <name>5</name>
       </collision>
       <visual name="5">
         <geometry>
@@ -111,10 +98,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>5</name>
       </visual>
       <pose>0.0215 0 0.0155 0 0 0</pose>
-      <name>5</name>
     </link>
     <link name="6">
       <collision name="6">
@@ -123,7 +108,6 @@
             <size>0.371 0.564 0.031</size>
           </box>
         </geometry>
-        <name>6</name>
       </collision>
       <visual name="6">
         <geometry>
@@ -134,10 +118,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>6</name>
       </visual>
       <pose>0.0215 0 0.3555 0 0 0</pose>
-      <name>6</name>
     </link>
     <link name="7">
       <collision name="7">
@@ -146,7 +128,6 @@
             <size>0.371 0.564 0.031</size>
           </box>
         </geometry>
-        <name>7</name>
       </collision>
       <visual name="7">
         <geometry>
@@ -157,10 +138,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>7</name>
       </visual>
       <pose>0.0215 0 0.7065 0 0 0</pose>
-      <name>7</name>
     </link>
     <link name="8">
       <collision name="8">
@@ -169,7 +148,6 @@
             <size>0.371 0.564 0.031</size>
           </box>
         </geometry>
-        <name>8</name>
       </collision>
       <visual name="8">
         <geometry>
@@ -180,10 +158,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>8</name>
       </visual>
       <pose>0.0215 0 1.0575 0 0 0</pose>
-      <name>8</name>
     </link>
     <link name="9">
       <collision name="9">
@@ -192,7 +168,6 @@
             <size>0.371 0.564 0.031</size>
           </box>
         </geometry>
-        <name>9</name>
       </collision>
       <visual name="9">
         <geometry>
@@ -203,10 +178,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>9</name>
       </visual>
       <pose>0.0215 0 1.4135 0 0 0</pose>
-      <name>9</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
@@ -216,9 +189,7 @@
           </box>
         </geometry>
         <pose>0.707 0.0 0.005 0 0 0</pose>
-        <name>in_front_of</name>
       </virtual_volume>
-      <name>in_front_of</name>
     </link>
     <link name="shelf1">
       <virtual_volume name="shelf1">
@@ -228,9 +199,7 @@
           </box>
         </geometry>
         <pose>0.0215 0.0 0.186 0 0 0</pose>
-        <name>shelf1</name>
       </virtual_volume>
-      <name>shelf1</name>
     </link>
     <link name="shelf2">
       <virtual_volume name="shelf2">
@@ -240,9 +209,7 @@
           </box>
         </geometry>
         <pose>0.0215 0.0 0.526 0 0 0</pose>
-        <name>shelf2</name>
       </virtual_volume>
-      <name>shelf2</name>
     </link>
     <link name="shelf3">
       <virtual_volume name="shelf3">
@@ -252,9 +219,7 @@
           </box>
         </geometry>
         <pose>0.0215 0.0 0.877 0 0 0</pose>
-        <name>shelf3</name>
       </virtual_volume>
-      <name>shelf3</name>
     </link>
     <link name="on_top_of">
       <virtual_volume name="on_top_of">
@@ -264,9 +229,7 @@
           </box>
         </geometry>
         <pose>0.0215 0.0 0.877 0 0 0</pose>
-        <name>on_top_of</name>
       </virtual_volume>
-      <name>on_top_of</name>
     </link>
     <link name="shelf4">
       <virtual_volume name="shelf4">
@@ -276,9 +239,7 @@
           </box>
         </geometry>
         <pose>0.0215 0.0 1.228 0 0 0</pose>
-        <name>shelf4</name>
       </virtual_volume>
-      <name>shelf4</name>
     </link>
     <link name="shelf5">
       <virtual_volume name="shelf5">
@@ -288,11 +249,8 @@
           </box>
         </geometry>
         <pose>0.0215 0.0 1.584 0 0 0</pose>
-        <name>shelf5</name>
       </virtual_volume>
-      <name>shelf5</name>
     </link>
     <static>true</static>
-    <name>robotics_testlabs/plastic_cabinet</name>
   </model>
 </sdf>

--- a/models/robotics_testlabs/r5cop/model.sdf
+++ b/models/robotics_testlabs/r5cop/model.sdf
@@ -4,7 +4,6 @@
     <light name="sun" type="directional">
       <direction>0.5 0.1 -0.9</direction>
       <pose>0 0 10 0 0 0</pose>
-      <name>sun</name>
       <specular>0.2 0.2 0.2 1</specular>
       <cast_shadows>true</cast_shadows>
       <diffuse>0.8 0.8 0.8 1</diffuse>
@@ -24,13 +23,10 @@
             </box>
           </geometry>
           <pose>-0.15 -0.1 0.0 0 0 0</pose>
-          <name>in</name>
         </virtual_volume>
-        <name>in</name>
       </link>
       <pose>1.5 1.0 0.0 0 0 0</pose>
       <static>true</static>
-      <name>livingroom</name>
     </model>
     <model name="kitchen" type="room">
       <link name="in">
@@ -41,13 +37,10 @@
             </box>
           </geometry>
           <pose>0.2 -0.15 0.0 0 0 0</pose>
-          <name>in</name>
         </virtual_volume>
-        <name>in</name>
       </link>
       <pose>2.2 4.5 0.0 0 0 0</pose>
       <static>true</static>
-      <name>kitchen</name>
     </model>
     <model name="bedroom" type="room">
       <link name="in">
@@ -58,13 +51,10 @@
             </box>
           </geometry>
           <pose>0.55 0.1 0.0 0 0 0</pose>
-          <name>in</name>
         </virtual_volume>
-        <name>in</name>
       </link>
       <pose>-2.0 -0.5 0.0 0 0 0</pose>
       <static>true</static>
-      <name>bedroom</name>
     </model>
     <model name="workshop" type="room">
       <link name="in">
@@ -75,13 +65,10 @@
             </box>
           </geometry>
           <pose>0.2 0.1 0.0 0 0 0</pose>
-          <name>in</name>
         </virtual_volume>
-        <name>in</name>
       </link>
       <pose>-2.0 3.0 0.0 0 0 0</pose>
       <static>true</static>
-      <name>workshop</name>
     </model>
     <model name="hallway" type="room">
       <link name="in">
@@ -92,30 +79,27 @@
             </box>
           </geometry>
           <pose>0.3 -0.1 0.0 0 0 0</pose>
-          <name>in</name>
         </virtual_volume>
-        <name>in</name>
       </link>
       <pose>0.0 4.5 0.0 0 0 0</pose>
       <static>true</static>
-      <name>hallway</name>
     </model>
-    <include name="walls">
+    <include>
       <pose>0 0 0 0 0 0</pose>
       <name>walls</name>
       <uri>model://robotics_testlabs/walls</uri>
     </include>
-    <include name="door1">
+    <include>
       <pose>-0.58 5.585 0 0 0 -1.57079632679</pose>
       <name>door1</name>
       <uri>model://robotics_testlabs/blue_door_left</uri>
     </include>
-    <include name="door2">
+    <include>
       <pose>1.31 5.585 0 0 0 -1.57079632679</pose>
       <name>door2</name>
       <uri>model://robotics_testlabs/blue_door_right</uri>
     </include>
-    <include name="floor">
+    <include>
       <pose>0 0 0 0 0 0</pose>
       <name>floor</name>
       <uri>model://floor</uri>
@@ -132,6 +116,5 @@
         </solver>
       </ode>
     </physics>
-    <name>robotics_testlabs/r5cop</name>
   </world>
 </sdf>

--- a/models/robotics_testlabs/rack/model.sdf
+++ b/models/robotics_testlabs/rack/model.sdf
@@ -8,7 +8,6 @@
             <size>0.015 0.015 0.77</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -16,10 +15,8 @@
             <size>0.015 0.015 0.77</size>
           </box>
         </geometry>
-        <name>1</name>
       </visual>
       <pose>0.12 -0.2325 0.385 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="1_1">
       <collision name="1_1">
@@ -28,7 +25,6 @@
             <size>0.015 0.015 0.77</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1_1">
         <geometry>
@@ -36,10 +32,8 @@
             <size>0.015 0.015 0.77</size>
           </box>
         </geometry>
-        <name>1_1</name>
       </visual>
       <pose>-0.12 -0.2325 0.385 0 0 0</pose>
-      <name>1_1</name>
     </link>
     <link name="1_2">
       <collision name="1_2">
@@ -48,7 +42,6 @@
             <size>0.24 0.015 0.015</size>
           </box>
         </geometry>
-        <name>1_2</name>
       </collision>
       <visual name="1_2">
         <geometry>
@@ -56,10 +49,8 @@
             <size>0.24 0.015 0.015</size>
           </box>
         </geometry>
-        <name>1_2</name>
       </visual>
       <pose>0 -0.2325 0.7625 0 0 0</pose>
-      <name>1_2</name>
     </link>
     <link name="2">
       <collision name="2">
@@ -68,7 +59,6 @@
             <size>0.015 0.015 0.77</size>
           </box>
         </geometry>
-        <name>2</name>
       </collision>
       <visual name="2">
         <geometry>
@@ -76,10 +66,8 @@
             <size>0.015 0.015 0.77</size>
           </box>
         </geometry>
-        <name>2</name>
       </visual>
       <pose>0.12 0.2325 0.385 0 0 0</pose>
-      <name>2</name>
     </link>
     <link name="2_2">
       <collision name="2_2">
@@ -88,7 +76,6 @@
             <size>0.015 0.015 0.77</size>
           </box>
         </geometry>
-        <name>2_2</name>
       </collision>
       <visual name="2_2">
         <geometry>
@@ -96,10 +83,8 @@
             <size>0.015 0.015 0.77</size>
           </box>
         </geometry>
-        <name>2_2</name>
       </visual>
       <pose>-0.12 0.2325 0.385 0 0 0</pose>
-      <name>2_2</name>
     </link>
     <link name="2_3">
       <collision name="2_3">
@@ -108,7 +93,6 @@
             <size>0.24 0.015 0.015</size>
           </box>
         </geometry>
-        <name>2_3</name>
       </collision>
       <visual name="2_3">
         <geometry>
@@ -116,10 +100,8 @@
             <size>0.24 0.015 0.015</size>
           </box>
         </geometry>
-        <name>2_3</name>
       </visual>
       <pose>0 0.2325 0.7625 0 0 0</pose>
-      <name>2_3</name>
     </link>
     <link name="6">
       <collision name="6">
@@ -128,7 +110,6 @@
             <size>0.245 0.45 0.05</size>
           </box>
         </geometry>
-        <name>6</name>
       </collision>
       <visual name="6">
         <geometry>
@@ -136,10 +117,8 @@
             <size>0.245 0.45 0.05</size>
           </box>
         </geometry>
-        <name>6</name>
       </visual>
       <pose>0.0 0.0 0.445 0 0 0</pose>
-      <name>6</name>
     </link>
     <link name="7">
       <collision name="7">
@@ -148,7 +127,6 @@
             <size>0.245 0.45 0.05</size>
           </box>
         </geometry>
-        <name>7</name>
       </collision>
       <visual name="7">
         <geometry>
@@ -156,24 +134,19 @@
             <size>0.245 0.45 0.05</size>
           </box>
         </geometry>
-        <name>7</name>
       </visual>
       <pose>0.0 0.0 0.655 0 0 0</pose>
-      <name>7</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
         <geometry>
           <box>
-            <size>0.2 0.15 0.01</size> <!-- SIZE -->
+            <size>0.2 0.15 0.01</size>
           </box>
         </geometry>
-        <pose>0.63 0.05 0.005 0 0 0</pose> <!-- POSE -->
-        <name>in_front_of</name>
+        <pose>0.63 0.05 0.005 0 0 0</pose>
       </virtual_volume>
-      <name>in_front_of</name>
     </link>
     <static>true</static>
-    <name>rack/rack</name>
   </model>
 </sdf>

--- a/models/robotics_testlabs/trashbin/model.sdf
+++ b/models/robotics_testlabs/trashbin/model.sdf
@@ -9,7 +9,6 @@
             <radius>0.15</radius>
           </cylinder>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -18,13 +17,10 @@
             <radius>0.15</radius>
           </cylinder>
         </geometry>
-        <name>1</name>
       </visual>
       <pose>0 0 0.25 0 0 0</pose>
-      <name>1</name>
     </link>
     <static>true</static>
-    <name>robotics_testlabs/trashbin</name>
     <link name="on_top_of">
       <virtual_volume name="on_top_of">
         <geometry>
@@ -33,21 +29,17 @@
           </box>
         </geometry>
         <pose>0.0 0.0 0.5 0 0 0</pose>
-        <name>on_top_of</name>
       </virtual_volume>
-      <name>on_top_of</name>
     </link>
-        <link name="in_front_of">
+    <link name="in_front_of">
       <virtual_volume name="in_front_of">
         <geometry>
           <box>
             <size>0.05 0.05 0.01</size>
           </box>
         </geometry>
-        <name>in_front_of</name>
       </virtual_volume>
       <pose>0.6 0 0 0 0 0</pose>
-      <name>in_front_of</name>
     </link>
   </model>
 </sdf>

--- a/models/robotics_testlabs/walls/model.sdf
+++ b/models/robotics_testlabs/walls/model.sdf
@@ -8,7 +8,6 @@
             <uri>model://robotics_testlabs/walls/shape/heightmap.stl</uri>
           </mesh>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -16,12 +15,9 @@
             <uri>model://robotics_testlabs/walls/shape/heightmap.stl</uri>
           </mesh>
         </geometry>
-        <name>1</name>
       </visual>
       <pose>0 0 0 0 0 0</pose>
-      <name>1</name>
     </link>
     <static>true</static>
-    <name>robotics_testlabs/walls</name>
   </model>
 </sdf>

--- a/models/robotics_testlabs_empty/model.sdf
+++ b/models/robotics_testlabs_empty/model.sdf
@@ -4,7 +4,6 @@
     <light name="sun" type="directional">
       <direction>0.5 0.1 -0.9</direction>
       <pose>0 0 10 0 0 0</pose>
-      <name>sun</name>
       <specular>0.2 0.2 0.2 1</specular>
       <cast_shadows>true</cast_shadows>
       <diffuse>0.8 0.8 0.8 1</diffuse>
@@ -18,74 +17,61 @@
     <model name="initial_pose" type="waypoint">
       <pose>0.586 4.259 0 0 0 0</pose>
       <static>true</static>
-      <name>initial_pose</name>
     </model>
     <model name="exit" type="waypoint">
       <pose>-1.48 -0.031 0 0 0 3.1415</pose>
       <static>true</static>
-      <name>exit</name>
     </model>
     <model name="operator_pose" type="waypoint">
       <pose>0.0 0.0 0 0 0 0.0</pose>
       <static>true</static>
-      <name>operator_pose</name>
     </model>
     <model name="explore1" type="waypoint">
       <pose>2.0 4.0 0 0 0 0.0</pose>
       <static>true</static>
-      <name>explore1</name>
     </model>
     <model name="explore2" type="waypoint">
       <pose>2.0 2.5 0 0 0 0.0</pose>
       <static>true</static>
-      <name>explore2</name>
     </model>
     <model name="explore3" type="waypoint">
       <pose>2.0 2.0 0 0 0 3.14</pose>
       <static>true</static>
-      <name>explore3</name>
     </model>
     <model name="explore4" type="waypoint">
       <pose>2.0 1.5 0 0 0 0.0</pose>
       <static>true</static>
-      <name>explore4</name>
     </model>
     <model name="explore5" type="waypoint">
       <pose>1.0 0.3 0 0 0 0.0</pose>
       <static>true</static>
-      <name>explore5</name>
     </model>
     <model name="explore6" type="waypoint">
       <pose>1.5 -0.5 0 0 0 -1.57</pose>
       <static>true</static>
-      <name>explore6</name>
     </model>
     <model name="explore7" type="waypoint">
       <pose>-1.5 0.0 0 0 0 3.14</pose>
       <static>true</static>
-      <name>explore7</name>
     </model>
     <model name="explore8" type="waypoint">
       <pose>-1.5 2.0 0 0 0 2.36</pose>
       <static>true</static>
-      <name>explore8</name>
     </model>
     <model name="explore9" type="waypoint">
       <pose>-0.5 4.0 0 0 0 3.14</pose>
       <static>true</static>
-      <name>explore9</name>
     </model>
     <model name="explore10" type="waypoint">
       <pose>0.5 4.5 0 0 0 -1.57</pose>
       <static>true</static>
-      <name>explore10</name>
     </model>
-    <include name="walls">
+    <include>
       <pose>0 0 0 0 0 0</pose>
       <name>walls</name>
       <uri>model://robotics_testlabs/walls</uri>
     </include>
-    <include name="floor">
+    <include>
       <pose>0 0 0 0 0 0</pose>
       <name>floor</name>
       <uri>model://floor</uri>
@@ -102,6 +88,5 @@
         </solver>
       </ode>
     </physics>
-    <name>robotics_testlabs_empty</name>
   </world>
 </sdf>

--- a/models/room/model.sdf
+++ b/models/room/model.sdf
@@ -2,6 +2,5 @@
 <sdf version="1.6">
   <model name="room">
     <static>true</static>
-    <name>room</name>
   </model>
 </sdf>

--- a/models/rosebv/model.sdf
+++ b/models/rosebv/model.sdf
@@ -4,7 +4,6 @@
     <light name="sun" type="directional">
       <direction>0.5 0.1 -0.9</direction>
       <pose>0 0 10 0 0 0</pose>
-      <name>sun</name>
       <specular>0.2 0.2 0.2 1</specular>
       <cast_shadows>true</cast_shadows>
       <diffuse>0.8 0.8 0.8 1</diffuse>
@@ -15,37 +14,37 @@
         <linear>0.01</linear>
       </attenuation>
     </light>
-    <include name="walls">
+    <include>
       <pose>0 0 0 0 0 0</pose>
       <name>walls</name>
       <uri>model://rosebv/walls</uri>
     </include>
-    <include name="floor">
+    <include>
       <pose>0 0 0 0 0 0</pose>
       <name>floor</name>
       <uri>model://floor</uri>
     </include>
-    <include name="office_table1">
+    <include>
       <pose>3 0 0 0 0 0</pose>
       <name>office_table1</name>
       <uri>model://table_200x100x76</uri>
     </include>
-    <include name="desk1">
+    <include>
       <pose>-0.2 -1.1 0 0 0 -1.57</pose>
       <name>desk1</name>
       <uri>model://table_ahrend_180x90x75_with_drawers</uri>
     </include>
-    <include name="desk2">
+    <include>
       <pose>-0.2 -2.9 0 0 0 -1.57</pose>
       <name>desk2</name>
       <uri>model://table_ahrend_180x90x75_with_drawers</uri>
     </include>
-    <include name="desk3">
+    <include>
       <pose>1.7 -3.3 0 0 0 1.57</pose>
       <name>desk3</name>
       <uri>model://table_2legs_180x80x76</uri>
     </include>
-    <include name="desk4">
+    <include>
       <pose>2.5 -3.3 0 0 0 1.57</pose>
       <name>desk4</name>
       <uri>model://table_2legs_180x80x76</uri>
@@ -62,6 +61,5 @@
         </solver>
       </ode>
     </physics>
-    <name>rosebv</name>
   </world>
 </sdf>

--- a/models/rosebv/walls/model.sdf
+++ b/models/rosebv/walls/model.sdf
@@ -8,7 +8,6 @@
             <uri>model://rosebv/walls/shape/rosebv.stl</uri>
           </mesh>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -16,12 +15,9 @@
             <uri>model://rosebv/walls/shape/rosebv.stl</uri>
           </mesh>
         </geometry>
-        <name>1</name>
       </visual>
       <pose>0 0 0 0 0 0</pose>
-      <name>1</name>
     </link>
     <static>true</static>
-    <name>rosebv/walls</name>
   </model>
 </sdf>

--- a/models/rwc2013/armchair/model.sdf
+++ b/models/rwc2013/armchair/model.sdf
@@ -8,7 +8,6 @@
             <size>0.74 0.583 0.45</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -19,12 +18,9 @@
         <material>
           <ambient>0.8 0.8 0.8 1</ambient>
         </material>
-        <name>1</name>
       </visual>
       <pose>0.0 0.0 0.225 0 0 0</pose>
-      <name>1</name>
     </link>
     <static>true</static>
-    <name>rwc2013/armchair</name>
   </model>
 </sdf>

--- a/models/rwc2013/bed/model.sdf
+++ b/models/rwc2013/bed/model.sdf
@@ -8,7 +8,6 @@
             <size>2.261 1.806 0.45</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -19,12 +18,9 @@
         <material>
           <ambient>0.8 0.8 0.8 1</ambient>
         </material>
-        <name>1</name>
       </visual>
       <pose>0.0 0.0 0.225 0 0 0</pose>
-      <name>1</name>
     </link>
     <static>true</static>
-    <name>rwc2013/bed</name>
   </model>
 </sdf>

--- a/models/rwc2013/bedroom_cabinet/model.sdf
+++ b/models/rwc2013/bedroom_cabinet/model.sdf
@@ -8,7 +8,6 @@
             <size>0.406 1.214 0.4</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -19,12 +18,9 @@
         <material>
           <ambient>0.8 0.8 0.8 1</ambient>
         </material>
-        <name>1</name>
       </visual>
       <pose>0.0 0.0 0.2 0 0 0</pose>
-      <name>1</name>
     </link>
     <static>true</static>
-    <name>rwc2013/bedroom_cabinet</name>
   </model>
 </sdf>

--- a/models/rwc2013/book_case/model.sdf
+++ b/models/rwc2013/book_case/model.sdf
@@ -8,7 +8,6 @@
             <size>0.32 1.0 1.2</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -16,12 +15,9 @@
             <size>0.32 1.0 1.2</size>
           </box>
         </geometry>
-        <name>1</name>
       </visual>
       <pose>0.0 0.0 0.6 0 0 0</pose>
-      <name>1</name>
     </link>
     <static>true</static>
-    <name>rwc2013/book_case</name>
   </model>
 </sdf>

--- a/models/rwc2013/couch/model.sdf
+++ b/models/rwc2013/couch/model.sdf
@@ -8,7 +8,6 @@
             <size>0.716 1.966 0.51</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -19,12 +18,9 @@
         <material>
           <ambient>0.8 0.8 0.8 1</ambient>
         </material>
-        <name>1</name>
       </visual>
       <pose>0.0 0.0 0.255 0 0 0</pose>
-      <name>1</name>
     </link>
     <static>true</static>
-    <name>rwc2013/couch</name>
   </model>
 </sdf>

--- a/models/rwc2013/couch_table/model.sdf
+++ b/models/rwc2013/couch_table/model.sdf
@@ -8,7 +8,6 @@
             <size>0.7 1.2 0.35</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -19,12 +18,9 @@
         <material>
           <ambient>0.8 0.8 0.8 1</ambient>
         </material>
-        <name>1</name>
       </visual>
       <pose>0.0 0.0 0.175 0 0 0</pose>
-      <name>1</name>
     </link>
     <static>true</static>
-    <name>rwc2013/couch_table</name>
   </model>
 </sdf>

--- a/models/rwc2013/fridge/model.sdf
+++ b/models/rwc2013/fridge/model.sdf
@@ -8,7 +8,6 @@
             <size>0.69 0.92 1.75</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -19,12 +18,9 @@
         <material>
           <ambient>0.8 0.8 0.8 1</ambient>
         </material>
-        <name>1</name>
       </visual>
       <pose>0.0 0.0 0.875 0 0 0</pose>
-      <name>1</name>
     </link>
     <static>true</static>
-    <name>rwc2013/fridge</name>
   </model>
 </sdf>

--- a/models/rwc2013/kitchen_cabinet/model.sdf
+++ b/models/rwc2013/kitchen_cabinet/model.sdf
@@ -8,7 +8,6 @@
             <size>0.59 0.57 2.2</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -19,12 +18,9 @@
         <material>
           <ambient>0.8 0.8 0.8 1</ambient>
         </material>
-        <name>1</name>
       </visual>
       <pose>0.0 0.0 1.1 0 0 0</pose>
-      <name>1</name>
     </link>
     <static>true</static>
-    <name>rwc2013/kitchen_cabinet</name>
   </model>
 </sdf>

--- a/models/rwc2013/kitchen_countertop/model.sdf
+++ b/models/rwc2013/kitchen_countertop/model.sdf
@@ -8,7 +8,6 @@
             <size>0.642 2.989 0.95</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -19,12 +18,9 @@
         <material>
           <ambient>0.8 0.8 0.8 1</ambient>
         </material>
-        <name>1</name>
       </visual>
       <pose>0.0 0.0 0.475 0 0 0</pose>
-      <name>1</name>
     </link>
     <static>true</static>
-    <name>rwc2013/kitchen_countertop</name>
   </model>
 </sdf>

--- a/models/rwc2013/kitchen_countertop2/model.sdf
+++ b/models/rwc2013/kitchen_countertop2/model.sdf
@@ -8,7 +8,6 @@
             <size>0.4 1.25 0.75</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -19,12 +18,9 @@
         <material>
           <ambient>0.8 0.8 0.8 1</ambient>
         </material>
-        <name>1</name>
       </visual>
       <pose>0.0 0.0 0.375 0 0 0</pose>
-      <name>1</name>
     </link>
     <static>true</static>
-    <name>rwc2013/kitchen_countertop2</name>
   </model>
 </sdf>

--- a/models/rwc2013/kitchen_table/model.sdf
+++ b/models/rwc2013/kitchen_table/model.sdf
@@ -8,7 +8,6 @@
             <size>1.8 0.78 0.76</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -19,12 +18,9 @@
         <material>
           <ambient>0.8 0.8 0.8 1</ambient>
         </material>
-        <name>1</name>
       </visual>
       <pose>0.0 0.0 0.38 0 0 0</pose>
-      <name>1</name>
     </link>
     <static>true</static>
-    <name>rwc2013/kitchen_table</name>
   </model>
 </sdf>

--- a/models/rwc2013/model.sdf
+++ b/models/rwc2013/model.sdf
@@ -4,7 +4,6 @@
     <light name="sun" type="directional">
       <direction>0.5 0.1 -0.9</direction>
       <pose>0 0 10 0 0 0</pose>
-      <name>sun</name>
       <specular>0.2 0.2 0.2 1</specular>
       <cast_shadows>true</cast_shadows>
       <diffuse>0.8 0.8 0.8 1</diffuse>
@@ -15,87 +14,87 @@
         <linear>0.01</linear>
       </attenuation>
     </light>
-    <include name="walls">
+    <include>
       <pose>0 0 0 0 0 0</pose>
       <name>walls</name>
       <uri>model://rwc2013/walls</uri>
     </include>
-    <include name="floor">
+    <include>
       <pose>0 0 0 0 0 0</pose>
       <name>floor</name>
       <uri>model://floor</uri>
     </include>
-    <include name="kitchen_table">
+    <include>
       <pose>3.105 -6.331 0 0 0 0</pose>
       <name>kitchen_table</name>
       <uri>model://rwc2013/kitchen_table</uri>
     </include>
-    <include name="kitchen_countertop">
+    <include>
       <pose>0.654 -6.9815 0 0 0 0</pose>
       <name>kitchen_countertop</name>
       <uri>model://rwc2013/kitchen_countertop</uri>
     </include>
-    <include name="fridge">
+    <include>
       <pose>0.795 -5.02 0 0 0 0</pose>
       <name>fridge</name>
       <uri>model://rwc2013/fridge</uri>
     </include>
-    <include name="trashbin">
+    <include>
       <pose>3.297 -8.183 0 0 0 0</pose>
       <name>trashbin</name>
       <uri>model://rwc2013/trashbin</uri>
     </include>
-    <include name="kitchen_cabinet">
+    <include>
       <pose>2.705 -8.1965 0 0 0 0</pose>
       <name>kitchen_cabinet</name>
       <uri>model://rwc2013/kitchen_cabinet</uri>
     </include>
-    <include name="bedroom_cabinet">
+    <include>
       <pose>6.078 -6.841 0 0 0 0</pose>
       <name>bedroom_cabinet</name>
       <uri>model://rwc2013/bedroom_cabinet</uri>
     </include>
-    <include name="nightstand1">
+    <include>
       <pose>10.223 -5.419 0 0 0 0</pose>
       <name>nightstand1</name>
       <uri>model://rwc2013/nightstand1</uri>
     </include>
-    <include name="nightstand2">
+    <include>
       <pose>10.2305 -7.6205 0 0 0 0</pose>
       <name>nightstand2</name>
       <uri>model://rwc2013/nightstand2</uri>
     </include>
-    <include name="bed">
+    <include>
       <pose>9.3415 -6.519 0 0 0 0</pose>
       <name>bed</name>
       <uri>model://rwc2013/bed</uri>
     </include>
-    <include name="tv_cabinet">
+    <include>
       <pose>8.943 -4.0365 0 0 0 0</pose>
       <name>tv_cabinet</name>
       <uri>model://rwc2013/tv_cabinet</uri>
     </include>
-    <include name="tv">
+    <include>
       <pose>8.943 -4.0365 0 0 0 0</pose>
       <name>tv</name>
       <uri>model://rwc2013/tv</uri>
     </include>
-    <include name="couch_table">
+    <include>
       <pose>8.718 -1.2 0 0 0 0</pose>
       <name>couch_table</name>
       <uri>model://rwc2013/couch_table</uri>
     </include>
-    <include name="armchair">
+    <include>
       <pose>8.748 0.7515 0 0 0 0</pose>
       <name>armchair</name>
       <uri>model://rwc2013/armchair</uri>
     </include>
-    <include name="couch">
+    <include>
       <pose>9.919 -1.112 0 0 0 0</pose>
       <name>couch</name>
       <uri>model://rwc2013/couch</uri>
     </include>
-    <include name="book_case">
+    <include>
       <pose>3.5355 -1.428 0 0 0 0</pose>
       <name>book_case</name>
       <uri>model://rwc2013/book_case</uri>
@@ -112,6 +111,5 @@
         </solver>
       </ode>
     </physics>
-    <name>rwc2013</name>
   </world>
 </sdf>

--- a/models/rwc2013/nightstand1/model.sdf
+++ b/models/rwc2013/nightstand1/model.sdf
@@ -8,7 +8,6 @@
             <size>0.38 0.376 0.4</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -19,12 +18,9 @@
         <material>
           <ambient>0.8 0.8 0.8 1</ambient>
         </material>
-        <name>1</name>
       </visual>
       <pose>0.0 0.0 0.2 0 0 0</pose>
-      <name>1</name>
     </link>
     <static>true</static>
-    <name>rwc2013/nightstand1</name>
   </model>
 </sdf>

--- a/models/rwc2013/nightstand2/model.sdf
+++ b/models/rwc2013/nightstand2/model.sdf
@@ -8,7 +8,6 @@
             <size>0.411 0.377 0.4</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -19,12 +18,9 @@
         <material>
           <ambient>0.8 0.8 0.8 1</ambient>
         </material>
-        <name>1</name>
       </visual>
       <pose>0.0 0.0 0.2 0 0 0</pose>
-      <name>1</name>
     </link>
     <static>true</static>
-    <name>rwc2013/nightstand2</name>
   </model>
 </sdf>

--- a/models/rwc2013/trashbin/model.sdf
+++ b/models/rwc2013/trashbin/model.sdf
@@ -8,7 +8,6 @@
             <size>0.3 0.3 0.5</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -19,12 +18,9 @@
         <material>
           <ambient>0.8 0.8 0.8 1</ambient>
         </material>
-        <name>1</name>
       </visual>
       <pose>0.0 0.0 0.25 0 0 0</pose>
-      <name>1</name>
     </link>
     <static>true</static>
-    <name>rwc2013/trashbin</name>
   </model>
 </sdf>

--- a/models/rwc2013/tv/model.sdf
+++ b/models/rwc2013/tv/model.sdf
@@ -8,7 +8,6 @@
             <size>0.95 0.1 0.62</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -19,12 +18,9 @@
         <material>
           <ambient>0.8 0.8 0.8 1</ambient>
         </material>
-        <name>1</name>
       </visual>
       <pose>0.0 0.0 0.86 0 0 0</pose>
-      <name>1</name>
     </link>
     <static>true</static>
-    <name>rwc2013/tv</name>
   </model>
 </sdf>

--- a/models/rwc2013/tv_cabinet/model.sdf
+++ b/models/rwc2013/tv_cabinet/model.sdf
@@ -8,7 +8,6 @@
             <size>2.2 0.5 0.5</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -19,12 +18,9 @@
         <material>
           <ambient>0.8 0.8 0.8 1</ambient>
         </material>
-        <name>1</name>
       </visual>
       <pose>0.0 0.0 0.25 0 0 0</pose>
-      <name>1</name>
     </link>
     <static>true</static>
-    <name>rwc2013/tv_cabinet</name>
   </model>
 </sdf>

--- a/models/rwc2013/walls/model.sdf
+++ b/models/rwc2013/walls/model.sdf
@@ -8,7 +8,6 @@
             <uri>model://rwc2013/walls/shape/heightmap.stl</uri>
           </mesh>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -16,12 +15,9 @@
             <uri>model://rwc2013/walls/shape/heightmap.stl</uri>
           </mesh>
         </geometry>
-        <name>1</name>
       </visual>
       <pose>0 0 0 0 0 0</pose>
-      <name>1</name>
     </link>
     <static>true</static>
-    <name>rwc2013/walls</name>
   </model>
 </sdf>

--- a/models/rwc2015/bar/model.sdf
+++ b/models/rwc2015/bar/model.sdf
@@ -8,7 +8,6 @@
             <size>0.34 1.49 0.43</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -19,10 +18,8 @@
         <material>
           <ambient>0.9 0.9 0.9 1</ambient>
         </material>
-        <name>1</name>
       </visual>
       <pose>0.0 0.0 0.215 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
@@ -32,11 +29,8 @@
           </box>
         </geometry>
         <pose>-0.6 0.0 0.5 0 0 0</pose>
-        <name>in_front_of</name>
       </virtual_volume>
-      <name>in_front_of</name>
     </link>
     <static>true</static>
-    <name>rwc2015/bar</name>
   </model>
 </sdf>

--- a/models/rwc2015/bed/model.sdf
+++ b/models/rwc2015/bed/model.sdf
@@ -8,7 +8,6 @@
             <size>2.18 1.5 0.21</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -19,10 +18,8 @@
         <material>
           <ambient>0.9 0.9 0.9 1</ambient>
         </material>
-        <name>1</name>
       </visual>
       <pose>0.0 0.0 0.41 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="2">
       <collision name="2">
@@ -31,7 +28,6 @@
             <size>0.03 1.5 0.51</size>
           </box>
         </geometry>
-        <name>2</name>
       </collision>
       <visual name="2">
         <geometry>
@@ -42,10 +38,8 @@
         <material>
           <ambient>0.9 0.9 0.9 1</ambient>
         </material>
-        <name>2</name>
       </visual>
       <pose>-1.075 0.0 0.255 0 0 0</pose>
-      <name>2</name>
     </link>
     <link name="3">
       <collision name="3">
@@ -54,7 +48,6 @@
             <size>0.2 1.5 0.75</size>
           </box>
         </geometry>
-        <name>3</name>
       </collision>
       <visual name="3">
         <geometry>
@@ -65,10 +58,8 @@
         <material>
           <ambient>0.9 0.9 0.9 1</ambient>
         </material>
-        <name>3</name>
       </visual>
       <pose>1.01 0.0 0.68 0 0 0</pose>
-      <name>3</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
@@ -78,9 +69,7 @@
           </box>
         </geometry>
         <pose>-1.45 0.0 0.5 0 0 0</pose>
-        <name>in_front_of</name>
       </virtual_volume>
-      <name>in_front_of</name>
     </link>
     <link name="in_front_of_pos2">
       <virtual_volume name="in_front_of_pos2">
@@ -90,9 +79,7 @@
           </box>
         </geometry>
         <pose>-0.6 1.1 0.5 0 0 0</pose>
-        <name>in_front_of_pos2</name>
       </virtual_volume>
-      <name>in_front_of_pos2</name>
     </link>
     <link name="at_bedside">
       <virtual_volume name="at_bedside">
@@ -102,11 +89,8 @@
           </box>
         </geometry>
         <pose>0.0 0.0 0.5 0 0 0</pose>
-        <name>at_bedside</name>
       </virtual_volume>
-      <name>at_bedside</name>
     </link>
     <static>true</static>
-    <name>rwc2015/bed</name>
   </model>
 </sdf>

--- a/models/rwc2015/bedside_table/model.sdf
+++ b/models/rwc2015/bedside_table/model.sdf
@@ -8,7 +8,6 @@
             <size>0.4 0.47 0.455</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -19,10 +18,8 @@
         <material>
           <ambient>0.9 0.9 0.9 1</ambient>
         </material>
-        <name>1</name>
       </visual>
       <pose>0.0 0.0 0.2275 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
@@ -32,11 +29,8 @@
           </box>
         </geometry>
         <pose>-0.6 0.0 0.5 0 0 0</pose>
-        <name>in_front_of</name>
       </virtual_volume>
-      <name>in_front_of</name>
     </link>
     <static>true</static>
-    <name>rwc2015/bedside_table</name>
   </model>
 </sdf>

--- a/models/rwc2015/bedstand/model.sdf
+++ b/models/rwc2015/bedstand/model.sdf
@@ -9,7 +9,6 @@
           </box>
         </geometry>
         <pose>0.0 0.0 0.2275 0 0 0</pose>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -21,10 +20,8 @@
           <ambient>0.9 0.9 0.9 1</ambient>
         </material>
         <pose>0.0 0.0 0.2275 0 0 0</pose>
-        <name>1</name>
       </visual>
       <pose>0 0 0 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
@@ -34,11 +31,8 @@
           </box>
         </geometry>
         <pose>-0.6 0.0 0.5 0 0 0</pose>
-        <name>in_front_of</name>
       </virtual_volume>
-      <name>in_front_of</name>
     </link>
     <static>true</static>
-    <name>rwc2015/bedstand</name>
   </model>
 </sdf>

--- a/models/rwc2015/bookcase/bookcase_frame/model.sdf
+++ b/models/rwc2015/bookcase/bookcase_frame/model.sdf
@@ -8,7 +8,6 @@
             <size>0.6 0.1 2.0</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -19,10 +18,8 @@
         <material>
           <ambient>0.9 0.9 0.9 1</ambient>
         </material>
-        <name>1</name>
       </visual>
       <pose>0.0 -0.87 1.0 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="2">
       <collision name="2">
@@ -31,7 +28,6 @@
             <size>0.6 0.1 2.0</size>
           </box>
         </geometry>
-        <name>2</name>
       </collision>
       <visual name="2">
         <geometry>
@@ -42,10 +38,8 @@
         <material>
           <ambient>0.9 0.9 0.9 1</ambient>
         </material>
-        <name>2</name>
       </visual>
       <pose>0.0 0.87 1.0 0 0 0</pose>
-      <name>2</name>
     </link>
     <link name="3">
       <collision name="3">
@@ -54,7 +48,6 @@
             <size>0.6 1.69 0.05</size>
           </box>
         </geometry>
-        <name>3</name>
       </collision>
       <visual name="3">
         <geometry>
@@ -65,10 +58,8 @@
         <material>
           <ambient>0.9 0.9 0.9 1</ambient>
         </material>
-        <name>3</name>
       </visual>
       <pose>0.0 0.0 0.285 0 0 0</pose>
-      <name>3</name>
     </link>
     <link name="4">
       <collision name="4">
@@ -77,7 +68,6 @@
             <size>0.6 1.69 0.05</size>
           </box>
         </geometry>
-        <name>4</name>
       </collision>
       <visual name="4">
         <geometry>
@@ -88,10 +78,8 @@
         <material>
           <ambient>0.9 0.9 0.9 1</ambient>
         </material>
-        <name>4</name>
       </visual>
       <pose>0.0 0.0 0.645 0 0 0</pose>
-      <name>4</name>
     </link>
     <link name="5">
       <collision name="5">
@@ -100,7 +88,6 @@
             <size>0.6 1.69 0.05</size>
           </box>
         </geometry>
-        <name>5</name>
       </collision>
       <visual name="5">
         <geometry>
@@ -111,10 +98,8 @@
         <material>
           <ambient>0.9 0.9 0.9 1</ambient>
         </material>
-        <name>5</name>
       </visual>
       <pose>0.0 0.0 1.005 0 0 0</pose>
-      <name>5</name>
     </link>
     <link name="6">
       <collision name="6">
@@ -123,7 +108,6 @@
             <size>0.6 1.69 0.05</size>
           </box>
         </geometry>
-        <name>6</name>
       </collision>
       <visual name="6">
         <geometry>
@@ -134,12 +118,9 @@
         <material>
           <ambient>0.9 0.9 0.9 1</ambient>
         </material>
-        <name>6</name>
       </visual>
       <pose>0.0 0.0 1.365 0 0 0</pose>
-      <name>6</name>
     </link>
     <static>true</static>
-    <name>rwc2015/bookcase/bookcase_frame</name>
   </model>
 </sdf>

--- a/models/rwc2015/bookcase/model.sdf
+++ b/models/rwc2015/bookcase/model.sdf
@@ -4,7 +4,6 @@
     <light name="sun" type="directional">
       <direction>0.5 0.1 -0.9</direction>
       <pose>0 0 10 0 0 0</pose>
-      <name>sun</name>
       <specular>0.2 0.2 0.2 1</specular>
       <cast_shadows>true</cast_shadows>
       <diffuse>0.8 0.8 0.8 1</diffuse>
@@ -15,47 +14,47 @@
         <linear>0.01</linear>
       </attenuation>
     </light>
-    <include name="bookcase_frame">
+    <include>
       <pose>0 0 0 0 0 0</pose>
       <name>bookcase_frame</name>
       <uri>model://rwc2015/bookcase/bookcase_frame</uri>
     </include>
-    <include name="shelf1">
+    <include>
       <pose>0 0.4225 0.285 0 0 0</pose>
       <name>shelf1</name>
       <uri>model://rwc2015/bookcase/shelf</uri>
     </include>
-    <include name="shelf2">
+    <include>
       <pose>0 0.4225 0.645 0 0 0</pose>
       <name>shelf2</name>
       <uri>model://rwc2015/bookcase/shelf</uri>
     </include>
-    <include name="shelf3">
+    <include>
       <pose>0 0.4225 1.005 0 0 0</pose>
       <name>shelf3</name>
       <uri>model://rwc2015/bookcase/shelf</uri>
     </include>
-    <include name="shelf4">
+    <include>
       <pose>0 0.4225 1.365 0 0 0</pose>
       <name>shelf4</name>
       <uri>model://rwc2015/bookcase/shelf</uri>
     </include>
-    <include name="shelf5">
+    <include>
       <pose>0 -0.4225 0.285 0 0 0</pose>
       <name>shelf5</name>
       <uri>model://rwc2015/bookcase/shelf</uri>
     </include>
-    <include name="shelf6">
+    <include>
       <pose>0 -0.4225 0.645 0 0 0</pose>
       <name>shelf6</name>
       <uri>model://rwc2015/bookcase/shelf</uri>
     </include>
-    <include name="shelf7">
+    <include>
       <pose>0 -0.4225 1.005 0 0 0</pose>
       <name>shelf7</name>
       <uri>model://rwc2015/bookcase/shelf</uri>
     </include>
-    <include name="shelf8">
+    <include>
       <pose>0 -0.4225 1.365 0 0 0</pose>
       <name>shelf8</name>
       <uri>model://rwc2015/bookcase/shelf</uri>
@@ -72,6 +71,5 @@
         </solver>
       </ode>
     </physics>
-    <name>rwc2015/bookcase</name>
   </world>
 </sdf>

--- a/models/rwc2015/bookcase/shelf/model.sdf
+++ b/models/rwc2015/bookcase/shelf/model.sdf
@@ -8,7 +8,6 @@
             <size>0.6 0.845 0.05</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -19,10 +18,8 @@
         <material>
           <ambient>0.9 0.9 0.9 1</ambient>
         </material>
-        <name>1</name>
       </visual>
       <pose>0.0 0.0 0.0 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
@@ -32,9 +29,7 @@
           </box>
         </geometry>
         <pose>0.91 0.0 0.88 0 0 0</pose>
-        <name>in_front_of</name>
       </virtual_volume>
-      <name>in_front_of</name>
     </link>
     <link name="in">
       <virtual_volume name="in">
@@ -44,11 +39,8 @@
           </box>
         </geometry>
         <pose>0.0 0.0 0.1 0 0 0</pose>
-        <name>in</name>
       </virtual_volume>
-      <name>in</name>
     </link>
     <static>true</static>
-    <name>rwc2015/bookcase/shelf</name>
   </model>
 </sdf>

--- a/models/rwc2015/cabinet/cabinet_frame/model.sdf
+++ b/models/rwc2015/cabinet/cabinet_frame/model.sdf
@@ -8,7 +8,6 @@
             <size>0.6 0.1 2.0</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -19,10 +18,8 @@
         <material>
           <ambient>0.9 0.9 0.9 1</ambient>
         </material>
-        <name>1</name>
       </visual>
       <pose>0.0 -0.87 1.0 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="2">
       <collision name="2">
@@ -31,7 +28,6 @@
             <size>0.6 0.1 2.0</size>
           </box>
         </geometry>
-        <name>2</name>
       </collision>
       <visual name="2">
         <geometry>
@@ -42,10 +38,8 @@
         <material>
           <ambient>0.9 0.9 0.9 1</ambient>
         </material>
-        <name>2</name>
       </visual>
       <pose>0.0 0.87 1.0 0 0 0</pose>
-      <name>2</name>
     </link>
     <link name="3">
       <collision name="3">
@@ -54,7 +48,6 @@
             <size>0.6 1.69 0.05</size>
           </box>
         </geometry>
-        <name>3</name>
       </collision>
       <visual name="3">
         <geometry>
@@ -65,10 +58,8 @@
         <material>
           <ambient>0.9 0.9 0.9 1</ambient>
         </material>
-        <name>3</name>
       </visual>
       <pose>0.0 0.0 0.285 0 0 0</pose>
-      <name>3</name>
     </link>
     <link name="4">
       <collision name="4">
@@ -77,7 +68,6 @@
             <size>0.6 1.69 0.05</size>
           </box>
         </geometry>
-        <name>4</name>
       </collision>
       <visual name="4">
         <geometry>
@@ -88,10 +78,8 @@
         <material>
           <ambient>0.9 0.9 0.9 1</ambient>
         </material>
-        <name>4</name>
       </visual>
       <pose>0.0 0.0 0.645 0 0 0</pose>
-      <name>4</name>
     </link>
     <link name="5">
       <collision name="5">
@@ -100,7 +88,6 @@
             <size>0.6 1.69 0.05</size>
           </box>
         </geometry>
-        <name>5</name>
       </collision>
       <visual name="5">
         <geometry>
@@ -111,10 +98,8 @@
         <material>
           <ambient>0.9 0.9 0.9 1</ambient>
         </material>
-        <name>5</name>
       </visual>
       <pose>0.0 0.0 1.005 0 0 0</pose>
-      <name>5</name>
     </link>
     <link name="6">
       <collision name="6">
@@ -123,7 +108,6 @@
             <size>0.6 1.69 0.05</size>
           </box>
         </geometry>
-        <name>6</name>
       </collision>
       <visual name="6">
         <geometry>
@@ -134,12 +118,9 @@
         <material>
           <ambient>0.9 0.9 0.9 1</ambient>
         </material>
-        <name>6</name>
       </visual>
       <pose>0.0 0.0 1.365 0 0 0</pose>
-      <name>6</name>
     </link>
     <static>true</static>
-    <name>rwc2015/cabinet/cabinet_frame</name>
   </model>
 </sdf>

--- a/models/rwc2015/cabinet/model.sdf
+++ b/models/rwc2015/cabinet/model.sdf
@@ -4,7 +4,6 @@
     <light name="sun" type="directional">
       <direction>0.5 0.1 -0.9</direction>
       <pose>0 0 10 0 0 0</pose>
-      <name>sun</name>
       <specular>0.2 0.2 0.2 1</specular>
       <cast_shadows>true</cast_shadows>
       <diffuse>0.8 0.8 0.8 1</diffuse>
@@ -15,47 +14,47 @@
         <linear>0.01</linear>
       </attenuation>
     </light>
-    <include name="cabinet_frame">
+    <include>
       <pose>0 0 0 0 0 0</pose>
       <name>cabinet_frame</name>
       <uri>model://rwc2015/cabinet/cabinet_frame</uri>
     </include>
-    <include name="shelf1">
+    <include>
       <pose>0 0.4225 0.285 0 0 0</pose>
       <name>shelf1</name>
       <uri>model://rwc2015/cabinet/shelf</uri>
     </include>
-    <include name="shelf2">
+    <include>
       <pose>0 0.4225 0.645 0 0 0</pose>
       <name>shelf2</name>
       <uri>model://rwc2015/cabinet/shelf</uri>
     </include>
-    <include name="shelf3">
+    <include>
       <pose>0 0.4225 1.005 0 0 0</pose>
       <name>shelf3</name>
       <uri>model://rwc2015/cabinet/shelf</uri>
     </include>
-    <include name="shelf4">
+    <include>
       <pose>0 0.4225 1.365 0 0 0</pose>
       <name>shelf4</name>
       <uri>model://rwc2015/cabinet/shelf</uri>
     </include>
-    <include name="shelf5">
+    <include>
       <pose>0 -0.4225 0.285 0 0 0</pose>
       <name>shelf5</name>
       <uri>model://rwc2015/cabinet/shelf</uri>
     </include>
-    <include name="shelf6">
+    <include>
       <pose>0 -0.4225 0.645 0 0 0</pose>
       <name>shelf6</name>
       <uri>model://rwc2015/cabinet/shelf</uri>
     </include>
-    <include name="shelf7">
+    <include>
       <pose>0 -0.4225 1.005 0 0 0</pose>
       <name>shelf7</name>
       <uri>model://rwc2015/cabinet/shelf</uri>
     </include>
-    <include name="shelf8">
+    <include>
       <pose>0 -0.4225 1.365 0 0 0</pose>
       <name>shelf8</name>
       <uri>model://rwc2015/cabinet/shelf</uri>
@@ -72,6 +71,5 @@
         </solver>
       </ode>
     </physics>
-    <name>rwc2015/cabinet</name>
   </world>
 </sdf>

--- a/models/rwc2015/cabinet/shelf/model.sdf
+++ b/models/rwc2015/cabinet/shelf/model.sdf
@@ -8,7 +8,6 @@
             <size>0.6 0.845 0.05</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -19,10 +18,8 @@
         <material>
           <ambient>0.9 0.9 0.9 1</ambient>
         </material>
-        <name>1</name>
       </visual>
       <pose>0.0 0.0 0.0 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
@@ -32,9 +29,7 @@
           </box>
         </geometry>
         <pose>0.91 0.0 0.88 0 0 0</pose>
-        <name>in_front_of</name>
       </virtual_volume>
-      <name>in_front_of</name>
     </link>
     <link name="in">
       <virtual_volume name="in">
@@ -44,11 +39,8 @@
           </box>
         </geometry>
         <pose>0.0 0.0 0.1 0 0 0</pose>
-        <name>in</name>
       </virtual_volume>
-      <name>in</name>
     </link>
     <static>true</static>
-    <name>rwc2015/cabinet/shelf</name>
   </model>
 </sdf>

--- a/models/rwc2015/couch/model.sdf
+++ b/models/rwc2015/couch/model.sdf
@@ -8,7 +8,6 @@
             <size>0.72 1.25 0.08</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -19,10 +18,8 @@
         <material>
           <ambient>0.1 0.1 0.1 1</ambient>
         </material>
-        <name>1</name>
       </visual>
       <pose>0.0 0.9 0.15 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="2">
       <collision name="2">
@@ -31,7 +28,6 @@
             <size>0.72 1.25 0.08</size>
           </box>
         </geometry>
-        <name>2</name>
       </collision>
       <visual name="2">
         <geometry>
@@ -42,10 +38,8 @@
         <material>
           <ambient>0.1 0.1 0.1 1</ambient>
         </material>
-        <name>2</name>
       </visual>
       <pose>0.0 -0.9 0.15 0 0 0</pose>
-      <name>2</name>
     </link>
     <link name="3">
       <collision name="3">
@@ -54,7 +48,6 @@
             <size>0.72 3.6 0.175</size>
           </box>
         </geometry>
-        <name>3</name>
       </collision>
       <visual name="3">
         <geometry>
@@ -65,10 +58,8 @@
         <material>
           <ambient>0.1 0.1 0.1 1</ambient>
         </material>
-        <name>3</name>
       </visual>
       <pose>0.0 0.0 0.2775 0 0 0</pose>
-      <name>3</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
@@ -78,9 +69,7 @@
           </box>
         </geometry>
         <pose>-0.6 -1.22 0.5 0 0 0</pose>
-        <name>in_front_of</name>
       </virtual_volume>
-      <name>in_front_of</name>
     </link>
     <link name="in_front_of_pos2">
       <virtual_volume name="in_front_of_pos2">
@@ -90,11 +79,8 @@
           </box>
         </geometry>
         <pose>-0.6 1.22 0.5 0 0 0</pose>
-        <name>in_front_of_pos2</name>
       </virtual_volume>
-      <name>in_front_of_pos2</name>
     </link>
     <static>true</static>
-    <name>rwc2015/couch</name>
   </model>
 </sdf>

--- a/models/rwc2015/couch_table/model.sdf
+++ b/models/rwc2015/couch_table/model.sdf
@@ -8,7 +8,6 @@
             <size>0.6 1.2 0.42</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -19,10 +18,8 @@
         <material>
           <ambient>0.5 0.5 0.5 1</ambient>
         </material>
-        <name>1</name>
       </visual>
       <pose>0.0 0.0 0.21 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
@@ -32,11 +29,8 @@
           </box>
         </geometry>
         <pose>0.0 -0.65 0.5 0 0 0</pose>
-        <name>in_front_of</name>
       </virtual_volume>
-      <name>in_front_of</name>
     </link>
     <static>true</static>
-    <name>rwc2015/couch_table</name>
   </model>
 </sdf>

--- a/models/rwc2015/couchtable/model.sdf
+++ b/models/rwc2015/couchtable/model.sdf
@@ -8,7 +8,6 @@
             <size>0.6 1.2 0.42</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -19,10 +18,8 @@
         <material>
           <ambient>0.5 0.5 0.5 1</ambient>
         </material>
-        <name>1</name>
       </visual>
       <pose>0.0 0.0 0.21 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
@@ -32,11 +29,8 @@
           </box>
         </geometry>
         <pose>0.0 -0.65 0.5 0 0 0</pose>
-        <name>in_front_of</name>
       </virtual_volume>
-      <name>in_front_of</name>
     </link>
     <static>true</static>
-    <name>rwc2015/couchtable</name>
   </model>
 </sdf>

--- a/models/rwc2015/cupboard/model.sdf
+++ b/models/rwc2015/cupboard/model.sdf
@@ -8,7 +8,6 @@
             <size>0.33 1.0 0.93</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -19,10 +18,8 @@
         <material>
           <ambient>0.9 0.9 0.9 1</ambient>
         </material>
-        <name>1</name>
       </visual>
       <pose>0.0 0.0 0.465 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
@@ -32,11 +29,8 @@
           </box>
         </geometry>
         <pose>-0.55 0.0 0.5 0 0 0</pose>
-        <name>in_front_of</name>
       </virtual_volume>
-      <name>in_front_of</name>
     </link>
     <static>true</static>
-    <name>rwc2015/cupboard</name>
   </model>
 </sdf>

--- a/models/rwc2015/desk/model.sdf
+++ b/models/rwc2015/desk/model.sdf
@@ -8,7 +8,6 @@
             <size>0.55 1.1 0.015</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -19,10 +18,8 @@
         <material>
           <ambient>0.5 0.5 0.5 1</ambient>
         </material>
-        <name>1</name>
       </visual>
       <pose>0.0 0.0 0.7275 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="2">
       <collision name="2">
@@ -31,7 +28,6 @@
             <size>0.03 0.03 0.7275</size>
           </box>
         </geometry>
-        <name>2</name>
       </collision>
       <visual name="2">
         <geometry>
@@ -42,10 +38,8 @@
         <material>
           <ambient>0.5 0.5 0.5 1</ambient>
         </material>
-        <name>2</name>
       </visual>
       <pose>-0.19 -0.395 0.36375 0 0 0</pose>
-      <name>2</name>
     </link>
     <link name="3">
       <collision name="3">
@@ -54,7 +48,6 @@
             <size>0.03 0.03 0.7275</size>
           </box>
         </geometry>
-        <name>3</name>
       </collision>
       <visual name="3">
         <geometry>
@@ -65,10 +58,8 @@
         <material>
           <ambient>0.5 0.5 0.5 1</ambient>
         </material>
-        <name>3</name>
       </visual>
       <pose>0.19 -0.395 0.36375 0 0 0</pose>
-      <name>3</name>
     </link>
     <link name="4">
       <collision name="4">
@@ -77,7 +68,6 @@
             <size>0.03 0.03 0.7275</size>
           </box>
         </geometry>
-        <name>4</name>
       </collision>
       <visual name="4">
         <geometry>
@@ -88,10 +78,8 @@
         <material>
           <ambient>0.5 0.5 0.5 1</ambient>
         </material>
-        <name>4</name>
       </visual>
       <pose>-0.19 0.395 0.36375 0 0 0</pose>
-      <name>4</name>
     </link>
     <link name="5">
       <collision name="5">
@@ -100,7 +88,6 @@
             <size>0.03 0.03 0.7275</size>
           </box>
         </geometry>
-        <name>5</name>
       </collision>
       <visual name="5">
         <geometry>
@@ -111,10 +98,8 @@
         <material>
           <ambient>0.5 0.5 0.5 1</ambient>
         </material>
-        <name>5</name>
       </visual>
       <pose>0.19 0.395 0.36375 0 0 0</pose>
-      <name>5</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
@@ -124,11 +109,8 @@
           </box>
         </geometry>
         <pose>0.65 0.0 0.5 0 0 0</pose>
-        <name>in_front_of</name>
       </virtual_volume>
-      <name>in_front_of</name>
     </link>
     <static>true</static>
-    <name>rwc2015/desk</name>
   </model>
 </sdf>

--- a/models/rwc2015/dinnertable/model.sdf
+++ b/models/rwc2015/dinnertable/model.sdf
@@ -8,7 +8,6 @@
             <size>0.915 1.83 0.3</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -19,10 +18,8 @@
         <material>
           <ambient>0.5 0.5 0.5 1</ambient>
         </material>
-        <name>1</name>
       </visual>
       <pose>0.0 0.0 0.625 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="2">
       <collision name="2">
@@ -31,7 +28,6 @@
             <size>0.03 0.03 0.75</size>
           </box>
         </geometry>
-        <name>2</name>
       </collision>
       <visual name="2">
         <geometry>
@@ -42,10 +38,8 @@
         <material>
           <ambient>0.5 0.5 0.5 1</ambient>
         </material>
-        <name>2</name>
       </visual>
       <pose>-0.4025 -0.79 0.375 0 0 0</pose>
-      <name>2</name>
     </link>
     <link name="3">
       <collision name="3">
@@ -54,7 +48,6 @@
             <size>0.03 0.03 0.75</size>
           </box>
         </geometry>
-        <name>3</name>
       </collision>
       <visual name="3">
         <geometry>
@@ -65,10 +58,8 @@
         <material>
           <ambient>0.5 0.5 0.5 1</ambient>
         </material>
-        <name>3</name>
       </visual>
       <pose>-0.4025 0.79 0.375 0 0 0</pose>
-      <name>3</name>
     </link>
     <link name="4">
       <collision name="4">
@@ -77,7 +68,6 @@
             <size>0.03 0.03 0.75</size>
           </box>
         </geometry>
-        <name>4</name>
       </collision>
       <visual name="4">
         <geometry>
@@ -88,10 +78,8 @@
         <material>
           <ambient>0.5 0.5 0.5 1</ambient>
         </material>
-        <name>4</name>
       </visual>
       <pose>0.4025 -0.79 0.375 0 0 0</pose>
-      <name>4</name>
     </link>
     <link name="5">
       <collision name="5">
@@ -100,7 +88,6 @@
             <size>0.03 0.03 0.75</size>
           </box>
         </geometry>
-        <name>5</name>
       </collision>
       <visual name="5">
         <geometry>
@@ -111,10 +98,8 @@
         <material>
           <ambient>0.5 0.5 0.5 1</ambient>
         </material>
-        <name>5</name>
       </visual>
       <pose>0.4025 0.79 0.375 0 0 0</pose>
-      <name>5</name>
     </link>
     <link name="6">
       <collision name="6">
@@ -123,7 +108,6 @@
             <size>0.03 0.03 0.75</size>
           </box>
         </geometry>
-        <name>6</name>
       </collision>
       <visual name="6">
         <geometry>
@@ -134,10 +118,8 @@
         <material>
           <ambient>0.5 0.5 0.5 1</ambient>
         </material>
-        <name>6</name>
       </visual>
       <pose>-0.055 -0.79 0.375 0 0 0</pose>
-      <name>6</name>
     </link>
     <link name="7">
       <collision name="7">
@@ -146,7 +128,6 @@
             <size>0.03 0.03 0.75</size>
           </box>
         </geometry>
-        <name>7</name>
       </collision>
       <visual name="7">
         <geometry>
@@ -157,10 +138,8 @@
         <material>
           <ambient>0.5 0.5 0.5 1</ambient>
         </material>
-        <name>7</name>
       </visual>
       <pose>-0.055 0.79 0.375 0 0 0</pose>
-      <name>7</name>
     </link>
     <link name="8">
       <collision name="8">
@@ -169,7 +148,6 @@
             <size>0.03 0.03 0.75</size>
           </box>
         </geometry>
-        <name>8</name>
       </collision>
       <visual name="8">
         <geometry>
@@ -180,10 +158,8 @@
         <material>
           <ambient>0.5 0.5 0.5 1</ambient>
         </material>
-        <name>8</name>
       </visual>
       <pose>0.055 -0.79 0.375 0 0 0</pose>
-      <name>8</name>
     </link>
     <link name="9">
       <collision name="9">
@@ -192,7 +168,6 @@
             <size>0.03 0.03 0.75</size>
           </box>
         </geometry>
-        <name>9</name>
       </collision>
       <visual name="9">
         <geometry>
@@ -203,10 +178,8 @@
         <material>
           <ambient>0.5 0.5 0.5 1</ambient>
         </material>
-        <name>9</name>
       </visual>
       <pose>0.055 0.79 0.375 0 0 0</pose>
-      <name>9</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
@@ -216,9 +189,7 @@
           </box>
         </geometry>
         <pose>0.0 0.85 0.5 0 0 0</pose>
-        <name>in_front_of</name>
       </virtual_volume>
-      <name>in_front_of</name>
     </link>
     <link name="in_front_of_pos2">
       <virtual_volume name="in_front_of_pos2">
@@ -228,9 +199,7 @@
           </box>
         </geometry>
         <pose>0.0 -0.85 0.5 0 0 0</pose>
-        <name>in_front_of_pos2</name>
       </virtual_volume>
-      <name>in_front_of_pos2</name>
     </link>
     <link name="in_front_of_pos3">
       <virtual_volume name="in_front_of_pos3">
@@ -240,11 +209,8 @@
           </box>
         </geometry>
         <pose>0.425 -1.5 0.5 0 0 0</pose>
-        <name>in_front_of_pos3</name>
       </virtual_volume>
-      <name>in_front_of_pos3</name>
     </link>
     <static>true</static>
-    <name>rwc2015/dinnertable</name>
   </model>
 </sdf>

--- a/models/rwc2015/fridge/model.sdf
+++ b/models/rwc2015/fridge/model.sdf
@@ -8,7 +8,6 @@
             <size>0.545 0.495 1.395</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -19,10 +18,8 @@
         <material>
           <ambient>0.9 0.9 0.9 1</ambient>
         </material>
-        <name>1</name>
       </visual>
       <pose>0.0 0.0 0.6975 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
@@ -32,11 +29,8 @@
           </box>
         </geometry>
         <pose>-0.65 -0.025 0.5 0 0 0</pose>
-        <name>in_front_of</name>
       </virtual_volume>
-      <name>in_front_of</name>
     </link>
     <static>true</static>
-    <name>rwc2015/fridge</name>
   </model>
 </sdf>

--- a/models/rwc2015/hallwaytable/model.sdf
+++ b/models/rwc2015/hallwaytable/model.sdf
@@ -8,7 +8,6 @@
             <size>0.7 1.2 0.02</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -19,10 +18,8 @@
         <material>
           <ambient>0.9 0.9 0.9 1</ambient>
         </material>
-        <name>1</name>
       </visual>
       <pose>0.0 0.0 0.76 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="2">
       <collision name="2">
@@ -31,7 +28,6 @@
             <size>0.05 0.075 0.76</size>
           </box>
         </geometry>
-        <name>2</name>
       </collision>
       <visual name="2">
         <geometry>
@@ -42,10 +38,8 @@
         <material>
           <ambient>0.9 0.9 0.9 1</ambient>
         </material>
-        <name>2</name>
       </visual>
       <pose>-0.305 -0.5425 0.38 0 0 0</pose>
-      <name>2</name>
     </link>
     <link name="3">
       <collision name="3">
@@ -54,7 +48,6 @@
             <size>0.05 0.075 0.76</size>
           </box>
         </geometry>
-        <name>3</name>
       </collision>
       <visual name="3">
         <geometry>
@@ -65,10 +58,8 @@
         <material>
           <ambient>0.9 0.9 0.9 1</ambient>
         </material>
-        <name>3</name>
       </visual>
       <pose>-0.305 0.5425 0.38 0 0 0</pose>
-      <name>3</name>
     </link>
     <link name="4">
       <collision name="4">
@@ -77,7 +68,6 @@
             <size>0.05 0.075 0.76</size>
           </box>
         </geometry>
-        <name>4</name>
       </collision>
       <visual name="4">
         <geometry>
@@ -88,10 +78,8 @@
         <material>
           <ambient>0.9 0.9 0.9 1</ambient>
         </material>
-        <name>4</name>
       </visual>
       <pose>0.305 -0.5425 0.38 0 0 0</pose>
-      <name>4</name>
     </link>
     <link name="5">
       <collision name="5">
@@ -100,7 +88,6 @@
             <size>0.05 0.075 0.76</size>
           </box>
         </geometry>
-        <name>5</name>
       </collision>
       <visual name="5">
         <geometry>
@@ -111,10 +98,8 @@
         <material>
           <ambient>0.9 0.9 0.9 1</ambient>
         </material>
-        <name>5</name>
       </visual>
       <pose>0.305 0.5425 0.38 0 0 0</pose>
-      <name>5</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
@@ -124,9 +109,7 @@
           </box>
         </geometry>
         <pose>0.0 -0.325 0.5 0 0 0</pose>
-        <name>in_front_of</name>
       </virtual_volume>
-      <name>in_front_of</name>
     </link>
     <link name="in_front_of_pos2">
       <virtual_volume name="in_front_of_pos2">
@@ -136,11 +119,8 @@
           </box>
         </geometry>
         <pose>0.0 0.325 0.5 0 0 0</pose>
-        <name>in_front_of_pos2</name>
       </virtual_volume>
-      <name>in_front_of_pos2</name>
     </link>
     <static>true</static>
-    <name>rwc2015/hallwaytable</name>
   </model>
 </sdf>

--- a/models/rwc2015/kitchen_counter/model.sdf
+++ b/models/rwc2015/kitchen_counter/model.sdf
@@ -8,7 +8,6 @@
             <size>0.33 1.0 0.93</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -19,10 +18,8 @@
         <material>
           <ambient>0.9 0.9 0.9 1</ambient>
         </material>
-        <name>1</name>
       </visual>
       <pose>0.0 0.0 0.465 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
@@ -32,11 +29,8 @@
           </box>
         </geometry>
         <pose>-0.55 0.0 0.5 0 0 0</pose>
-        <name>in_front_of</name>
       </virtual_volume>
-      <name>in_front_of</name>
     </link>
     <static>true</static>
-    <name>rwc2015/kitchen_counter</name>
   </model>
 </sdf>

--- a/models/rwc2015/kitchencounter/model.sdf
+++ b/models/rwc2015/kitchencounter/model.sdf
@@ -8,7 +8,6 @@
             <size>0.55 1.1 0.015</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -19,10 +18,8 @@
         <material>
           <ambient>0.5 0.5 0.5 1</ambient>
         </material>
-        <name>1</name>
       </visual>
       <pose>0.0 0.0 0.7275 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="2">
       <collision name="2">
@@ -31,7 +28,6 @@
             <size>0.03 0.03 0.7275</size>
           </box>
         </geometry>
-        <name>2</name>
       </collision>
       <visual name="2">
         <geometry>
@@ -42,10 +38,8 @@
         <material>
           <ambient>0.5 0.5 0.5 1</ambient>
         </material>
-        <name>2</name>
       </visual>
       <pose>-0.19 -0.395 0.36375 0 0 0</pose>
-      <name>2</name>
     </link>
     <link name="3">
       <collision name="3">
@@ -54,7 +48,6 @@
             <size>0.03 0.03 0.7275</size>
           </box>
         </geometry>
-        <name>3</name>
       </collision>
       <visual name="3">
         <geometry>
@@ -65,10 +58,8 @@
         <material>
           <ambient>0.5 0.5 0.5 1</ambient>
         </material>
-        <name>3</name>
       </visual>
       <pose>0.19 -0.395 0.36375 0 0 0</pose>
-      <name>3</name>
     </link>
     <link name="4">
       <collision name="4">
@@ -77,7 +68,6 @@
             <size>0.03 0.03 0.7275</size>
           </box>
         </geometry>
-        <name>4</name>
       </collision>
       <visual name="4">
         <geometry>
@@ -88,10 +78,8 @@
         <material>
           <ambient>0.5 0.5 0.5 1</ambient>
         </material>
-        <name>4</name>
       </visual>
       <pose>-0.19 0.395 0.36375 0 0 0</pose>
-      <name>4</name>
     </link>
     <link name="5">
       <collision name="5">
@@ -100,7 +88,6 @@
             <size>0.03 0.03 0.7275</size>
           </box>
         </geometry>
-        <name>5</name>
       </collision>
       <visual name="5">
         <geometry>
@@ -111,10 +98,8 @@
         <material>
           <ambient>0.5 0.5 0.5 1</ambient>
         </material>
-        <name>5</name>
       </visual>
       <pose>0.19 0.395 0.36375 0 0 0</pose>
-      <name>5</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
@@ -124,11 +109,8 @@
           </box>
         </geometry>
         <pose>0.65 0.0 0.5 0 0 0</pose>
-        <name>in_front_of</name>
       </virtual_volume>
-      <name>in_front_of</name>
     </link>
     <static>true</static>
-    <name>rwc2015/kitchencounter</name>
   </model>
 </sdf>

--- a/models/rwc2015/kitchentable/model.sdf
+++ b/models/rwc2015/kitchentable/model.sdf
@@ -9,7 +9,6 @@
           </box>
         </geometry>
         <pose>0.0 0.0 0.76 0 0 0</pose>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -21,10 +20,8 @@
           <ambient>0.9 0.9 0.9 1</ambient>
         </material>
         <pose>0.0 0.0 0.76 0 0 0</pose>
-        <name>1</name>
       </visual>
       <pose>0 0 0 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="2">
       <collision name="2">
@@ -33,7 +30,6 @@
             <size>0.05 0.075 0.76</size>
           </box>
         </geometry>
-        <name>2</name>
       </collision>
       <visual name="2">
         <geometry>
@@ -44,10 +40,8 @@
         <material>
           <ambient>0.9 0.9 0.9 1</ambient>
         </material>
-        <name>2</name>
       </visual>
       <pose>-0.305 -0.5425 0.38 0 0 0</pose>
-      <name>2</name>
     </link>
     <link name="3">
       <collision name="3">
@@ -56,7 +50,6 @@
             <size>0.05 0.075 0.76</size>
           </box>
         </geometry>
-        <name>3</name>
       </collision>
       <visual name="3">
         <geometry>
@@ -67,10 +60,8 @@
         <material>
           <ambient>0.9 0.9 0.9 1</ambient>
         </material>
-        <name>3</name>
       </visual>
       <pose>-0.305 0.5425 0.38 0 0 0</pose>
-      <name>3</name>
     </link>
     <link name="4">
       <collision name="4">
@@ -79,7 +70,6 @@
             <size>0.05 0.075 0.76</size>
           </box>
         </geometry>
-        <name>4</name>
       </collision>
       <visual name="4">
         <geometry>
@@ -90,10 +80,8 @@
         <material>
           <ambient>0.9 0.9 0.9 1</ambient>
         </material>
-        <name>4</name>
       </visual>
       <pose>0.305 -0.5425 0.38 0 0 0</pose>
-      <name>4</name>
     </link>
     <link name="5">
       <collision name="5">
@@ -102,7 +90,6 @@
             <size>0.05 0.075 0.76</size>
           </box>
         </geometry>
-        <name>5</name>
       </collision>
       <visual name="5">
         <geometry>
@@ -113,10 +100,8 @@
         <material>
           <ambient>0.9 0.9 0.9 1</ambient>
         </material>
-        <name>5</name>
       </visual>
       <pose>0.305 0.5425 0.38 0 0 0</pose>
-      <name>5</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
@@ -126,11 +111,8 @@
           </box>
         </geometry>
         <pose>0.0 0.95 0.5 0 0 0</pose>
-        <name>in_front_of</name>
       </virtual_volume>
-      <name>in_front_of</name>
     </link>
     <static>true</static>
-    <name>rwc2015/kitchentable</name>
   </model>
 </sdf>

--- a/models/rwc2015/large_table/model.sdf
+++ b/models/rwc2015/large_table/model.sdf
@@ -8,7 +8,6 @@
             <size>0.915 1.83 0.3</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -19,10 +18,8 @@
         <material>
           <ambient>0.5 0.5 0.5 1</ambient>
         </material>
-        <name>1</name>
       </visual>
       <pose>0.0 0.0 0.625 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="2">
       <collision name="2">
@@ -31,7 +28,6 @@
             <size>0.03 0.03 0.75</size>
           </box>
         </geometry>
-        <name>2</name>
       </collision>
       <visual name="2">
         <geometry>
@@ -42,10 +38,8 @@
         <material>
           <ambient>0.5 0.5 0.5 1</ambient>
         </material>
-        <name>2</name>
       </visual>
       <pose>-0.4025 -0.79 0.375 0 0 0</pose>
-      <name>2</name>
     </link>
     <link name="3">
       <collision name="3">
@@ -54,7 +48,6 @@
             <size>0.03 0.03 0.75</size>
           </box>
         </geometry>
-        <name>3</name>
       </collision>
       <visual name="3">
         <geometry>
@@ -65,10 +58,8 @@
         <material>
           <ambient>0.5 0.5 0.5 1</ambient>
         </material>
-        <name>3</name>
       </visual>
       <pose>-0.4025 0.79 0.375 0 0 0</pose>
-      <name>3</name>
     </link>
     <link name="4">
       <collision name="4">
@@ -77,7 +68,6 @@
             <size>0.03 0.03 0.75</size>
           </box>
         </geometry>
-        <name>4</name>
       </collision>
       <visual name="4">
         <geometry>
@@ -88,10 +78,8 @@
         <material>
           <ambient>0.5 0.5 0.5 1</ambient>
         </material>
-        <name>4</name>
       </visual>
       <pose>0.4025 -0.79 0.375 0 0 0</pose>
-      <name>4</name>
     </link>
     <link name="5">
       <collision name="5">
@@ -100,7 +88,6 @@
             <size>0.03 0.03 0.75</size>
           </box>
         </geometry>
-        <name>5</name>
       </collision>
       <visual name="5">
         <geometry>
@@ -111,10 +98,8 @@
         <material>
           <ambient>0.5 0.5 0.5 1</ambient>
         </material>
-        <name>5</name>
       </visual>
       <pose>0.4025 0.79 0.375 0 0 0</pose>
-      <name>5</name>
     </link>
     <link name="6">
       <collision name="6">
@@ -123,7 +108,6 @@
             <size>0.03 0.03 0.75</size>
           </box>
         </geometry>
-        <name>6</name>
       </collision>
       <visual name="6">
         <geometry>
@@ -134,10 +118,8 @@
         <material>
           <ambient>0.5 0.5 0.5 1</ambient>
         </material>
-        <name>6</name>
       </visual>
       <pose>-0.055 -0.79 0.375 0 0 0</pose>
-      <name>6</name>
     </link>
     <link name="7">
       <collision name="7">
@@ -146,7 +128,6 @@
             <size>0.03 0.03 0.75</size>
           </box>
         </geometry>
-        <name>7</name>
       </collision>
       <visual name="7">
         <geometry>
@@ -157,10 +138,8 @@
         <material>
           <ambient>0.5 0.5 0.5 1</ambient>
         </material>
-        <name>7</name>
       </visual>
       <pose>-0.055 0.79 0.375 0 0 0</pose>
-      <name>7</name>
     </link>
     <link name="8">
       <collision name="8">
@@ -169,7 +148,6 @@
             <size>0.03 0.03 0.75</size>
           </box>
         </geometry>
-        <name>8</name>
       </collision>
       <visual name="8">
         <geometry>
@@ -180,10 +158,8 @@
         <material>
           <ambient>0.5 0.5 0.5 1</ambient>
         </material>
-        <name>8</name>
       </visual>
       <pose>0.055 -0.79 0.375 0 0 0</pose>
-      <name>8</name>
     </link>
     <link name="9">
       <collision name="9">
@@ -192,7 +168,6 @@
             <size>0.03 0.03 0.75</size>
           </box>
         </geometry>
-        <name>9</name>
       </collision>
       <visual name="9">
         <geometry>
@@ -203,10 +178,8 @@
         <material>
           <ambient>0.5 0.5 0.5 1</ambient>
         </material>
-        <name>9</name>
       </visual>
       <pose>0.055 0.79 0.375 0 0 0</pose>
-      <name>9</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
@@ -216,9 +189,7 @@
           </box>
         </geometry>
         <pose>0.0 0.85 0.5 0 0 0</pose>
-        <name>in_front_of</name>
       </virtual_volume>
-      <name>in_front_of</name>
     </link>
     <link name="in_front_of_pos2">
       <virtual_volume name="in_front_of_pos2">
@@ -228,9 +199,7 @@
           </box>
         </geometry>
         <pose>0.0 -0.85 0.5 0 0 0</pose>
-        <name>in_front_of_pos2</name>
       </virtual_volume>
-      <name>in_front_of_pos2</name>
     </link>
     <link name="in_front_of_pos3">
       <virtual_volume name="in_front_of_pos3">
@@ -240,11 +209,8 @@
           </box>
         </geometry>
         <pose>0.425 -1.5 0.5 0 0 0</pose>
-        <name>in_front_of_pos3</name>
       </virtual_volume>
-      <name>in_front_of_pos3</name>
     </link>
     <static>true</static>
-    <name>rwc2015/large_table</name>
   </model>
 </sdf>

--- a/models/rwc2015/model.sdf
+++ b/models/rwc2015/model.sdf
@@ -4,7 +4,6 @@
     <light name="sun" type="directional">
       <direction>0.5 0.1 -0.9</direction>
       <pose>0 0 10 0 0 0</pose>
-      <name>sun</name>
       <specular>0.2 0.2 0.2 1</specular>
       <cast_shadows>true</cast_shadows>
       <diffuse>0.8 0.8 0.8 1</diffuse>
@@ -18,112 +17,90 @@
     <model name="initial_pose" type="waypoint">
       <pose>0 0 0 0 0 0</pose>
       <static>true</static>
-      <name>initial_pose</name>
     </model>
     <model name="initial_pose_door_B" type="waypoint">
       <pose>0 0 0 0 0 0</pose>
       <static>true</static>
-      <name>initial_pose_door_B</name>
     </model>
     <model name="initial_pose_door_A" type="waypoint">
       <pose>0 -8.35 0 0 0 0.0</pose>
       <static>true</static>
-      <name>initial_pose_door_A</name>
     </model>
     <model name="exit_door_B1" type="waypoint">
       <pose>-1.0 0 0 0 0 3.1415</pose>
       <static>true</static>
-      <name>exit_door_B1</name>
     </model>
     <model name="exit_door_B2" type="waypoint">
       <pose>-2.0 0 0 0 0 3.1415</pose>
       <static>true</static>
-      <name>exit_door_B2</name>
     </model>
     <model name="exit_door_B3" type="waypoint">
       <pose>1.0 0 0 0 0 3.1415</pose>
       <static>true</static>
-      <name>exit_door_B3</name>
     </model>
     <model name="exit_door_A1" type="waypoint">
       <pose>-1.0 -8.35 0 0 0 3.1415</pose>
       <static>true</static>
-      <name>exit_door_A1</name>
     </model>
     <model name="exit_door_A2" type="waypoint">
       <pose>-2.0 -8.35 0 0 0 3.1415</pose>
       <static>true</static>
-      <name>exit_door_A2</name>
     </model>
     <model name="exit_door_A3" type="waypoint">
       <pose>1.0 -8.35 0 0 0 3.1415</pose>
       <static>true</static>
-      <name>exit_door_A3</name>
     </model>
     <model name="entry_point_B" type="waypoint">
       <pose>1.0 0 0 0 0 0</pose>
       <static>true</static>
-      <name>entry_point_B</name>
     </model>
     <model name="entry_point_A" type="waypoint">
       <pose>1.0 -8.35 0 0 0 0</pose>
       <static>true</static>
-      <name>entry_point_A</name>
     </model>
     <model name="navigation1" type="waypoint">
       <pose>6.8 -5 0 0 0 1.582</pose>
       <static>true</static>
-      <name>navigation1</name>
     </model>
     <model name="navigation2" type="waypoint">
       <pose>9.8 0.65 0 0 0 3.1415</pose>
       <static>true</static>
-      <name>navigation2</name>
     </model>
     <model name="navigation3" type="waypoint">
       <pose>5.39 0 0 0 0 3.1415</pose>
       <static>true</static>
-      <name>navigation3</name>
     </model>
     <model name="navigation4" type="waypoint">
       <pose>4.6 0 0 0 0 0</pose>
       <static>true</static>
-      <name>navigation4</name>
     </model>
     <model name="rips1" type="waypoint">
       <pose>8.0 -1.5 0 0 0 -1.57</pose>
       <static>true</static>
-      <name>rips1</name>
     </model>
     <model name="rips2" type="waypoint">
       <pose>8.0 -1.5 0 0 0 1.57</pose>
       <static>true</static>
-      <name>rips2</name>
     </model>
     <model name="rips1" type="waypoint">
       <pose>8.0 -3.5 0 0 0 1.57</pose>
       <static>true</static>
-      <name>rips1</name>
     </model>
     <model name="bookcase_waypoint" type="waypoint">
       <pose>2.285 -8.414 0 0 0 0</pose>
       <static>true</static>
-      <name>bookcase_waypoint</name>
     </model>
     <model name="dinnertable_waypoint" type="waypoint">
       <pose>6.271 0.613 0 0 0 0</pose>
       <static>true</static>
-      <name>dinnertable_waypoint</name>
     </model>
     <model name="granny_waypoint" type="waypoint">
       <pose>3.062 -5.214 0 0 0 -1.57</pose>
       <static>true</static>
-      <name>granny_waypoint</name>
     </model>
     <model name="gpsr_meeting_point" type="waypoint">
       <pose>3.25 -7.0 0 0 0 -1.57</pose>
       <static>true</static>
-      <name>gpsr_meeting_point</name>
     </model>
     <model name="kitchen" type="room">
       <link name="in">
@@ -134,13 +111,10 @@
             </box>
           </geometry>
           <pose>0.0 0.0 0.0 0 0 0</pose>
-          <name>in</name>
         </virtual_volume>
-        <name>in</name>
       </link>
       <pose>2.95 0 0 0 0 0</pose>
       <static>true</static>
-      <name>kitchen</name>
     </model>
     <model name="livingroom" type="room">
       <link name="in">
@@ -151,13 +125,10 @@
             </box>
           </geometry>
           <pose>0.0 0.0 0.0 0 0 0</pose>
-          <name>in</name>
         </virtual_volume>
-        <name>in</name>
       </link>
       <pose>8.5 -1.825 0 0 0 0</pose>
       <static>true</static>
-      <name>livingroom</name>
     </model>
     <model name="bedroom" type="room">
       <link name="in">
@@ -168,13 +139,10 @@
             </box>
           </geometry>
           <pose>0.0 0.0 0.0 0 0 0</pose>
-          <name>in</name>
         </virtual_volume>
-        <name>in</name>
       </link>
       <pose>8.5 -7.825 0 0 0 0</pose>
       <static>true</static>
-      <name>bedroom</name>
     </model>
     <model name="hallway" type="room">
       <link name="in">
@@ -185,140 +153,133 @@
             </box>
           </geometry>
           <pose>0.0 0.0 0.0 0 0 0</pose>
-          <name>in</name>
         </virtual_volume>
-        <name>in</name>
       </link>
       <pose>2.975 -6.175 0 0 0 0</pose>
       <static>true</static>
-      <name>hallway</name>
     </model>
     <model name="person_rec_learning" type="waypoint">
       <pose>7.316 -3.636 0 0 0 -1.578</pose>
       <static>true</static>
-      <name>person_rec_learning</name>
     </model>
     <model name="person_rec_living_room_1" type="waypoint">
       <pose>8.533 -4.677 0 0 0 1.562</pose>
       <static>true</static>
-      <name>person_rec_living_room_1</name>
     </model>
     <model name="person_rec_living_room_2" type="waypoint">
       <pose>7.773 -3.956 0 0 0 1.588</pose>
       <static>true</static>
-      <name>person_rec_living_room_2</name>
     </model>
     <model name="person_rec_living_room_3" type="waypoint">
       <pose>6.598 -2.748 0 0 0 0.96</pose>
       <static>true</static>
-      <name>person_rec_living_room_3</name>
     </model>
-    <include name="walls">
+    <include>
       <pose>0 0 0 0 0 0</pose>
       <name>walls</name>
       <uri>model://rwc2015/walls</uri>
     </include>
-    <include name="floor">
+    <include>
       <pose>0 0 0 0 0 0</pose>
       <name>floor</name>
       <uri>model://floor</uri>
     </include>
-    <include name="bookcase">
+    <include>
       <pose>0.925 -4.74 0 0 0 0</pose>
       <name>bookcase</name>
       <uri>model://rwc2015/bookcase</uri>
     </include>
-    <include name="hallwaytable">
+    <include>
       <pose>3.12 -6.725 0 0 0 0</pose>
       <name>hallwaytable</name>
       <uri>model://rwc2015/hallwaytable</uri>
     </include>
-    <include name="kitchentable">
+    <include>
       <pose>3.055 -1.775 0 0 0 0</pose>
       <name>kitchentable</name>
       <uri>model://rwc2015/kitchentable</uri>
     </include>
-    <include name="left_bedside_table">
+    <include>
       <pose>11.425 -9.135 0 0 0 0</pose>
       <name>left_bedside_table</name>
       <uri>model://rwc2015/bedstand</uri>
     </include>
-    <include name="right_bedside_table">
+    <include>
       <pose>11.425 -7.165 0 0 0 0</pose>
       <name>right_bedside_table</name>
       <uri>model://rwc2015/bedstand</uri>
     </include>
-    <include name="bed">
+    <include>
       <pose>10.535 -8.15 0 0 0 0</pose>
       <name>bed</name>
       <uri>model://rwc2015/bed</uri>
     </include>
-    <include name="desk">
+    <include>
       <pose>6.875 -9.675 0 0 0 1.571</pose>
       <name>desk</name>
       <uri>model://rwc2015/desk</uri>
     </include>
-    <include name="kitchencounter">
+    <include>
       <pose>2.555 2.175 0 0 0 -1.571</pose>
       <name>kitchencounter</name>
       <uri>model://rwc2015/kitchencounter</uri>
     </include>
-    <include name="bar">
+    <include>
       <pose>5.57 -2.315 0 0 0 3.1415</pose>
       <name>bar</name>
       <uri>model://rwc2015/bar</uri>
     </include>
-    <include name="sofa">
+    <include>
       <pose>11.265 -2.48 0 0 0 0</pose>
       <name>sofa</name>
       <uri>model://rwc2015/sofa</uri>
     </include>
-    <include name="couchtable">
+    <include>
       <pose>10.135 -2.48 0 0 0 0</pose>
       <name>couchtable</name>
       <uri>model://rwc2015/couchtable</uri>
     </include>
-    <include name="dinnertable">
+    <include>
       <pose>8.185 0.6825 0 0 0 1.571</pose>
       <name>dinnertable</name>
       <uri>model://rwc2015/dinnertable</uri>
     </include>
-    <include name="cupboard">
+    <include>
       <pose>3.875 2.28 0 0 0 1.571</pose>
       <name>cupboard</name>
       <uri>model://rwc2015/cupboard</uri>
     </include>
-    <include name="fridge">
+    <include>
       <pose>1.1425 2.1025 0 0 0 1.571</pose>
       <name>fridge</name>
       <uri>model://rwc2015/fridge</uri>
     </include>
-    <include name="trashbin">
+    <include>
       <pose>5.15 -1.375 0 0 0 0.0</pose>
       <name>trashbin</name>
       <uri>model://rwc2015/trashbin</uri>
     </include>
-    <include name="plant_hallway">
+    <include>
       <pose>5.05 -2.775 0 0 0 0.0</pose>
       <name>plant_hallway</name>
       <uri>model://rwc2015/plant_hallway</uri>
     </include>
-    <include name="plant_bedroom_low">
+    <include>
       <pose>5.7 -9.65 0 0 0 0.0</pose>
       <name>plant_bedroom_low</name>
       <uri>model://rwc2015/plant_bedroom_low</uri>
     </include>
-    <include name="plant_bedroom_high">
+    <include>
       <pose>5.7 -6.35 0 0 0 0.0</pose>
       <name>plant_bedroom_high</name>
       <uri>model://rwc2015/plant_bedroom_high</uri>
     </include>
-    <include name="plant_livingroom_low">
+    <include>
       <pose>11.125 -5.55 0 0 0 0.0</pose>
       <name>plant_livingroom_low</name>
       <uri>model://rwc2015/plant_livingroom_low</uri>
     </include>
-    <include name="plant_livingroom_high">
+    <include>
       <pose>5.75 2.1 0 0 0 0.0</pose>
       <name>plant_livingroom_high</name>
       <uri>model://rwc2015/plant_livingroom_high</uri>
@@ -335,6 +296,5 @@
         </solver>
       </ode>
     </physics>
-    <name>rwc2015</name>
   </world>
 </sdf>

--- a/models/rwc2015/old/coathanger/model.sdf
+++ b/models/rwc2015/old/coathanger/model.sdf
@@ -8,7 +8,6 @@
             <size>0.35 0.35 0.055</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -19,10 +18,8 @@
         <material>
           <ambient>0.9 0.9 0.9 1</ambient>
         </material>
-        <name>1</name>
       </visual>
       <pose>0.0 0.0 0.0275 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="2">
       <collision name="2">
@@ -31,7 +28,6 @@
             <size>0.05 0.05 1.29</size>
           </box>
         </geometry>
-        <name>2</name>
       </collision>
       <visual name="2">
         <geometry>
@@ -42,12 +38,9 @@
         <material>
           <ambient>0.9 0.9 0.9 1</ambient>
         </material>
-        <name>2</name>
       </visual>
       <pose>0.0 0.0 0.645 0 0 0</pose>
-      <name>2</name>
     </link>
     <static>true</static>
-    <name>rwc2015/old/coathanger</name>
   </model>
 </sdf>

--- a/models/rwc2015/old/sink/model.sdf
+++ b/models/rwc2015/old/sink/model.sdf
@@ -8,7 +8,6 @@
             <size>0.5 0.6 0.01</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -19,12 +18,9 @@
         <material>
           <ambient>0.8 0.8 0.8 1</ambient>
         </material>
-        <name>1</name>
       </visual>
       <pose>0.0 0.0 0.05 0 0 0</pose>
-      <name>1</name>
     </link>
     <static>true</static>
-    <name>rwc2015/old/sink</name>
   </model>
 </sdf>

--- a/models/rwc2015/old/stove/model.sdf
+++ b/models/rwc2015/old/stove/model.sdf
@@ -8,7 +8,6 @@
             <size>0.51 0.29 0.01</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -19,12 +18,9 @@
         <material>
           <ambient>0.1 0.1 0.1 1</ambient>
         </material>
-        <name>1</name>
       </visual>
       <pose>0.0 0.0 0.05 0 0 0</pose>
-      <name>1</name>
     </link>
     <static>true</static>
-    <name>rwc2015/old/stove</name>
   </model>
 </sdf>

--- a/models/rwc2015/old/tv/foot/model.sdf
+++ b/models/rwc2015/old/tv/foot/model.sdf
@@ -8,7 +8,6 @@
             <uri>model://rwc2015/old/tv/foot/shape/disc.stl</uri>
           </mesh>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -16,12 +15,9 @@
             <uri>model://rwc2015/old/tv/foot/shape/disc.stl</uri>
           </mesh>
         </geometry>
-        <name>1</name>
       </visual>
       <pose>0 0 0 0 0 0</pose>
-      <name>1</name>
     </link>
     <static>true</static>
-    <name>rwc2015/old/tv/foot</name>
   </model>
 </sdf>

--- a/models/rwc2015/old/tv/model.sdf
+++ b/models/rwc2015/old/tv/model.sdf
@@ -4,7 +4,6 @@
     <light name="sun" type="directional">
       <direction>0.5 0.1 -0.9</direction>
       <pose>0 0 10 0 0 0</pose>
-      <name>sun</name>
       <specular>0.2 0.2 0.2 1</specular>
       <cast_shadows>true</cast_shadows>
       <diffuse>0.8 0.8 0.8 1</diffuse>
@@ -15,17 +14,17 @@
         <linear>0.01</linear>
       </attenuation>
     </light>
-    <include name="foot">
+    <include>
       <pose>0 0 0 0 0 0</pose>
       <name>foot</name>
       <uri>model://rwc2015/tv/foot</uri>
     </include>
-    <include name="pole">
+    <include>
       <pose>0 0 0 0 0 0</pose>
       <name>pole</name>
       <uri>model://rwc2015/tv/pole</uri>
     </include>
-    <include name="tv">
+    <include>
       <pose>0.23 0 1.67 0 0.1 0</pose>
       <name>tv</name>
       <uri>model://rwc2015/tv/tv</uri>
@@ -42,6 +41,5 @@
         </solver>
       </ode>
     </physics>
-    <name>rwc2015/old/tv</name>
   </world>
 </sdf>

--- a/models/rwc2015/old/tv/pole/model.sdf
+++ b/models/rwc2015/old/tv/pole/model.sdf
@@ -8,7 +8,6 @@
             <size>0.28 0.28 2.0</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -19,12 +18,9 @@
         <material>
           <ambient>0.7 0.7 0.7 1</ambient>
         </material>
-        <name>1</name>
       </visual>
       <pose>0.0 0.0 1.0 0 0 0</pose>
-      <name>1</name>
     </link>
     <static>true</static>
-    <name>rwc2015/old/tv/pole</name>
   </model>
 </sdf>

--- a/models/rwc2015/old/tv/tv/model.sdf
+++ b/models/rwc2015/old/tv/tv/model.sdf
@@ -8,7 +8,6 @@
             <size>0.1 1.5 0.92</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -19,12 +18,9 @@
         <material>
           <ambient>0.1 0.1 0.1 1</ambient>
         </material>
-        <name>1</name>
       </visual>
       <pose>0.0 0.0 0.46 0 0 0</pose>
-      <name>1</name>
     </link>
     <static>true</static>
-    <name>rwc2015/old/tv/tv</name>
   </model>
 </sdf>

--- a/models/rwc2015/old/tv_stand/model.sdf
+++ b/models/rwc2015/old/tv_stand/model.sdf
@@ -8,7 +8,6 @@
             <size>0.4 1.2 0.39</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -19,12 +18,9 @@
         <material>
           <ambient>0.9 0.9 0.9 1</ambient>
         </material>
-        <name>1</name>
       </visual>
       <pose>0.0 0.0 0.195 0 0 0</pose>
-      <name>1</name>
     </link>
     <static>true</static>
-    <name>rwc2015/old/tv_stand</name>
   </model>
 </sdf>

--- a/models/rwc2015/plant_bedroom_high/model.sdf
+++ b/models/rwc2015/plant_bedroom_high/model.sdf
@@ -8,7 +8,6 @@
             <size>0.2 0.2 2.0</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -19,12 +18,9 @@
         <material>
           <ambient>0.0 0.6 0.0 1</ambient>
         </material>
-        <name>1</name>
       </visual>
       <pose>0.0 0.0 1.0 0 0 0</pose>
-      <name>1</name>
     </link>
     <static>true</static>
-    <name>rwc2015/plant_bedroom_high</name>
   </model>
 </sdf>

--- a/models/rwc2015/plant_bedroom_low/model.sdf
+++ b/models/rwc2015/plant_bedroom_low/model.sdf
@@ -8,7 +8,6 @@
             <size>0.2 0.2 1.0</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -19,12 +18,9 @@
         <material>
           <ambient>0.0 0.6 0.0 1</ambient>
         </material>
-        <name>1</name>
       </visual>
       <pose>0.0 0.0 0.5 0 0 0</pose>
-      <name>1</name>
     </link>
     <static>true</static>
-    <name>rwc2015/plant_bedroom_low</name>
   </model>
 </sdf>

--- a/models/rwc2015/plant_hallway/model.sdf
+++ b/models/rwc2015/plant_hallway/model.sdf
@@ -8,7 +8,6 @@
             <size>0.2 0.2 1.5</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -19,12 +18,9 @@
         <material>
           <ambient>0.0 0.6 0.0 1</ambient>
         </material>
-        <name>1</name>
       </visual>
       <pose>0.0 0.0 0.75 0 0 0</pose>
-      <name>1</name>
     </link>
     <static>true</static>
-    <name>rwc2015/plant_hallway</name>
   </model>
 </sdf>

--- a/models/rwc2015/plant_livingroom_high/model.sdf
+++ b/models/rwc2015/plant_livingroom_high/model.sdf
@@ -8,7 +8,6 @@
             <size>0.7 0.7 2.0</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -19,12 +18,9 @@
         <material>
           <ambient>0.0 0.6 0.0 1</ambient>
         </material>
-        <name>1</name>
       </visual>
       <pose>0.0 0.0 1.0 0 0 0</pose>
-      <name>1</name>
     </link>
     <static>true</static>
-    <name>rwc2015/plant_livingroom_high</name>
   </model>
 </sdf>

--- a/models/rwc2015/plant_livingroom_low/model.sdf
+++ b/models/rwc2015/plant_livingroom_low/model.sdf
@@ -8,7 +8,6 @@
             <size>0.7 0.7 1.1</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -19,12 +18,9 @@
         <material>
           <ambient>0.0 0.6 0.0 1</ambient>
         </material>
-        <name>1</name>
       </visual>
       <pose>0.0 0.0 0.55 0 0 0</pose>
-      <name>1</name>
     </link>
     <static>true</static>
-    <name>rwc2015/plant_livingroom_low</name>
   </model>
 </sdf>

--- a/models/rwc2015/small_table/model.sdf
+++ b/models/rwc2015/small_table/model.sdf
@@ -8,7 +8,6 @@
             <size>0.55 1.1 0.015</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -19,10 +18,8 @@
         <material>
           <ambient>0.5 0.5 0.5 1</ambient>
         </material>
-        <name>1</name>
       </visual>
       <pose>0.0 0.0 0.7275 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="2">
       <collision name="2">
@@ -31,7 +28,6 @@
             <size>0.03 0.03 0.7275</size>
           </box>
         </geometry>
-        <name>2</name>
       </collision>
       <visual name="2">
         <geometry>
@@ -42,10 +38,8 @@
         <material>
           <ambient>0.5 0.5 0.5 1</ambient>
         </material>
-        <name>2</name>
       </visual>
       <pose>-0.19 -0.395 0.36375 0 0 0</pose>
-      <name>2</name>
     </link>
     <link name="3">
       <collision name="3">
@@ -54,7 +48,6 @@
             <size>0.03 0.03 0.7275</size>
           </box>
         </geometry>
-        <name>3</name>
       </collision>
       <visual name="3">
         <geometry>
@@ -65,10 +58,8 @@
         <material>
           <ambient>0.5 0.5 0.5 1</ambient>
         </material>
-        <name>3</name>
       </visual>
       <pose>0.19 -0.395 0.36375 0 0 0</pose>
-      <name>3</name>
     </link>
     <link name="4">
       <collision name="4">
@@ -77,7 +68,6 @@
             <size>0.03 0.03 0.7275</size>
           </box>
         </geometry>
-        <name>4</name>
       </collision>
       <visual name="4">
         <geometry>
@@ -88,10 +78,8 @@
         <material>
           <ambient>0.5 0.5 0.5 1</ambient>
         </material>
-        <name>4</name>
       </visual>
       <pose>-0.19 0.395 0.36375 0 0 0</pose>
-      <name>4</name>
     </link>
     <link name="5">
       <collision name="5">
@@ -100,7 +88,6 @@
             <size>0.03 0.03 0.7275</size>
           </box>
         </geometry>
-        <name>5</name>
       </collision>
       <visual name="5">
         <geometry>
@@ -111,10 +98,8 @@
         <material>
           <ambient>0.5 0.5 0.5 1</ambient>
         </material>
-        <name>5</name>
       </visual>
       <pose>0.19 0.395 0.36375 0 0 0</pose>
-      <name>5</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
@@ -124,11 +109,8 @@
           </box>
         </geometry>
         <pose>0.65 0.0 0.5 0 0 0</pose>
-        <name>in_front_of</name>
       </virtual_volume>
-      <name>in_front_of</name>
     </link>
     <static>true</static>
-    <name>rwc2015/small_table</name>
   </model>
 </sdf>

--- a/models/rwc2015/sofa/model.sdf
+++ b/models/rwc2015/sofa/model.sdf
@@ -8,7 +8,6 @@
             <size>0.72 1.25 0.08</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -19,10 +18,8 @@
         <material>
           <ambient>0.1 0.1 0.1 1</ambient>
         </material>
-        <name>1</name>
       </visual>
       <pose>0.0 0.9 0.15 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="2">
       <collision name="2">
@@ -31,7 +28,6 @@
             <size>0.72 1.25 0.08</size>
           </box>
         </geometry>
-        <name>2</name>
       </collision>
       <visual name="2">
         <geometry>
@@ -42,10 +38,8 @@
         <material>
           <ambient>0.1 0.1 0.1 1</ambient>
         </material>
-        <name>2</name>
       </visual>
       <pose>0.0 -0.9 0.15 0 0 0</pose>
-      <name>2</name>
     </link>
     <link name="3">
       <collision name="3">
@@ -54,7 +48,6 @@
             <size>0.72 3.6 0.175</size>
           </box>
         </geometry>
-        <name>3</name>
       </collision>
       <visual name="3">
         <geometry>
@@ -65,10 +58,8 @@
         <material>
           <ambient>0.1 0.1 0.1 1</ambient>
         </material>
-        <name>3</name>
       </visual>
       <pose>0.0 0.0 0.2775 0 0 0</pose>
-      <name>3</name>
     </link>
     <link name="4">
       <collision name="4">
@@ -77,7 +68,6 @@
             <size>0.17 3.6 0.48</size>
           </box>
         </geometry>
-        <name>4</name>
       </collision>
       <visual name="4">
         <geometry>
@@ -88,10 +78,8 @@
         <material>
           <ambient>0.1 0.1 0.1 1</ambient>
         </material>
-        <name>4</name>
       </visual>
       <pose>0.29 0.0 0.605 0 0 0</pose>
-      <name>4</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
@@ -101,9 +89,7 @@
           </box>
         </geometry>
         <pose>-0.6 -1.22 0.5 0 0 0</pose>
-        <name>in_front_of</name>
       </virtual_volume>
-      <name>in_front_of</name>
     </link>
     <link name="in_front_of_pos2">
       <virtual_volume name="in_front_of_pos2">
@@ -113,11 +99,8 @@
           </box>
         </geometry>
         <pose>-0.6 1.22 0.5 0 0 0</pose>
-        <name>in_front_of_pos2</name>
       </virtual_volume>
-      <name>in_front_of_pos2</name>
     </link>
     <static>true</static>
-    <name>rwc2015/sofa</name>
   </model>
 </sdf>

--- a/models/rwc2015/table/model.sdf
+++ b/models/rwc2015/table/model.sdf
@@ -8,7 +8,6 @@
             <size>0.7 1.2 0.02</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -19,10 +18,8 @@
         <material>
           <ambient>0.9 0.9 0.9 1</ambient>
         </material>
-        <name>1</name>
       </visual>
       <pose>0.0 0.0 0.76 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="2">
       <collision name="2">
@@ -31,7 +28,6 @@
             <size>0.05 0.075 0.76</size>
           </box>
         </geometry>
-        <name>2</name>
       </collision>
       <visual name="2">
         <geometry>
@@ -42,10 +38,8 @@
         <material>
           <ambient>0.9 0.9 0.9 1</ambient>
         </material>
-        <name>2</name>
       </visual>
       <pose>-0.305 -0.5425 0.38 0 0 0</pose>
-      <name>2</name>
     </link>
     <link name="3">
       <collision name="3">
@@ -54,7 +48,6 @@
             <size>0.05 0.075 0.76</size>
           </box>
         </geometry>
-        <name>3</name>
       </collision>
       <visual name="3">
         <geometry>
@@ -65,10 +58,8 @@
         <material>
           <ambient>0.9 0.9 0.9 1</ambient>
         </material>
-        <name>3</name>
       </visual>
       <pose>-0.305 0.5425 0.38 0 0 0</pose>
-      <name>3</name>
     </link>
     <link name="4">
       <collision name="4">
@@ -77,7 +68,6 @@
             <size>0.05 0.075 0.76</size>
           </box>
         </geometry>
-        <name>4</name>
       </collision>
       <visual name="4">
         <geometry>
@@ -88,10 +78,8 @@
         <material>
           <ambient>0.9 0.9 0.9 1</ambient>
         </material>
-        <name>4</name>
       </visual>
       <pose>0.305 -0.5425 0.38 0 0 0</pose>
-      <name>4</name>
     </link>
     <link name="5">
       <collision name="5">
@@ -100,7 +88,6 @@
             <size>0.05 0.075 0.76</size>
           </box>
         </geometry>
-        <name>5</name>
       </collision>
       <visual name="5">
         <geometry>
@@ -111,10 +98,8 @@
         <material>
           <ambient>0.9 0.9 0.9 1</ambient>
         </material>
-        <name>5</name>
       </visual>
       <pose>0.305 0.5425 0.38 0 0 0</pose>
-      <name>5</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
@@ -124,9 +109,7 @@
           </box>
         </geometry>
         <pose>0.0 -0.325 0.5 0 0 0</pose>
-        <name>in_front_of</name>
       </virtual_volume>
-      <name>in_front_of</name>
     </link>
     <link name="in_front_of_pos2">
       <virtual_volume name="in_front_of_pos2">
@@ -136,11 +119,8 @@
           </box>
         </geometry>
         <pose>0.0 0.325 0.5 0 0 0</pose>
-        <name>in_front_of_pos2</name>
       </virtual_volume>
-      <name>in_front_of_pos2</name>
     </link>
     <static>true</static>
-    <name>rwc2015/table</name>
   </model>
 </sdf>

--- a/models/rwc2015/trashbin/model.sdf
+++ b/models/rwc2015/trashbin/model.sdf
@@ -8,7 +8,6 @@
             <size>0.3 0.3 0.4</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -19,10 +18,8 @@
         <material>
           <ambient>0.8 0.8 0.8 1</ambient>
         </material>
-        <name>1</name>
       </visual>
       <pose>0.0 0.0 0.2 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
@@ -32,11 +29,8 @@
           </box>
         </geometry>
         <pose>-0.6 0.55 0.5 0 0 0</pose>
-        <name>in_front_of</name>
       </virtual_volume>
-      <name>in_front_of</name>
     </link>
     <static>true</static>
-    <name>rwc2015/trashbin</name>
   </model>
 </sdf>

--- a/models/rwc2015/walls/model.sdf
+++ b/models/rwc2015/walls/model.sdf
@@ -8,7 +8,6 @@
             <uri>model://rwc2015/walls/heightmap_arenaa.stl</uri>
           </mesh>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -16,12 +15,9 @@
             <uri>model://rwc2015/walls/heightmap_arenaa.stl</uri>
           </mesh>
         </geometry>
-        <name>1</name>
       </visual>
       <pose>0 0 0 0 0 0</pose>
-      <name>1</name>
     </link>
     <static>true</static>
-    <name>rwc2015/walls</name>
   </model>
 </sdf>

--- a/models/rwc2015_empty/model.sdf
+++ b/models/rwc2015_empty/model.sdf
@@ -4,7 +4,6 @@
     <light name="sun" type="directional">
       <direction>0.5 0.1 -0.9</direction>
       <pose>0 0 10 0 0 0</pose>
-      <name>sun</name>
       <specular>0.2 0.2 0.2 1</specular>
       <cast_shadows>true</cast_shadows>
       <diffuse>0.8 0.8 0.8 1</diffuse>
@@ -18,117 +17,94 @@
     <model name="initial_pose" type="waypoint">
       <pose>0 0 0 0 0 0</pose>
       <static>true</static>
-      <name>initial_pose</name>
     </model>
     <model name="initial_pose_door_B" type="waypoint">
       <pose>0 0 0 0 0 0</pose>
       <static>true</static>
-      <name>initial_pose_door_B</name>
     </model>
     <model name="initial_pose_door_A" type="waypoint">
       <pose>0 -6.15 0 0 0 0.0</pose>
       <static>true</static>
-      <name>initial_pose_door_A</name>
     </model>
     <model name="exit_door_B1" type="waypoint">
       <pose>-1.0 0 0 0 0 3.1415</pose>
       <static>true</static>
-      <name>exit_door_B1</name>
     </model>
     <model name="exit_door_B2" type="waypoint">
       <pose>-2.0 0 0 0 0 3.1415</pose>
       <static>true</static>
-      <name>exit_door_B2</name>
     </model>
     <model name="exit_door_B3" type="waypoint">
       <pose>1.0 0 0 0 0 3.1415</pose>
       <static>true</static>
-      <name>exit_door_B3</name>
     </model>
     <model name="exit_door_A1" type="waypoint">
       <pose>-1.0 -6.15 0 0 0 3.1415</pose>
       <static>true</static>
-      <name>exit_door_A1</name>
     </model>
     <model name="exit_door_A2" type="waypoint">
       <pose>-2.0 -6.15 0 0 0 3.1415</pose>
       <static>true</static>
-      <name>exit_door_A2</name>
     </model>
     <model name="exit_door_A3" type="waypoint">
       <pose>1.0 -6.15 0 0 0 3.1415</pose>
       <static>true</static>
-      <name>exit_door_A3</name>
     </model>
     <model name="entry_point_B" type="waypoint">
       <pose>1.0 0 0 0 0 0</pose>
       <static>true</static>
-      <name>entry_point_B</name>
     </model>
     <model name="entry_point_A" type="waypoint">
       <pose>1.0 -6.15 0 0 0 0</pose>
       <static>true</static>
-      <name>entry_point_A</name>
     </model>
     <model name="operator_pose" type="waypoint">
       <pose>9.0 -1.0 0 0 0 0.0</pose>
       <static>true</static>
-      <name>operator_pose</name>
     </model>
     <model name="explore1" type="waypoint">
       <pose>2.0 0.0 0 0 0 1.57</pose>
       <static>true</static>
-      <name>explore1</name>
     </model>
     <model name="explore2" type="waypoint">
       <pose>3.0 0.0 0 0 0 -1.57</pose>
       <static>true</static>
-      <name>explore2</name>
     </model>
     <model name="explore3" type="waypoint">
       <pose>5.0 0.0 0 0 0 0.0</pose>
       <static>true</static>
-      <name>explore3</name>
     </model>
     <model name="explore4" type="waypoint">
       <pose>7.0 -1.0 0 0 0 -1.57</pose>
       <static>true</static>
-      <name>explore4</name>
     </model>
     <model name="explore5" type="waypoint">
       <pose>8.0 -2.0 0 0 0 0.0</pose>
       <static>true</static>
-      <name>explore5</name>
     </model>
     <model name="explore6" type="waypoint">
       <pose>8.0 -3.0 0 0 0 3.14</pose>
       <static>true</static>
-      <name>explore6</name>
     </model>
     <model name="explore7" type="waypoint">
       <pose>8.5 -4.0 0 0 0 -1.57</pose>
       <static>true</static>
-      <name>explore7</name>
     </model>
     <model name="explore8" type="waypoint">
       <pose>8.0 -7.0 0 0 0 0.0</pose>
       <static>true</static>
-      <name>explore8</name>
     </model>
     <model name="explore9" type="waypoint">
       <pose>8.0 -8.0 0 0 0 -1.57</pose>
       <static>true</static>
-      <name>explore9</name>
     </model>
     <model name="explore10" type="waypoint">
       <pose>3.0 -8.0 0 0 0 3.14</pose>
       <static>true</static>
-      <name>explore10</name>
     </model>
     <model name="explore11" type="waypoint">
       <pose>3.0 -8.0 0 0 0 1.57</pose>
       <static>true</static>
-      <name>explore11</name>
     </model>
     <model name="kitchen" type="room">
       <link name="in">
@@ -139,13 +115,10 @@
             </box>
           </geometry>
           <pose>0.0 0.0 0.0 0 0 0</pose>
-          <name>in</name>
         </virtual_volume>
-        <name>in</name>
       </link>
       <pose>2.95 0 0 0 0 0</pose>
       <static>true</static>
-      <name>kitchen</name>
     </model>
     <model name="livingroom" type="room">
       <link name="in">
@@ -156,13 +129,10 @@
             </box>
           </geometry>
           <pose>0.0 0.0 0.0 0 0 0</pose>
-          <name>in</name>
         </virtual_volume>
-        <name>in</name>
       </link>
       <pose>8.5 -1.825 0 0 0 0</pose>
       <static>true</static>
-      <name>livingroom</name>
     </model>
     <model name="bedroom" type="room">
       <link name="in">
@@ -173,13 +143,10 @@
             </box>
           </geometry>
           <pose>0.0 0.0 0.0 0 0 0</pose>
-          <name>in</name>
         </virtual_volume>
-        <name>in</name>
       </link>
       <pose>8.5 -7.825 0 0 0 0</pose>
       <static>true</static>
-      <name>bedroom</name>
     </model>
     <model name="hallway" type="room">
       <link name="in">
@@ -190,20 +157,17 @@
             </box>
           </geometry>
           <pose>0.0 0.0 0.0 0 0 0</pose>
-          <name>in</name>
         </virtual_volume>
-        <name>in</name>
       </link>
       <pose>2.975 -6.175 0 0 0 0</pose>
       <static>true</static>
-      <name>hallway</name>
     </model>
-    <include name="walls">
+    <include>
       <pose>0 0 0 0 0 0</pose>
       <name>walls</name>
       <uri>model://rwc2015/walls</uri>
     </include>
-    <include name="floor">
+    <include>
       <pose>0 0 0 0 0 0</pose>
       <name>floor</name>
       <uri>model://floor</uri>
@@ -220,6 +184,5 @@
         </solver>
       </ode>
     </physics>
-    <name>rwc2015_empty</name>
   </world>
 </sdf>

--- a/models/rwc2016/armchair/model.sdf
+++ b/models/rwc2016/armchair/model.sdf
@@ -8,7 +8,6 @@
             <uri>model://rwc2016/armchair/heightmap.stl</uri>
           </mesh>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -16,12 +15,9 @@
             <uri>model://rwc2016/armchair/heightmap.stl</uri>
           </mesh>
         </geometry>
-        <name>1</name>
       </visual>
       <pose>0 0 0 0 0 -1.57</pose>
-      <name>1</name>
     </link>
     <static>true</static>
-    <name>rwc2016/armchair</name>
   </model>
 </sdf>

--- a/models/rwc2016/bed_frame/model.sdf
+++ b/models/rwc2016/bed_frame/model.sdf
@@ -8,7 +8,6 @@
             <size>0.972 2.063 0.445</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -19,10 +18,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>1</name>
       </visual>
       <pose>0 0 0.225 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="2">
       <collision name="2">
@@ -31,7 +28,6 @@
             <size>0.972 0.04 0.355</size>
           </box>
         </geometry>
-        <name>2</name>
       </collision>
       <visual name="2">
         <geometry>
@@ -42,10 +38,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>2</name>
       </visual>
       <pose>0 -1.0115 0.6225 0 0 0</pose>
-      <name>2</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
@@ -55,11 +49,8 @@
           </box>
         </geometry>
         <pose>0.0 0.5 0.005 0 0 0</pose>
-        <name>in_front_of</name>
       </virtual_volume>
-      <name>in_front_of</name>
     </link>
     <static>true</static>
-    <name>rwc2016/bed_frame</name>
   </model>
 </sdf>

--- a/models/rwc2016/bookcase1/model.sdf
+++ b/models/rwc2016/bookcase1/model.sdf
@@ -8,7 +8,6 @@
             <size>0.35 0.02 1.798</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -19,10 +18,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>1</name>
       </visual>
       <pose>0 -0.39 0.899 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="2">
       <collision name="2">
@@ -31,7 +28,6 @@
             <size>0.35 0.02 1.798</size>
           </box>
         </geometry>
-        <name>2</name>
       </collision>
       <visual name="2">
         <geometry>
@@ -42,10 +38,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>2</name>
       </visual>
       <pose>0 0.39 0.899 0 0 0</pose>
-      <name>2</name>
     </link>
     <link name="3">
       <collision name="3">
@@ -54,7 +48,6 @@
             <size>0.02 0.8 1.798</size>
           </box>
         </geometry>
-        <name>3</name>
       </collision>
       <visual name="3">
         <geometry>
@@ -65,10 +58,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>3</name>
       </visual>
       <pose>-0.165 0 0.899 0 0 0</pose>
-      <name>3</name>
     </link>
     <link name="4">
       <collision name="4">
@@ -77,7 +68,6 @@
             <size>0.33 0.76 0.02</size>
           </box>
         </geometry>
-        <name>4</name>
       </collision>
       <visual name="4">
         <geometry>
@@ -88,10 +78,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>4</name>
       </visual>
       <pose>0.01 0 1.788 0 0 0</pose>
-      <name>4</name>
     </link>
     <link name="5">
       <collision name="5">
@@ -100,7 +88,6 @@
             <size>0.33 0.76 0.069</size>
           </box>
         </geometry>
-        <name>5</name>
       </collision>
       <visual name="5">
         <geometry>
@@ -111,10 +98,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>5</name>
       </visual>
       <pose>0.01 0 0.0345 0 0 0</pose>
-      <name>5</name>
     </link>
     <link name="6">
       <collision name="6">
@@ -123,7 +108,6 @@
             <size>0.33 0.76 0.02</size>
           </box>
         </geometry>
-        <name>6</name>
       </collision>
       <visual name="6">
         <geometry>
@@ -134,10 +118,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>6</name>
       </visual>
       <pose>0.01 0 0.408 0 0 0</pose>
-      <name>6</name>
     </link>
     <link name="7">
       <collision name="7">
@@ -146,7 +128,6 @@
             <size>0.33 0.76 0.02</size>
           </box>
         </geometry>
-        <name>7</name>
       </collision>
       <visual name="7">
         <geometry>
@@ -157,10 +138,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>7</name>
       </visual>
       <pose>0.01 0 0.755 0 0 0</pose>
-      <name>7</name>
     </link>
     <link name="8">
       <collision name="8">
@@ -169,7 +148,6 @@
             <size>0.33 0.76 0.02</size>
           </box>
         </geometry>
-        <name>8</name>
       </collision>
       <visual name="8">
         <geometry>
@@ -180,10 +158,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>8</name>
       </visual>
       <pose>0.01 0 1.097 0 0 0</pose>
-      <name>8</name>
     </link>
     <link name="9">
       <collision name="9">
@@ -192,7 +168,6 @@
             <size>0.33 0.76 0.02</size>
           </box>
         </geometry>
-        <name>9</name>
       </collision>
       <visual name="9">
         <geometry>
@@ -203,10 +178,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>9</name>
       </visual>
       <pose>0.01 0 1.443 0 0 0</pose>
-      <name>9</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
@@ -216,9 +189,7 @@
           </box>
         </geometry>
         <pose>0.675 0.0 0.005 0 0 0</pose>
-        <name>in_front_of</name>
       </virtual_volume>
-      <name>in_front_of</name>
     </link>
     <link name="shelf1">
       <virtual_volume name="shelf1">
@@ -228,9 +199,7 @@
           </box>
         </geometry>
         <pose>0.01 0.0 0.214 0 0 0</pose>
-        <name>shelf1</name>
       </virtual_volume>
-      <name>shelf1</name>
     </link>
     <link name="shelf2">
       <virtual_volume name="shelf2">
@@ -240,9 +209,7 @@
           </box>
         </geometry>
         <pose>0.01 0.0 0.563 0 0 0</pose>
-        <name>shelf2</name>
       </virtual_volume>
-      <name>shelf2</name>
     </link>
     <link name="shelf3">
       <virtual_volume name="shelf3">
@@ -252,9 +219,7 @@
           </box>
         </geometry>
         <pose>0.01 0.0 0.92 0 0 0</pose>
-        <name>shelf3</name>
       </virtual_volume>
-      <name>shelf3</name>
     </link>
     <link name="shelf4">
       <virtual_volume name="shelf4">
@@ -264,9 +229,7 @@
           </box>
         </geometry>
         <pose>0.01 0.0 1.257 0 0 0</pose>
-        <name>shelf4</name>
       </virtual_volume>
-      <name>shelf4</name>
     </link>
     <link name="shelf5">
       <virtual_volume name="shelf5">
@@ -276,11 +239,8 @@
           </box>
         </geometry>
         <pose>0.01 0.0 1.598 0 0 0</pose>
-        <name>shelf5</name>
       </virtual_volume>
-      <name>shelf5</name>
     </link>
     <static>true</static>
-    <name>rwc2016/bookcase1</name>
   </model>
 </sdf>

--- a/models/rwc2016/bookcase2/model.sdf
+++ b/models/rwc2016/bookcase2/model.sdf
@@ -8,7 +8,6 @@
             <size>0.281 0.02 2.018</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -19,10 +18,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>1</name>
       </visual>
       <pose>0 -0.39 1.009 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="2">
       <collision name="2">
@@ -31,7 +28,6 @@
             <size>0.281 0.02 2.018</size>
           </box>
         </geometry>
-        <name>2</name>
       </collision>
       <visual name="2">
         <geometry>
@@ -42,10 +38,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>2</name>
       </visual>
       <pose>0 0.39 1.009 0 0 0</pose>
-      <name>2</name>
     </link>
     <link name="3">
       <collision name="3">
@@ -54,7 +48,6 @@
             <size>0.02 0.8 2.018</size>
           </box>
         </geometry>
-        <name>3</name>
       </collision>
       <visual name="3">
         <geometry>
@@ -65,10 +58,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>3</name>
       </visual>
       <pose>-0.1305 0 1.009 0 0 0</pose>
-      <name>3</name>
     </link>
     <link name="4">
       <collision name="4">
@@ -77,7 +68,6 @@
             <size>0.261 0.76 0.02</size>
           </box>
         </geometry>
-        <name>4</name>
       </collision>
       <visual name="4">
         <geometry>
@@ -88,10 +78,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>4</name>
       </visual>
       <pose>0.01 0 2.008 0 0 0</pose>
-      <name>4</name>
     </link>
     <link name="5">
       <collision name="5">
@@ -100,7 +88,6 @@
             <size>0.261 0.76 0.098</size>
           </box>
         </geometry>
-        <name>5</name>
       </collision>
       <visual name="5">
         <geometry>
@@ -111,10 +98,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>5</name>
       </visual>
       <pose>0.01 0 0.049 0 0 0</pose>
-      <name>5</name>
     </link>
     <link name="6">
       <collision name="6">
@@ -123,7 +108,6 @@
             <size>0.261 0.76 0.02</size>
           </box>
         </geometry>
-        <name>6</name>
       </collision>
       <visual name="6">
         <geometry>
@@ -134,10 +118,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>6</name>
       </visual>
       <pose>0.01 0 0.338 0 0 0</pose>
-      <name>6</name>
     </link>
     <link name="7">
       <collision name="7">
@@ -146,7 +128,6 @@
             <size>0.261 0.76 0.02</size>
           </box>
         </geometry>
-        <name>7</name>
       </collision>
       <visual name="7">
         <geometry>
@@ -157,10 +138,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>7</name>
       </visual>
       <pose>0.01 0 0.656 0 0 0</pose>
-      <name>7</name>
     </link>
     <link name="8">
       <collision name="8">
@@ -169,7 +148,6 @@
             <size>0.261 0.76 0.02</size>
           </box>
         </geometry>
-        <name>8</name>
       </collision>
       <visual name="8">
         <geometry>
@@ -180,10 +158,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>8</name>
       </visual>
       <pose>0.01 0 1.048 0 0 0</pose>
-      <name>8</name>
     </link>
     <link name="9">
       <collision name="9">
@@ -192,7 +168,6 @@
             <size>0.261 0.76 0.02</size>
           </box>
         </geometry>
-        <name>9</name>
       </collision>
       <visual name="9">
         <geometry>
@@ -203,10 +178,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>9</name>
       </visual>
       <pose>0.01 0 1.398 0 0 0</pose>
-      <name>9</name>
     </link>
     <link name="10">
       <collision name="10">
@@ -215,7 +188,6 @@
             <size>0.261 0.76 0.02</size>
           </box>
         </geometry>
-        <name>10</name>
       </collision>
       <visual name="10">
         <geometry>
@@ -226,10 +198,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>10</name>
       </visual>
       <pose>0.01 0 1.718 0 0 0</pose>
-      <name>10</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
@@ -239,9 +209,7 @@
           </box>
         </geometry>
         <pose>0.6405 0.0 0.005 0 0 0</pose>
-        <name>in_front_of</name>
       </virtual_volume>
-      <name>in_front_of</name>
     </link>
     <link name="shelf1">
       <virtual_volume name="shelf1">
@@ -251,9 +219,7 @@
           </box>
         </geometry>
         <pose>0.01 0.0 0.213 0 0 0</pose>
-        <name>shelf1</name>
       </virtual_volume>
-      <name>shelf1</name>
     </link>
     <link name="shelf2">
       <virtual_volume name="shelf2">
@@ -263,9 +229,7 @@
           </box>
         </geometry>
         <pose>0.01 0.0 0.493 0 0 0</pose>
-        <name>shelf2</name>
       </virtual_volume>
-      <name>shelf2</name>
     </link>
     <link name="shelf3">
       <virtual_volume name="shelf3">
@@ -275,9 +239,7 @@
           </box>
         </geometry>
         <pose>0.01 0.0 0.811 0 0 0</pose>
-        <name>shelf3</name>
       </virtual_volume>
-      <name>shelf3</name>
     </link>
     <link name="shelf4">
       <virtual_volume name="shelf4">
@@ -287,9 +249,7 @@
           </box>
         </geometry>
         <pose>0.01 0.0 1.203 0 0 0</pose>
-        <name>shelf4</name>
       </virtual_volume>
-      <name>shelf4</name>
     </link>
     <link name="shelf5">
       <virtual_volume name="shelf5">
@@ -299,9 +259,7 @@
           </box>
         </geometry>
         <pose>0.01 0.0 1.553 0 0 0</pose>
-        <name>shelf5</name>
       </virtual_volume>
-      <name>shelf5</name>
     </link>
     <link name="shelf6">
       <virtual_volume name="shelf6">
@@ -311,11 +269,8 @@
           </box>
         </geometry>
         <pose>0.01 0.0 1.868 0 0 0</pose>
-        <name>shelf6</name>
       </virtual_volume>
-      <name>shelf6</name>
     </link>
     <static>true</static>
-    <name>rwc2016/bookcase2</name>
   </model>
 </sdf>

--- a/models/rwc2016/bookcase_noback/model.sdf
+++ b/models/rwc2016/bookcase_noback/model.sdf
@@ -8,7 +8,6 @@
             <size>0.35 0.02 1.798</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -19,10 +18,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>1</name>
       </visual>
       <pose>0 -0.39 0.899 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="2">
       <collision name="2">
@@ -31,7 +28,6 @@
             <size>0.35 0.02 1.798</size>
           </box>
         </geometry>
-        <name>2</name>
       </collision>
       <visual name="2">
         <geometry>
@@ -42,10 +38,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>2</name>
       </visual>
       <pose>0 0.39 0.899 0 0 0</pose>
-      <name>2</name>
     </link>
     <link name="3">
       <collision name="3">
@@ -54,7 +48,6 @@
             <size>0.35 0.76 0.02</size>
           </box>
         </geometry>
-        <name>3</name>
       </collision>
       <visual name="3">
         <geometry>
@@ -65,10 +58,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>3</name>
       </visual>
       <pose>0 0 1.788 0 0 0</pose>
-      <name>3</name>
     </link>
     <link name="4">
       <collision name="4">
@@ -77,7 +68,6 @@
             <size>0.35 0.76 0.125</size>
           </box>
         </geometry>
-        <name>4</name>
       </collision>
       <visual name="4">
         <geometry>
@@ -88,10 +78,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>4</name>
       </visual>
       <pose>0 0 0.0625 0 0 0</pose>
-      <name>4</name>
     </link>
     <link name="5">
       <collision name="5">
@@ -100,7 +88,6 @@
             <size>0.35 0.76 0.02</size>
           </box>
         </geometry>
-        <name>5</name>
       </collision>
       <visual name="5">
         <geometry>
@@ -111,10 +98,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>5</name>
       </visual>
       <pose>0 0 0.38 0 0 0</pose>
-      <name>5</name>
     </link>
     <link name="6">
       <collision name="6">
@@ -123,7 +108,6 @@
             <size>0.35 0.76 0.02</size>
           </box>
         </geometry>
-        <name>6</name>
       </collision>
       <visual name="6">
         <geometry>
@@ -134,10 +118,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>6</name>
       </visual>
       <pose>0 0 0.731 0 0 0</pose>
-      <name>6</name>
     </link>
     <link name="7">
       <collision name="7">
@@ -146,7 +128,6 @@
             <size>0.35 0.76 0.02</size>
           </box>
         </geometry>
-        <name>7</name>
       </collision>
       <visual name="7">
         <geometry>
@@ -157,10 +138,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>7</name>
       </visual>
       <pose>0 0 1.081 0 0 0</pose>
-      <name>7</name>
     </link>
     <link name="8">
       <collision name="8">
@@ -169,7 +148,6 @@
             <size>0.35 0.76 0.02</size>
           </box>
         </geometry>
-        <name>8</name>
       </collision>
       <visual name="8">
         <geometry>
@@ -180,10 +158,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>8</name>
       </visual>
       <pose>0 0 1.431 0 0 0</pose>
-      <name>8</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
@@ -193,9 +169,7 @@
           </box>
         </geometry>
         <pose>0.675 0.0 0.005 0 0 0</pose>
-        <name>in_front_of</name>
       </virtual_volume>
-      <name>in_front_of</name>
     </link>
     <link name="shelf1">
       <virtual_volume name="shelf1">
@@ -205,9 +179,7 @@
           </box>
         </geometry>
         <pose>0.01 0.0 0.232 0 0 0</pose>
-        <name>shelf1</name>
       </virtual_volume>
-      <name>shelf1</name>
     </link>
     <link name="shelf2">
       <virtual_volume name="shelf2">
@@ -217,9 +189,7 @@
           </box>
         </geometry>
         <pose>0.01 0.0 0.539 0 0 0</pose>
-        <name>shelf2</name>
       </virtual_volume>
-      <name>shelf2</name>
     </link>
     <link name="shelf3">
       <virtual_volume name="shelf3">
@@ -229,9 +199,7 @@
           </box>
         </geometry>
         <pose>0.01 0.0 0.8875 0 0 0</pose>
-        <name>shelf3</name>
       </virtual_volume>
-      <name>shelf3</name>
     </link>
     <link name="shelf4">
       <virtual_volume name="shelf4">
@@ -241,9 +209,7 @@
           </box>
         </geometry>
         <pose>0.01 0.0 1.2335 0 0 0</pose>
-        <name>shelf4</name>
       </virtual_volume>
-      <name>shelf4</name>
     </link>
     <link name="shelf5">
       <virtual_volume name="shelf5">
@@ -253,11 +219,8 @@
           </box>
         </geometry>
         <pose>0.01 0.0 1.582 0 0 0</pose>
-        <name>shelf5</name>
       </virtual_volume>
-      <name>shelf5</name>
     </link>
     <static>true</static>
-    <name>rwc2016/bookcase_noback</name>
   </model>
 </sdf>

--- a/models/rwc2016/cabinet_2doors/model.sdf
+++ b/models/rwc2016/cabinet_2doors/model.sdf
@@ -8,7 +8,6 @@
             <size>0.401 0.8 0.8</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -19,10 +18,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>1</name>
       </visual>
       <pose>0 0 0.4 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="on_top_of">
       <virtual_volume name="on_top_of">
@@ -32,9 +29,7 @@
           </box>
         </geometry>
         <pose>0.0 0.0 0.945 0 0 0</pose>
-        <name>on_top_of</name>
       </virtual_volume>
-      <name>on_top_of</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
@@ -44,11 +39,8 @@
           </box>
         </geometry>
         <pose>0.7005 0.0 0.005 0 0 0</pose>
-        <name>in_front_of</name>
       </virtual_volume>
-      <name>in_front_of</name>
     </link>
     <static>true</static>
-    <name>rwc2016/cabinet_2doors</name>
   </model>
 </sdf>

--- a/models/rwc2016/cabinet_2slides/model.sdf
+++ b/models/rwc2016/cabinet_2slides/model.sdf
@@ -8,7 +8,6 @@
             <size>0.37 0.768 0.741</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -19,10 +18,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>1</name>
       </visual>
       <pose>0 0 0.37 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="on_top_of">
       <virtual_volume name="on_top_of">
@@ -32,9 +29,7 @@
           </box>
         </geometry>
         <pose>0.0 0.0 0.8855 0 0 0</pose>
-        <name>on_top_of</name>
       </virtual_volume>
-      <name>on_top_of</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
@@ -44,11 +39,8 @@
           </box>
         </geometry>
         <pose>0.685 0.0 0.005 0 0 0</pose>
-        <name>in_front_of</name>
       </virtual_volume>
-      <name>in_front_of</name>
     </link>
     <static>true</static>
-    <name>rwc2016/cabinet_2slides</name>
   </model>
 </sdf>

--- a/models/rwc2016/cabinet_open_large/model.sdf
+++ b/models/rwc2016/cabinet_open_large/model.sdf
@@ -8,7 +8,6 @@
             <size>0.395 0.05 0.79</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -19,10 +18,8 @@
         <material>
           <ambient>1.0 1.0 1.0 1</ambient>
         </material>
-        <name>1</name>
       </visual>
       <pose>0 -0.37 0.395 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="2">
       <collision name="2">
@@ -31,7 +28,6 @@
             <size>0.395 0.05 0.79</size>
           </box>
         </geometry>
-        <name>2</name>
       </collision>
       <visual name="2">
         <geometry>
@@ -42,10 +38,8 @@
         <material>
           <ambient>1.0 1.0 1.0 1</ambient>
         </material>
-        <name>2</name>
       </visual>
       <pose>0 0.37 0.395 0 0 0</pose>
-      <name>2</name>
     </link>
     <link name="3">
       <collision name="3">
@@ -54,7 +48,6 @@
             <size>0.395 0.69 0.05</size>
           </box>
         </geometry>
-        <name>3</name>
       </collision>
       <visual name="3">
         <geometry>
@@ -65,10 +58,8 @@
         <material>
           <ambient>1.0 1.0 1.0 1</ambient>
         </material>
-        <name>3</name>
       </visual>
       <pose>0 0 0.765 0 0 0</pose>
-      <name>3</name>
     </link>
     <link name="4">
       <collision name="4">
@@ -77,7 +68,6 @@
             <size>0.395 0.69 0.05</size>
           </box>
         </geometry>
-        <name>4</name>
       </collision>
       <visual name="4">
         <geometry>
@@ -88,10 +78,8 @@
         <material>
           <ambient>1.0 1.0 1.0 1</ambient>
         </material>
-        <name>4</name>
       </visual>
       <pose>0 0 0.025 0 0 0</pose>
-      <name>4</name>
     </link>
     <link name="5">
       <collision name="5">
@@ -100,7 +88,6 @@
             <size>0.395 0.69 0.02</size>
           </box>
         </geometry>
-        <name>5</name>
       </collision>
       <visual name="5">
         <geometry>
@@ -111,10 +98,8 @@
         <material>
           <ambient>1.0 1.0 1.0 1</ambient>
         </material>
-        <name>5</name>
       </visual>
       <pose>0 0 0.395 0 0 0</pose>
-      <name>5</name>
     </link>
     <link name="6">
       <collision name="6">
@@ -123,7 +108,6 @@
             <size>0.395 0.02 0.69</size>
           </box>
         </geometry>
-        <name>6</name>
       </collision>
       <visual name="6">
         <geometry>
@@ -134,10 +118,8 @@
         <material>
           <ambient>1.0 1.0 1.0 1</ambient>
         </material>
-        <name>6</name>
       </visual>
       <pose>0 0 0.395 0 0 0</pose>
-      <name>6</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
@@ -147,9 +129,7 @@
           </box>
         </geometry>
         <pose>0.45 0.0 0.0 0 0 0</pose>
-        <name>in_front_of</name>
       </virtual_volume>
-      <name>in_front_of</name>
     </link>
     <link name="on_top_of">
       <virtual_volume name="on_top_of">
@@ -159,11 +139,8 @@
           </box>
         </geometry>
         <pose>0.0 0.0 1.0025 0 0 0</pose>
-        <name>on_top_of</name>
       </virtual_volume>
-      <name>on_top_of</name>
     </link>
     <static>true</static>
-    <name>rwc2016/cabinet_open_large</name>
   </model>
 </sdf>

--- a/models/rwc2016/cabinet_open_small/model.sdf
+++ b/models/rwc2016/cabinet_open_small/model.sdf
@@ -8,7 +8,6 @@
             <size>0.393 0.034 0.764</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -19,10 +18,8 @@
         <material>
           <ambient>1.0 1.0 1.0 1</ambient>
         </material>
-        <name>1</name>
       </visual>
       <pose>0 -0.366 0.382 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="2">
       <collision name="2">
@@ -31,7 +28,6 @@
             <size>0.393 0.034 0.764</size>
           </box>
         </geometry>
-        <name>2</name>
       </collision>
       <visual name="2">
         <geometry>
@@ -42,10 +38,8 @@
         <material>
           <ambient>1.0 1.0 1.0 1</ambient>
         </material>
-        <name>2</name>
       </visual>
       <pose>0 0.366 0.382 0 0 0</pose>
-      <name>2</name>
     </link>
     <link name="3">
       <collision name="3">
@@ -54,7 +48,6 @@
             <size>0.393 0.764 0.034</size>
           </box>
         </geometry>
-        <name>3</name>
       </collision>
       <visual name="3">
         <geometry>
@@ -65,10 +58,8 @@
         <material>
           <ambient>1.0 1.0 1.0 1</ambient>
         </material>
-        <name>3</name>
       </visual>
       <pose>0 0 0.747 0 0 0</pose>
-      <name>3</name>
     </link>
     <link name="4">
       <collision name="4">
@@ -77,7 +68,6 @@
             <size>0.393 0.764 0.034</size>
           </box>
         </geometry>
-        <name>4</name>
       </collision>
       <visual name="4">
         <geometry>
@@ -88,10 +78,8 @@
         <material>
           <ambient>1.0 1.0 1.0 1</ambient>
         </material>
-        <name>4</name>
       </visual>
       <pose>0 0 0.025 0 0 0</pose>
-      <name>4</name>
     </link>
     <link name="5">
       <collision name="5">
@@ -100,7 +88,6 @@
             <size>0.393 0.69 0.02</size>
           </box>
         </geometry>
-        <name>5</name>
       </collision>
       <visual name="5">
         <geometry>
@@ -111,10 +98,8 @@
         <material>
           <ambient>1.0 1.0 1.0 1</ambient>
         </material>
-        <name>5</name>
       </visual>
       <pose>0 0 0.382 0 0 0</pose>
-      <name>5</name>
     </link>
     <link name="6">
       <collision name="6">
@@ -123,7 +108,6 @@
             <size>0.393 0.02 0.69</size>
           </box>
         </geometry>
-        <name>6</name>
       </collision>
       <visual name="6">
         <geometry>
@@ -134,10 +118,8 @@
         <material>
           <ambient>1.0 1.0 1.0 1</ambient>
         </material>
-        <name>6</name>
       </visual>
       <pose>0 0 0.382 0 0 0</pose>
-      <name>6</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
@@ -147,9 +129,7 @@
           </box>
         </geometry>
         <pose>0.45 0.0 0.0 0 0 0</pose>
-        <name>in_front_of</name>
       </virtual_volume>
-      <name>in_front_of</name>
     </link>
     <link name="on_top_of">
       <virtual_volume name="on_top_of">
@@ -159,11 +139,8 @@
           </box>
         </geometry>
         <pose>0.0 0.0 0.9875 0 0 0</pose>
-        <name>on_top_of</name>
       </virtual_volume>
-      <name>on_top_of</name>
     </link>
     <static>true</static>
-    <name>rwc2016/cabinet_open_small</name>
   </model>
 </sdf>

--- a/models/rwc2016/couch/model.sdf
+++ b/models/rwc2016/couch/model.sdf
@@ -8,7 +8,6 @@
             <size>0.85 1.54 0.42</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -19,10 +18,8 @@
         <material>
           <ambient>0.1 0.1 0.1 1</ambient>
         </material>
-        <name>1</name>
       </visual>
       <pose>0.0 0.0 0.21 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="2">
       <collision name="2">
@@ -31,7 +28,6 @@
             <size>0.3 1.54 0.225</size>
           </box>
         </geometry>
-        <name>2</name>
       </collision>
       <visual name="2">
         <geometry>
@@ -42,10 +38,8 @@
         <material>
           <ambient>0.1 0.1 0.1 1</ambient>
         </material>
-        <name>2</name>
       </visual>
       <pose>-0.275 0.0 0.5325 0 0 0</pose>
-      <name>2</name>
     </link>
     <link name="3">
       <collision name="3">
@@ -54,7 +48,6 @@
             <size>0.85 0.175 0.225</size>
           </box>
         </geometry>
-        <name>3</name>
       </collision>
       <visual name="3">
         <geometry>
@@ -65,10 +58,8 @@
         <material>
           <ambient>0.1 0.1 0.1 1</ambient>
         </material>
-        <name>3</name>
       </visual>
       <pose>0.0 -0.682 0.5325 0 0 0</pose>
-      <name>3</name>
     </link>
     <link name="4">
       <collision name="4">
@@ -77,7 +68,6 @@
             <size>0.85 0.175 0.225</size>
           </box>
         </geometry>
-        <name>4</name>
       </collision>
       <visual name="4">
         <geometry>
@@ -88,10 +78,8 @@
         <material>
           <ambient>0.1 0.1 0.1 1</ambient>
         </material>
-        <name>4</name>
       </visual>
       <pose>0.0 0.682 0.5325 0 0 0</pose>
-      <name>4</name>
     </link>
     <link name="on_top_of">
       <virtual_volume name="on_top_of">
@@ -101,9 +89,7 @@
           </box>
         </geometry>
         <pose>0.175 0.0 0.6 0 0 0</pose>
-        <name>on_top_of</name>
       </virtual_volume>
-      <name>on_top_of</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
@@ -113,11 +99,8 @@
           </box>
         </geometry>
         <pose>1.05 0.0 0.005 0 0 0</pose>
-        <name>in_front_of</name>
       </virtual_volume>
-      <name>in_front_of</name>
     </link>
     <static>true</static>
-    <name>rwc2016/couch</name>
   </model>
 </sdf>

--- a/models/rwc2016/door_left/model.sdf
+++ b/models/rwc2016/door_left/model.sdf
@@ -8,7 +8,6 @@
             <size>0.04 0.84 2</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -19,12 +18,9 @@
         <material>
           <ambient>0.8 0.8 0.8 1</ambient>
         </material>
-        <name>1</name>
       </visual>
       <pose>0.02 0.42 1 0 0 0</pose>
-      <name>1</name>
     </link>
     <static>true</static>
-    <name>rwc2016/door_left</name>
   </model>
 </sdf>

--- a/models/rwc2016/door_right/model.sdf
+++ b/models/rwc2016/door_right/model.sdf
@@ -8,7 +8,6 @@
             <size>0.04 0.84 2</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -19,12 +18,9 @@
         <material>
           <ambient>0.8 0.8 0.8 1</ambient>
         </material>
-        <name>1</name>
       </visual>
       <pose>0.02 -0.42 1 0 0 0</pose>
-      <name>1</name>
     </link>
     <static>true</static>
-    <name>rwc2016/door_right</name>
   </model>
 </sdf>

--- a/models/rwc2016/ikea_table_black/model.sdf
+++ b/models/rwc2016/ikea_table_black/model.sdf
@@ -8,7 +8,6 @@
             <size>1.103 1.103 0.1</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -19,10 +18,8 @@
         <material>
           <ambient>0.3 0.3 0.3 1</ambient>
         </material>
-        <name>1</name>
       </visual>
       <pose>0 0 0.9 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="2">
       <collision name="2">
@@ -31,7 +28,6 @@
             <size>0.063 0.063 0.925</size>
           </box>
         </geometry>
-        <name>2</name>
       </collision>
       <visual name="2">
         <geometry>
@@ -42,10 +38,8 @@
         <material>
           <ambient>0.3 0.3 0.3 1</ambient>
         </material>
-        <name>2</name>
       </visual>
       <pose>-0.52 -0.52 0.4625 0 0 0</pose>
-      <name>2</name>
     </link>
     <link name="3">
       <collision name="3">
@@ -54,7 +48,6 @@
             <size>0.063 0.063 0.925</size>
           </box>
         </geometry>
-        <name>3</name>
       </collision>
       <visual name="3">
         <geometry>
@@ -65,10 +58,8 @@
         <material>
           <ambient>0.3 0.3 0.3 1</ambient>
         </material>
-        <name>3</name>
       </visual>
       <pose>0.52 -0.52 0.4625 0 0 0</pose>
-      <name>3</name>
     </link>
     <link name="4">
       <collision name="4">
@@ -77,7 +68,6 @@
             <size>0.063 0.063 0.925</size>
           </box>
         </geometry>
-        <name>4</name>
       </collision>
       <visual name="4">
         <geometry>
@@ -88,10 +78,8 @@
         <material>
           <ambient>0.3 0.3 0.3 1</ambient>
         </material>
-        <name>4</name>
       </visual>
       <pose>-0.52 0.52 0.4625 0 0 0</pose>
-      <name>4</name>
     </link>
     <link name="5">
       <collision name="5">
@@ -100,7 +88,6 @@
             <size>0.063 0.063 0.925</size>
           </box>
         </geometry>
-        <name>5</name>
       </collision>
       <visual name="5">
         <geometry>
@@ -111,10 +98,8 @@
         <material>
           <ambient>0.3 0.3 0.3 1</ambient>
         </material>
-        <name>5</name>
       </visual>
       <pose>0.52 0.52 0.4625 0 0 0</pose>
-      <name>5</name>
     </link>
     <link name="on_top_of">
       <virtual_volume name="on_top_of">
@@ -124,9 +109,7 @@
           </box>
         </geometry>
         <pose>0.0 0.0 1.095 0 0 0</pose>
-        <name>on_top_of</name>
       </virtual_volume>
-      <name>on_top_of</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
@@ -136,11 +119,8 @@
           </box>
         </geometry>
         <pose>1.0515 0.0 0.005 0 0 0</pose>
-        <name>in_front_of</name>
       </virtual_volume>
-      <name>in_front_of</name>
     </link>
     <static>true</static>
-    <name>rwc2016/ikea_table_black</name>
   </model>
 </sdf>

--- a/models/rwc2016/ikea_table_red/model.sdf
+++ b/models/rwc2016/ikea_table_red/model.sdf
@@ -8,7 +8,6 @@
             <size>0.42 0.7 0.04</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -19,10 +18,8 @@
         <material>
           <ambient>0.75 0.3 0.3 1</ambient>
         </material>
-        <name>1</name>
       </visual>
       <pose>0 0 0.46 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="2">
       <collision name="2">
@@ -31,7 +28,6 @@
             <size>0.42 0.7 0.04</size>
           </box>
         </geometry>
-        <name>2</name>
       </collision>
       <visual name="2">
         <geometry>
@@ -42,10 +38,8 @@
         <material>
           <ambient>0.75 0.3 0.3 1</ambient>
         </material>
-        <name>2</name>
       </visual>
       <pose>0 0 0.16 0 0 0</pose>
-      <name>2</name>
     </link>
     <link name="3">
       <collision name="3">
@@ -54,7 +48,6 @@
             <size>0.04 0.04 0.44</size>
           </box>
         </geometry>
-        <name>3</name>
       </collision>
       <visual name="3">
         <geometry>
@@ -65,10 +58,8 @@
         <material>
           <ambient>0.75 0.3 0.3 1</ambient>
         </material>
-        <name>3</name>
       </visual>
       <pose>-0.19 -0.33 0.22 0 0 0</pose>
-      <name>3</name>
     </link>
     <link name="4">
       <collision name="4">
@@ -77,7 +68,6 @@
             <size>0.04 0.04 0.44</size>
           </box>
         </geometry>
-        <name>4</name>
       </collision>
       <visual name="4">
         <geometry>
@@ -88,10 +78,8 @@
         <material>
           <ambient>0.75 0.3 0.3 1</ambient>
         </material>
-        <name>4</name>
       </visual>
       <pose>0.19 -0.33 0.22 0 0 0</pose>
-      <name>4</name>
     </link>
     <link name="5">
       <collision name="5">
@@ -100,7 +88,6 @@
             <size>0.04 0.04 0.44</size>
           </box>
         </geometry>
-        <name>5</name>
       </collision>
       <visual name="5">
         <geometry>
@@ -111,10 +98,8 @@
         <material>
           <ambient>0.75 0.3 0.3 1</ambient>
         </material>
-        <name>5</name>
       </visual>
       <pose>-0.19 0.33 0.22 0 0 0</pose>
-      <name>5</name>
     </link>
     <link name="6">
       <collision name="6">
@@ -123,7 +108,6 @@
             <size>0.04 0.04 0.44</size>
           </box>
         </geometry>
-        <name>6</name>
       </collision>
       <visual name="6">
         <geometry>
@@ -134,10 +118,8 @@
         <material>
           <ambient>0.75 0.3 0.3 1</ambient>
         </material>
-        <name>6</name>
       </visual>
       <pose>0.19 0.33 0.22 0 0 0</pose>
-      <name>6</name>
     </link>
     <link name="on_top_of">
       <virtual_volume name="on_top_of">
@@ -147,9 +129,7 @@
           </box>
         </geometry>
         <pose>0.0 0.0 0.625 0 0 0</pose>
-        <name>on_top_of</name>
       </virtual_volume>
-      <name>on_top_of</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
@@ -159,11 +139,8 @@
           </box>
         </geometry>
         <pose>0.71 0.0 0.005 0 0 0</pose>
-        <name>in_front_of</name>
       </virtual_volume>
-      <name>in_front_of</name>
     </link>
     <static>true</static>
-    <name>rwc2016/ikea_table_red</name>
   </model>
 </sdf>

--- a/models/rwc2016/kitchen_counter/model.sdf
+++ b/models/rwc2016/kitchen_counter/model.sdf
@@ -8,7 +8,6 @@
             <size>0.56 1.0 0.924</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -19,10 +18,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>1</name>
       </visual>
       <pose>0 0 0.462 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="on_top_of">
       <virtual_volume name="on_top_of">
@@ -32,9 +29,7 @@
           </box>
         </geometry>
         <pose>0.0 0.0 1.069 0 0 0</pose>
-        <name>on_top_of</name>
       </virtual_volume>
-      <name>on_top_of</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
@@ -44,11 +39,8 @@
           </box>
         </geometry>
         <pose>0.78 0.0 0.005 0 0 0</pose>
-        <name>in_front_of</name>
       </virtual_volume>
-      <name>in_front_of</name>
     </link>
     <static>true</static>
-    <name>rwc2016/kitchen_counter</name>
   </model>
 </sdf>

--- a/models/rwc2016/plant/model.sdf
+++ b/models/rwc2016/plant/model.sdf
@@ -9,7 +9,6 @@
             <radius>0.1825</radius>
           </cylinder>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -18,12 +17,9 @@
             <radius>0.1825</radius>
           </cylinder>
         </geometry>
-        <name>1</name>
       </visual>
       <pose>0 0 0.188 0 0 0</pose>
-      <name>1</name>
     </link>
     <static>true</static>
-    <name>rwc2016/plant</name>
   </model>
 </sdf>

--- a/models/rwc2016/plant_large/model.sdf
+++ b/models/rwc2016/plant_large/model.sdf
@@ -9,7 +9,6 @@
             <radius>0.21</radius>
           </cylinder>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -18,12 +17,9 @@
             <radius>0.21</radius>
           </cylinder>
         </geometry>
-        <name>1</name>
       </visual>
       <pose>0 0 0.21 0 0 0</pose>
-      <name>1</name>
     </link>
     <static>true</static>
-    <name>rwc2016/plant_large</name>
   </model>
 </sdf>

--- a/models/rwc2016/table_black/model.sdf
+++ b/models/rwc2016/table_black/model.sdf
@@ -8,7 +8,6 @@
             <size>1.4 0.7 0.021</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -19,10 +18,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>1</name>
       </visual>
       <pose>0 0 0.7065 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="2">
       <collision name="2">
@@ -31,7 +28,6 @@
             <size>0.038 0.038 0.696</size>
           </box>
         </geometry>
-        <name>2</name>
       </collision>
       <visual name="2">
         <geometry>
@@ -42,10 +38,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>2</name>
       </visual>
       <pose>-0.681 -0.331 0.348 0 0 0</pose>
-      <name>2</name>
     </link>
     <link name="3">
       <collision name="3">
@@ -54,7 +48,6 @@
             <size>0.038 0.038 0.696</size>
           </box>
         </geometry>
-        <name>3</name>
       </collision>
       <visual name="3">
         <geometry>
@@ -65,10 +58,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>3</name>
       </visual>
       <pose>0.681 -0.331 0.348 0 0 0</pose>
-      <name>3</name>
     </link>
     <link name="4">
       <collision name="4">
@@ -77,7 +68,6 @@
             <size>0.038 0.038 0.696</size>
           </box>
         </geometry>
-        <name>4</name>
       </collision>
       <visual name="4">
         <geometry>
@@ -88,10 +78,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>4</name>
       </visual>
       <pose>-0.681 0.331 0.348 0 0 0</pose>
-      <name>4</name>
     </link>
     <link name="5">
       <collision name="5">
@@ -100,7 +88,6 @@
             <size>0.038 0.038 0.696</size>
           </box>
         </geometry>
-        <name>5</name>
       </collision>
       <visual name="5">
         <geometry>
@@ -111,10 +98,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>5</name>
       </visual>
       <pose>0.681 0.331 0.348 0 0 0</pose>
-      <name>5</name>
     </link>
     <link name="on_top_of">
       <virtual_volume name="on_top_of">
@@ -124,9 +109,7 @@
           </box>
         </geometry>
         <pose>0.0 0.0 0.862 0 0 0</pose>
-        <name>on_top_of</name>
       </virtual_volume>
-      <name>on_top_of</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
@@ -136,11 +119,8 @@
           </box>
         </geometry>
         <pose>1.2 0.0 0.005 0 0 0</pose>
-        <name>in_front_of</name>
       </virtual_volume>
-      <name>in_front_of</name>
     </link>
     <static>true</static>
-    <name>rwc2016/table_black</name>
   </model>
 </sdf>

--- a/models/rwc2016/table_bureau/model.sdf
+++ b/models/rwc2016/table_bureau/model.sdf
@@ -8,7 +8,6 @@
             <size>0.601 1.2 0.025</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -19,10 +18,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>1</name>
       </visual>
       <pose>0 0 0.7115 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="2">
       <collision name="2">
@@ -31,7 +28,6 @@
             <size>0.031 0.031 0.699</size>
           </box>
         </geometry>
-        <name>2</name>
       </collision>
       <visual name="2">
         <geometry>
@@ -42,10 +38,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>2</name>
       </visual>
       <pose>-0.06 -0.5545 0.3495 0 0 0</pose>
-      <name>2</name>
     </link>
     <link name="3">
       <collision name="3">
@@ -54,7 +48,6 @@
             <size>0.031 0.031 0.699</size>
           </box>
         </geometry>
-        <name>3</name>
       </collision>
       <visual name="3">
         <geometry>
@@ -65,10 +58,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>3</name>
       </visual>
       <pose>-0.06 0.5545 0.3495 0 0 0</pose>
-      <name>3</name>
     </link>
     <link name="4">
       <collision name="4">
@@ -77,7 +68,6 @@
             <size>0.031 0.031 0.699</size>
           </box>
         </geometry>
-        <name>4</name>
       </collision>
       <visual name="4">
         <geometry>
@@ -88,10 +78,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>4</name>
       </visual>
       <pose>0.06 -0.5545 0.3495 0 0 0</pose>
-      <name>4</name>
     </link>
     <link name="5">
       <collision name="5">
@@ -100,7 +88,6 @@
             <size>0.031 0.031 0.699</size>
           </box>
         </geometry>
-        <name>5</name>
       </collision>
       <visual name="5">
         <geometry>
@@ -111,10 +98,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>5</name>
       </visual>
       <pose>0.06 0.5545 0.3495 0 0 0</pose>
-      <name>5</name>
     </link>
     <link name="6">
       <collision name="6">
@@ -123,7 +108,6 @@
             <size>0.603 0.036 0.045</size>
           </box>
         </geometry>
-        <name>6</name>
       </collision>
       <visual name="6">
         <geometry>
@@ -134,10 +118,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>6</name>
       </visual>
       <pose>0.0 0.555 0.0225 0 0 0</pose>
-      <name>6</name>
     </link>
     <link name="7">
       <collision name="7">
@@ -146,7 +128,6 @@
             <size>0.603 0.036 0.045</size>
           </box>
         </geometry>
-        <name>7</name>
       </collision>
       <visual name="7">
         <geometry>
@@ -157,10 +138,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>7</name>
       </visual>
       <pose>0.0 -0.555 0.0225 0 0 0</pose>
-      <name>7</name>
     </link>
     <link name="on_top_of">
       <virtual_volume name="on_top_of">
@@ -170,9 +149,7 @@
           </box>
         </geometry>
         <pose>0.0 0.0 0.869 0 0 0</pose>
-        <name>on_top_of</name>
       </virtual_volume>
-      <name>on_top_of</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
@@ -182,11 +159,8 @@
           </box>
         </geometry>
         <pose>0.86 0.0 0.005 0 0 0</pose>
-        <name>in_front_of</name>
       </virtual_volume>
-      <name>in_front_of</name>
     </link>
     <static>true</static>
-    <name>rwc2016/table_bureau</name>
   </model>
 </sdf>

--- a/models/rwc2016/table_salon/model.sdf
+++ b/models/rwc2016/table_salon/model.sdf
@@ -8,7 +8,6 @@
             <size>0.703 0.703 0.02</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -19,10 +18,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>1</name>
       </visual>
       <pose>0 0 0.421 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="2">
       <collision name="2">
@@ -31,7 +28,6 @@
             <size>0.04 0.04 0.411</size>
           </box>
         </geometry>
-        <name>2</name>
       </collision>
       <visual name="2">
         <geometry>
@@ -42,10 +38,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>2</name>
       </visual>
       <pose>-0.33 -0.33 0.2055 0 0 0</pose>
-      <name>2</name>
     </link>
     <link name="3">
       <collision name="3">
@@ -54,7 +48,6 @@
             <size>0.04 0.04 0.411</size>
           </box>
         </geometry>
-        <name>3</name>
       </collision>
       <visual name="3">
         <geometry>
@@ -65,10 +58,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>3</name>
       </visual>
       <pose>0.33 -0.33 0.2055 0 0 0</pose>
-      <name>3</name>
     </link>
     <link name="4">
       <collision name="4">
@@ -77,7 +68,6 @@
             <size>0.04 0.04 0.411</size>
           </box>
         </geometry>
-        <name>4</name>
       </collision>
       <visual name="4">
         <geometry>
@@ -88,10 +78,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>4</name>
       </visual>
       <pose>-0.33 0.33 0.2055 0 0 0</pose>
-      <name>4</name>
     </link>
     <link name="5">
       <collision name="5">
@@ -100,7 +88,6 @@
             <size>0.04 0.04 0.411</size>
           </box>
         </geometry>
-        <name>5</name>
       </collision>
       <visual name="5">
         <geometry>
@@ -111,10 +98,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>5</name>
       </visual>
       <pose>0.33 0.33 0.2055 0 0 0</pose>
-      <name>5</name>
     </link>
     <link name="on_top_of">
       <virtual_volume name="on_top_of">
@@ -124,9 +109,7 @@
           </box>
         </geometry>
         <pose>0.0 0.0 0.576 0 0 0</pose>
-        <name>on_top_of</name>
       </virtual_volume>
-      <name>on_top_of</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
@@ -136,11 +119,8 @@
           </box>
         </geometry>
         <pose>0.0 0.0 0.005 0 0 0</pose>
-        <name>in_front_of</name>
       </virtual_volume>
-      <name>in_front_of</name>
     </link>
     <static>true</static>
-    <name>rwc2016/table_salon</name>
   </model>
 </sdf>

--- a/models/rwc2016a/model.sdf
+++ b/models/rwc2016a/model.sdf
@@ -4,7 +4,6 @@
     <light name="sun" type="directional">
       <direction>0.5 0.1 -0.9</direction>
       <pose>0 0 10 0 0 0</pose>
-      <name>sun</name>
       <specular>0.2 0.2 0.2 1</specular>
       <cast_shadows>true</cast_shadows>
       <diffuse>0.8 0.8 0.8 1</diffuse>
@@ -24,13 +23,10 @@
             </box>
           </geometry>
           <pose>0.845 -0.285 0.005 0 0 0</pose>
-          <name>in</name>
         </virtual_volume>
-        <name>in</name>
       </link>
       <pose>8.53 4.01 0 0 0 0</pose>
       <static>true</static>
-      <name>kitchen</name>
     </model>
     <model name="living_room" type="room">
       <link name="in">
@@ -41,9 +37,7 @@
             </box>
           </geometry>
           <pose>2.93 1.19 0.005 0 0 0</pose>
-          <name>in1</name>
         </virtual_volume>
-        <name>in</name>
       </link>
       <link name="in">
         <virtual_volume name="in1">
@@ -53,13 +47,10 @@
             </box>
           </geometry>
           <pose>2.93 1.19 0.005 0 0 0</pose>
-          <name>in1</name>
         </virtual_volume>
-        <name>in</name>
       </link>
       <pose>10.88 1.04 0 0 0 0</pose>
       <static>true</static>
-      <name>living_room</name>
     </model>
     <model name="office" type="room">
       <link name="in">
@@ -70,13 +61,10 @@
             </box>
           </geometry>
           <pose>-0.025 0.005 0.005 0 0 0</pose>
-          <name>in</name>
         </virtual_volume>
-        <name>in</name>
       </link>
       <pose>1.73 4.74 0 0 0 0</pose>
       <static>true</static>
-      <name>office</name>
     </model>
     <model name="corridor" type="room">
       <link name="in">
@@ -87,9 +75,7 @@
             </box>
           </geometry>
           <pose>1.83 -0.175 0.005 0 0 0</pose>
-          <name>in1</name>
         </virtual_volume>
-        <name>in</name>
       </link>
       <link name="in">
         <virtual_volume name="in1">
@@ -99,13 +85,10 @@
             </box>
           </geometry>
           <pose>1.83 -0.175 0.005 0 0 0</pose>
-          <name>in1</name>
         </virtual_volume>
-        <name>in</name>
       </link>
       <pose>2.16 0.22 0 0 0 0</pose>
       <static>true</static>
-      <name>corridor</name>
     </model>
     <model name="bedroom" type="room">
       <link name="in">
@@ -116,315 +99,276 @@
             </box>
           </geometry>
           <pose>0.02 1.135 0.005 0 0 0</pose>
-          <name>in</name>
         </virtual_volume>
-        <name>in</name>
       </link>
       <pose>5.16 2.61 0 0 0 0</pose>
       <static>true</static>
-      <name>bedroom</name>
     </model>
     <model name="initial_pose_door_a" type="waypoint">
       <pose>-0.5 0.0 0 0 0 0.0</pose>
       <static>true</static>
-      <name>initial_pose_door_a</name>
     </model>
     <model name="initial_pose_door_b" type="waypoint">
       <pose>-0.5 3.0 0 0 0 0.0</pose>
       <static>true</static>
-      <name>initial_pose_door_b</name>
     </model>
     <model name="initial_pose_door_c" type="waypoint">
       <pose>12.44 6.5 0 0 0 -1.57</pose>
       <static>true</static>
-      <name>initial_pose_door_c</name>
     </model>
     <model name="entry_door_a" type="waypoint">
       <pose>1.0 0.0 0 0 0 0.0</pose>
       <static>true</static>
-      <name>entry_door_a</name>
     </model>
     <model name="entry_door_b" type="waypoint">
       <pose>1.0 2.5 0 0 0 0.0</pose>
       <static>true</static>
-      <name>entry_door_b</name>
     </model>
     <model name="entry_door_c" type="waypoint">
       <pose>12.45 4.9 0 0 0 -1.57</pose>
       <static>true</static>
-      <name>entry_door_c</name>
     </model>
     <model name="exit_door_a" type="waypoint">
       <pose>-1.5 0.0 0 0 0 3.14</pose>
       <static>true</static>
-      <name>exit_door_a</name>
     </model>
     <model name="exit_door_b" type="waypoint">
       <pose>-1.5 3.0 0 0 0 3.14</pose>
       <static>true</static>
-      <name>exit_door_b</name>
     </model>
     <model name="exit_door_c" type="waypoint">
       <pose>12.5 7.5 0 0 0 1.57</pose>
       <static>true</static>
-      <name>exit_door_c</name>
     </model>
     <model name="registration_table1" type="waypoint">
       <pose>9.7 -0.6 0 0 0 0</pose>
       <static>true</static>
-      <name>registration_table1</name>
     </model>
     <model name="registration_table2" type="waypoint">
       <pose>9.0 -1.4 0 0 0 0</pose>
       <static>true</static>
-      <name>registration_table2</name>
     </model>
     <model name="registration_table3" type="waypoint">
       <pose>8.4 -0.6 0 0 0 0</pose>
       <static>true</static>
-      <name>registration_table3</name>
     </model>
     <model name="exit_1_rips" type="waypoint">
       <pose>12.45 6.7 0 0 0 1.57</pose>
       <static>true</static>
-      <name>exit_1_rips</name>
     </model>
     <model name="exit_2_rips" type="waypoint">
       <pose>12.45 7.7 0 0 0 1.57</pose>
       <static>true</static>
-      <name>exit_2_rips</name>
     </model>
     <model name="exit_3_rips" type="waypoint">
       <pose>12.45 4.4 0 0 0 1.57</pose>
       <static>true</static>
-      <name>exit_3_rips</name>
     </model>
     <model name="exit_4_rips" type="waypoint">
       <pose>12.45 6.7 0 0 0 1.57</pose>
       <static>true</static>
-      <name>exit_4_rips</name>
     </model>
     <model name="navigation_target1" type="waypoint">
       <pose>5.0 2.6 0 0 0 3.14</pose>
       <static>true</static>
-      <name>navigation_target1</name>
     </model>
     <model name="navigation_target2_pre" type="waypoint">
       <pose>4.4 0.6 0 0 0 -1.57</pose>
       <static>true</static>
-      <name>navigation_target2_pre</name>
     </model>
     <model name="navigation_target2" type="waypoint">
       <pose>4.5 -0.5 0 0 0 -1.57</pose>
       <static>true</static>
-      <name>navigation_target2</name>
     </model>
     <model name="navigation_target3" type="waypoint">
       <pose>2.0 1.0 0 0 0 3.14</pose>
       <static>true</static>
-      <name>navigation_target3</name>
     </model>
     <model name="navigation_door" type="waypoint">
       <pose>-0.7 0.0 0 0 0 0.0</pose>
       <static>true</static>
-      <name>navigation_door</name>
     </model>
     <model name="navigation_door_1" type="waypoint">
       <pose>-0.7 0.0 0 0 0 0.0</pose>
       <static>true</static>
-      <name>navigation_door_1</name>
     </model>
     <model name="navigation_door_2" type="waypoint">
       <pose>-0.7 2.5 0 0 0 0.0</pose>
       <static>true</static>
-      <name>navigation_door_2</name>
     </model>
     <model name="navigation_reentrance_door_1" type="waypoint">
       <pose>0.0 0.0 0 0 0 0.0</pose>
       <static>true</static>
-      <name>navigation_reentrance_door_1</name>
     </model>
     <model name="navigation_reentrance_door_2" type="waypoint">
       <pose>0.0 2.5 0 0 0 0.0</pose>
       <static>true</static>
-      <name>navigation_reentrance_door_2</name>
     </model>
     <model name="navigation_target4" type="waypoint">
       <pose>2.0 1.0 0 0 0 0.0</pose>
       <static>true</static>
-      <name>navigation_target4</name>
     </model>
     <model name="navigation_exit1" type="waypoint">
       <pose>-1.0 0.0 0 0 0 3.1415</pose>
       <static>true</static>
-      <name>navigation_exit1</name>
     </model>
     <model name="navigation_exit2" type="waypoint">
       <pose>-1.0 2.5 0 0 0 3.1415</pose>
       <static>true</static>
-      <name>navigation_exit2</name>
     </model>
     <model name="navigation_exit3" type="waypoint">
       <pose>-2.0 4.0 0 0 0 3.1415</pose>
       <static>true</static>
-      <name>navigation_exit3</name>
     </model>
     <model name="navigation_exit4" type="waypoint">
       <pose>-2.0 -1.0 0 0 0 3.1415</pose>
       <static>true</static>
-      <name>navigation_exit4</name>
     </model>
     <model name="door_opening_start_1" type="waypoint">
       <pose>-0.5 0.0 0 0 0 0</pose>
       <static>true</static>
-      <name>door_opening_start_1</name>
     </model>
     <model name="door_opening_dest" type="waypoint">
       <pose>0.65 0.0 0 0 0 0</pose>
       <static>true</static>
-      <name>door_opening_dest</name>
     </model>
     <model name="door_opening_dest_1" type="waypoint">
       <pose>0.9 0.0 0 0 0 0</pose>
       <static>true</static>
-      <name>door_opening_dest_1</name>
     </model>
     <model name="door_opening_start_2" type="waypoint">
       <pose>-0.5 2.5 0 0 0 0</pose>
       <static>true</static>
-      <name>door_opening_start_2</name>
     </model>
     <model name="door_opening_dest_2" type="waypoint">
       <pose>0.9 2.5 0 0 0 0</pose>
       <static>true</static>
-      <name>door_opening_dest_2</name>
     </model>
     <model name="gpsr_meeting_point" type="waypoint">
       <pose>15.236 2.356 0 0 0 3.14</pose>
       <static>true</static>
-      <name>gpsr_meeting_point</name>
     </model>
-    <include name="floor">
+    <include>
       <pose>0 0 0 0 0 0</pose>
       <name>floor</name>
       <uri>model://floor</uri>
     </include>
-    <include name="walls">
+    <include>
       <pose>0 0 0 0 0 0</pose>
       <name>walls</name>
       <uri>model://rwc2016a/walls</uri>
     </include>
-    <include name="sideshelf">
+    <include>
       <pose>9.59961999631 2.06445025401 0.0 0 0 0.0</pose>
       <name>sideshelf</name>
       <uri>model://rwc2016/cabinet_2slides</uri>
     </include>
-    <include name="living_shelf">
+    <include>
       <pose>15.6340824996 3.45558782257 0.0 0 0 3.14159265359</pose>
       <name>living_shelf</name>
       <uri>model://rwc2016/cabinet_open_large</uri>
     </include>
-    <include name="bedside">
+    <include>
       <pose>3.73294564725 3.89240622111 0.0 0 0 0.0</pose>
       <name>bedside</name>
       <uri>model://rwc2016/bookcase_noback</uri>
     </include>
-    <include name="tv_stand">
+    <include>
       <pose>14.3957248256 5.65555181602 0.0 0 0 -1.57079632679</pose>
       <name>tv_stand</name>
       <uri>model://rwc2016/cabinet_open_small</uri>
     </include>
-    <include name="couch">
+    <include>
       <pose>14.1010391014 0.15676969619 0.0 0 0 2.409</pose>
       <name>couch</name>
       <uri>model://rwc2016/couch</uri>
     </include>
-    <include name="sink">
+    <include>
       <pose>8.9216065439 1.83933155327 0.0 0 0 1.57079632679</pose>
       <name>sink</name>
       <uri>model://rwc2016/kitchen_counter</uri>
     </include>
-    <include name="living_table">
+    <include>
       <pose>13.3500255193 0.826244757613 0.0 0 0 0.84</pose>
       <name>living_table</name>
       <uri>model://rwc2016/table_salon</uri>
     </include>
-    <include name="dining_table">
+    <include>
       <pose>10.7336615904 3.82007082986 0.0 0 0 3.14159265359</pose>
       <name>dining_table</name>
       <uri>model://rwc2016/table_black</uri>
     </include>
-    <include name="cupboard">
+    <include>
       <pose>7.9878231138 1.79059577037 0.0 0 0 1.57079632679</pose>
       <name>cupboard</name>
       <uri>model://rwc2016/cabinet_2doors</uri>
     </include>
-    <include name="desk">
+    <include>
       <pose>3.1 5.23 0.0 0 0 -3.14159265359</pose>
       <name>desk</name>
       <uri>model://rwc2016/table_bureau</uri>
     </include>
-    <include name="bed">
+    <include>
       <pose>5.54312696294 4.87689963252 0.0 0 0 -3.14159265359</pose>
       <name>bed</name>
       <uri>model://rwc2016/bed_frame</uri>
     </include>
-    <include name="night_stand">
+    <include>
       <pose>6.45 5.7 0.0 0 0 -1.57079632679</pose>
       <name>night_stand</name>
       <uri>model://rwc2016/ikea_table_red</uri>
     </include>
-    <include name="bar">
+    <include>
       <pose>7.2199743991 4.46354844791 0.0 0 0 0.0</pose>
       <name>bar</name>
       <uri>model://rwc2016/bookcase_noback</uri>
     </include>
-    <include name="cabinet">
+    <include>
       <pose>4.5 -1.23109049803 0.0 0 0 1.57079632679</pose>
       <name>cabinet</name>
       <uri>model://rwc2016/cabinet_open_small</uri>
     </include>
-    <include name="drawer">
+    <include>
       <pose>0.22226426908 4.60318484157 0.0 0 0 0.0</pose>
       <name>drawer</name>
       <uri>model://rwc2016/cabinet_2doors</uri>
     </include>
-    <include name="bookcase">
+    <include>
       <pose>9.40963771231 5.78810856047 0.0 0 0 -1.57079632679</pose>
       <name>bookcase</name>
       <uri>model://rwc2016/bookcase_noback</uri>
     </include>
-    <include name="plant_large">
+    <include>
       <pose>3.89536812137 5.36803348769 0.0 0 0 0</pose>
       <name>plant_large</name>
       <uri>model://rwc2016/plant_large</uri>
     </include>
-    <include name="plant_small_1">
+    <include>
       <pose>7.01406275975 0.90587587781 0.0 0 0 0</pose>
       <name>plant_small_1</name>
       <uri>model://rwc2016/plant</uri>
     </include>
-    <include name="plant_small_2">
+    <include>
       <pose>5.18986582633 -1.13721106556 0.0 0 0 0</pose>
       <name>plant_small_2</name>
       <uri>model://rwc2016/plant</uri>
     </include>
-    <include name="armchair_1">
+    <include>
       <pose>14.2507327613 1.50372431334 0.0 0 0 0.84</pose>
       <name>armchair_1</name>
       <uri>model://rwc2016/armchair</uri>
     </include>
-    <include name="armchair_3">
+    <include>
       <pose>12.7034840389 -0.11283179921 0.0 0 0 2.41079632679</pose>
       <name>armchair_3</name>
       <uri>model://rwc2016/armchair</uri>
     </include>
-    <include name="armchair_2">
+    <include>
       <pose>12.5876395892 1.47201037758 0.0 0 0 0.84</pose>
       <name>armchair_2</name>
       <uri>model://rwc2016/armchair</uri>
     </include>
-    <include name="ikea_table_high">
+    <include>
       <pose>11.3 -0.9 0.0 0 0 1.57079632679</pose>
       <name>ikea_table_high</name>
       <uri>model://rwc2016/ikea_table_black</uri>
@@ -441,6 +385,5 @@
         </solver>
       </ode>
     </physics>
-    <name>rwc2016a</name>
   </world>
 </sdf>

--- a/models/rwc2016a/walls/model.sdf
+++ b/models/rwc2016a/walls/model.sdf
@@ -8,7 +8,6 @@
             <uri>model://rwc2016a/walls/heightmap.stl</uri>
           </mesh>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -16,12 +15,9 @@
             <uri>model://rwc2016a/walls/heightmap.stl</uri>
           </mesh>
         </geometry>
-        <name>1</name>
       </visual>
       <pose>0 0 0 0 0 0</pose>
-      <name>1</name>
     </link>
     <static>true</static>
-    <name>rwc2016a/walls</name>
   </model>
 </sdf>

--- a/models/rwc2016b/model.sdf
+++ b/models/rwc2016b/model.sdf
@@ -4,7 +4,6 @@
     <light name="sun" type="directional">
       <direction>0.5 0.1 -0.9</direction>
       <pose>0 0 10 0 0 0</pose>
-      <name>sun</name>
       <specular>0.2 0.2 0.2 1</specular>
       <cast_shadows>true</cast_shadows>
       <diffuse>0.8 0.8 0.8 1</diffuse>
@@ -24,13 +23,10 @@
             </box>
           </geometry>
           <pose>-0.06 1.27 0.005 0 0 0</pose>
-          <name>in</name>
         </virtual_volume>
-        <name>in</name>
       </link>
       <pose>13.45 2.25 0 0 0 0</pose>
       <static>true</static>
-      <name>dining_room</name>
     </model>
     <model name="kitchen" type="room">
       <link name="in">
@@ -41,13 +37,10 @@
             </box>
           </geometry>
           <pose>-0.135 0.075 0.005 0 0 0</pose>
-          <name>in</name>
         </virtual_volume>
-        <name>in</name>
       </link>
       <pose>9.31 2.96 0 0 0 0</pose>
       <static>true</static>
-      <name>kitchen</name>
     </model>
     <model name="living_room" type="room">
       <link name="in">
@@ -58,13 +51,10 @@
             </box>
           </geometry>
           <pose>0.56 0.645 0.005 0 0 0</pose>
-          <name>in</name>
         </virtual_volume>
-        <name>in</name>
       </link>
       <pose>12.85 -0.39 0 0 0 0</pose>
       <static>true</static>
-      <name>living_room</name>
     </model>
     <model name="corridor" type="room">
       <link name="in">
@@ -75,9 +65,7 @@
             </box>
           </geometry>
           <pose>-0.265 2.385 0.005 0 0 0</pose>
-          <name>in1</name>
         </virtual_volume>
-        <name>in</name>
       </link>
       <link name="in">
         <virtual_volume name="in1">
@@ -87,13 +75,10 @@
             </box>
           </geometry>
           <pose>-0.265 2.385 0.005 0 0 0</pose>
-          <name>in1</name>
         </virtual_volume>
-        <name>in</name>
       </link>
       <pose>1.76 -0.64 0 0 0 0</pose>
       <static>true</static>
-      <name>corridor</name>
     </model>
     <model name="bedroom" type="room">
       <link name="in">
@@ -104,265 +89,227 @@
             </box>
           </geometry>
           <pose>-0.125 0.77 0.005 0 0 0</pose>
-          <name>in</name>
         </virtual_volume>
-        <name>in</name>
       </link>
       <pose>5.35 2.25 0 0 0 0</pose>
       <static>true</static>
-      <name>bedroom</name>
     </model>
     <model name="initial_pose_door_a" type="waypoint">
       <pose>-0.5 0.0 0 0 0 0.0</pose>
       <static>true</static>
-      <name>initial_pose_door_a</name>
     </model>
     <model name="initial_pose_door_b" type="waypoint">
       <pose>-0.5 3.0 0 0 0 0.0</pose>
       <static>true</static>
-      <name>initial_pose_door_b</name>
     </model>
     <model name="initial_pose_door_c" type="waypoint">
       <pose>14.66 5.56 0 0 0 -1.57</pose>
       <static>true</static>
-      <name>initial_pose_door_c</name>
     </model>
     <model name="entry_door_a" type="waypoint">
       <pose>1.0 0.0 0 0 0 0.0</pose>
       <static>true</static>
-      <name>entry_door_a</name>
     </model>
     <model name="entry_door_b" type="waypoint">
       <pose>1.0 3.0 0 0 0 0.0</pose>
       <static>true</static>
-      <name>entry_door_b</name>
     </model>
     <model name="entry_door_c" type="waypoint">
       <pose>14.7 4.0 0 0 0 -1.57</pose>
       <static>true</static>
-      <name>entry_door_c</name>
     </model>
     <model name="exit_door_a" type="waypoint">
       <pose>-1.5 0.0 0 0 0 3.14</pose>
       <static>true</static>
-      <name>exit_door_a</name>
     </model>
     <model name="exit_door_b" type="waypoint">
       <pose>-1.5 3.0 0 0 0 3.14</pose>
       <static>true</static>
-      <name>exit_door_b</name>
     </model>
     <model name="exit_door_c" type="waypoint">
       <pose>14.7 6.5 0 0 0 1.57</pose>
       <static>true</static>
-      <name>exit_door_c</name>
     </model>
     <model name="registration_table1" type="waypoint">
       <pose>9.7 -0.6 0 0 0 0</pose>
       <static>true</static>
-      <name>registration_table1</name>
     </model>
     <model name="registration_table2" type="waypoint">
       <pose>9.0 -1.4 0 0 0 0</pose>
       <static>true</static>
-      <name>registration_table2</name>
     </model>
     <model name="registration_table3" type="waypoint">
       <pose>8.4 -0.6 0 0 0 0</pose>
       <static>true</static>
-      <name>registration_table3</name>
     </model>
     <model name="exit_1_rips" type="waypoint">
       <pose>14.7 6.4 0 0 0 1.57</pose>
       <static>true</static>
-      <name>exit_1_rips</name>
     </model>
     <model name="exit_2_rips" type="waypoint">
       <pose>14.7 7.5 0 0 0 1.57</pose>
       <static>true</static>
-      <name>exit_2_rips</name>
     </model>
     <model name="exit_3_rips" type="waypoint">
       <pose>14.7 4.3 0 0 0 1.57</pose>
       <static>true</static>
-      <name>exit_3_rips</name>
     </model>
     <model name="exit_4_rips" type="waypoint">
       <pose>14.7 6.4 0 0 0 1.57</pose>
       <static>true</static>
-      <name>exit_4_rips</name>
     </model>
     <model name="navigation_target1" type="waypoint">
       <pose>9.5 -0.5 0 0 0 -1.57</pose>
       <static>true</static>
-      <name>navigation_target1</name>
     </model>
     <model name="navigation_target2_pre" type="waypoint">
       <pose>12.0 -0.6 0 0 0 -0.87</pose>
       <static>true</static>
-      <name>navigation_target2_pre</name>
     </model>
     <model name="navigation_target2" type="waypoint">
       <pose>13.0 -1.0 0 0 0 -1.57</pose>
       <static>true</static>
-      <name>navigation_target2</name>
     </model>
     <model name="navigation_target3" type="waypoint">
       <pose>2.0 1.5 0 0 0 3.14</pose>
       <static>true</static>
-      <name>navigation_target3</name>
     </model>
     <model name="navigation_door" type="waypoint">
       <pose>-0.7 0.0 0 0 0 0.0</pose>
       <static>true</static>
-      <name>navigation_door</name>
     </model>
     <model name="navigation_door_1" type="waypoint">
       <pose>-0.7 0.0 0 0 0 0.0</pose>
       <static>true</static>
-      <name>navigation_door_1</name>
     </model>
     <model name="navigation_door_2" type="waypoint">
       <pose>-0.7 3.0 0 0 0 0.0</pose>
       <static>true</static>
-      <name>navigation_door_2</name>
     </model>
     <model name="navigation_reentrance_door_1" type="waypoint">
       <pose>0.0 0.0 0 0 0 0.0</pose>
       <static>true</static>
-      <name>navigation_reentrance_door_1</name>
     </model>
     <model name="navigation_reentrance_door_2" type="waypoint">
       <pose>0.0 3.0 0 0 0 0.0</pose>
       <static>true</static>
-      <name>navigation_reentrance_door_2</name>
     </model>
     <model name="navigation_target4" type="waypoint">
       <pose>2.0 1.5 0 0 0 0.0</pose>
       <static>true</static>
-      <name>navigation_target4</name>
     </model>
     <model name="navigation_exit1" type="waypoint">
       <pose>-1.0 0.0 0 0 0 3.1415</pose>
       <static>true</static>
-      <name>navigation_exit1</name>
     </model>
     <model name="navigation_exit2" type="waypoint">
       <pose>-1.0 3.0 0 0 0 3.1415</pose>
       <static>true</static>
-      <name>navigation_exit2</name>
     </model>
     <model name="navigation_exit3" type="waypoint">
       <pose>-2.0 4.5 0 0 0 3.1415</pose>
       <static>true</static>
-      <name>navigation_exit3</name>
     </model>
     <model name="navigation_exit4" type="waypoint">
       <pose>-2.0 -1.0 0 0 0 3.1415</pose>
       <static>true</static>
-      <name>navigation_exit4</name>
     </model>
     <model name="door_opening_start_1" type="waypoint">
       <pose>-0.5 0.0 0 0 0 0</pose>
       <static>true</static>
-      <name>door_opening_start_1</name>
     </model>
     <model name="door_opening_dest_1" type="waypoint">
       <pose>0.9 0.0 0 0 0 0</pose>
       <static>true</static>
-      <name>door_opening_dest_1</name>
     </model>
     <model name="door_opening_start_2" type="waypoint">
       <pose>-0.5 3.0 0 0 0 0</pose>
       <static>true</static>
-      <name>door_opening_start_2</name>
     </model>
     <model name="door_opening_dest_2" type="waypoint">
       <pose>0.9 3.0 0 0 0 0</pose>
       <static>true</static>
-      <name>door_opening_dest_2</name>
     </model>
     <model name="gpsr_meeting_point" type="waypoint">
       <pose>2.006 -1.28 0 0 0 1.57</pose>
       <static>true</static>
-      <name>gpsr_meeting_point</name>
     </model>
-    <include name="floor">
+    <include>
       <pose>0 0 0 0 0 0</pose>
       <name>floor</name>
       <uri>model://floor</uri>
     </include>
-    <include name="walls">
+    <include>
       <pose>0 0 0 0 0 0</pose>
       <name>walls</name>
       <uri>model://rwc2016b/walls</uri>
     </include>
-    <include name="bed">
+    <include>
       <pose>4.2350414095 3.61956635071 0.0 0 0 -1.57079632679</pose>
       <name>bed</name>
       <uri>model://rwc2016/bed_frame</uri>
     </include>
-    <include name="bedside">
+    <include>
       <pose>7.20064872224 3.07295793463 0.0 0 0 3.14159265359</pose>
       <name>bedside</name>
       <uri>model://rwc2016/cabinet_2doors</uri>
     </include>
-    <include name="plant_small_bedroom">
+    <include>
       <pose>3.44435067195 5.07663793686 0.0 0 0 0.0</pose>
       <name>plant_small_bedroom</name>
       <uri>model://rwc2016/plant</uri>
     </include>
-    <include name="plant_small_hall_1">
+    <include>
       <pose>7.34685494228 -0.0256348198448 0.0 0 0 0.0</pose>
       <name>plant_small_hall_1</name>
       <uri>model://rwc2016/plant</uri>
     </include>
-    <include name="sink">
+    <include>
       <pose>7.79068520743 2.35834741039 0.0 0 0 0.0</pose>
       <name>sink</name>
       <uri>model://rwc2016/kitchen_counter</uri>
     </include>
-    <include name="cupboard">
+    <include>
       <pose>9.50542128925 5.24257608022 0.0 0 0 -1.57079632679</pose>
       <name>cupboard</name>
       <uri>model://rwc2016/cabinet_2slides</uri>
     </include>
-    <include name="bar">
+    <include>
       <pose>7.6934243492 3.89551713301 0.0 0 0 0.0</pose>
       <name>bar</name>
       <uri>model://rwc2016/bookcase_noback</uri>
     </include>
-    <include name="cabinet">
+    <include>
       <pose>4.03141751655 0.320342320845 0.0 0 0 -1.57079632679</pose>
       <name>cabinet</name>
       <uri>model://rwc2016/cabinet_2doors</uri>
     </include>
-    <include name="plant_small_hall_2">
+    <include>
       <pose>2.843662104 0.322526422217 0.0 0 0 0.0</pose>
       <name>plant_small_hall_2</name>
       <uri>model://rwc2016/plant</uri>
     </include>
-    <include name="sideshelf">
+    <include>
       <pose>10.6916059274 2.94276122472 0.0 0 0 3.14159265359</pose>
       <name>sideshelf</name>
       <uri>model://rwc2016/cabinet_2doors</uri>
     </include>
-    <include name="table1">
+    <include>
       <pose>14.8 3.1 0.0 0 0 3.14159265359</pose>
       <name>table1</name>
       <uri>model://rwc2016/table_bureau</uri>
     </include>
-    <include name="table2">
+    <include>
       <pose>14.8 0.2 0.0 0 0 3.14159265359</pose>
       <name>table2</name>
       <uri>model://rwc2016/table_bureau</uri>
     </include>
-    <include name="table3">
+    <include>
       <pose>12.0 -1.0 0.0 0 0 1.57079632679</pose>
       <name>table3</name>
       <uri>model://rwc2016/table_bureau</uri>
     </include>
-    <include name="bar">
+    <include>
       <pose>12.0 5.21299446298 0.0 0 0 -1.57079632679</pose>
       <name>bar</name>
       <uri>model://rwc2016/cabinet_open_small</uri>
@@ -379,6 +326,5 @@
         </solver>
       </ode>
     </physics>
-    <name>rwc2016b</name>
   </world>
 </sdf>

--- a/models/rwc2016b/walls/model.sdf
+++ b/models/rwc2016b/walls/model.sdf
@@ -8,7 +8,6 @@
             <uri>model://rwc2016b/walls/heightmap.stl</uri>
           </mesh>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -16,12 +15,9 @@
             <uri>model://rwc2016b/walls/heightmap.stl</uri>
           </mesh>
         </geometry>
-        <name>1</name>
       </visual>
       <pose>0 0 0 0 0 0</pose>
-      <name>1</name>
     </link>
     <static>true</static>
-    <name>rwc2016b/walls</name>
   </model>
 </sdf>

--- a/models/rwc2017/bed/model.sdf
+++ b/models/rwc2017/bed/model.sdf
@@ -8,7 +8,6 @@
             <size>1.07 2.04 0.36</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -16,10 +15,8 @@
             <size>1.07 2.04 0.36</size>
           </box>
         </geometry>
-        <name>1</name>
       </visual>
       <pose>0 0 0.18 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="2">
       <collision name="2">
@@ -28,7 +25,6 @@
             <size>1.07 0.02 0.44</size>
           </box>
         </geometry>
-        <name>2</name>
       </collision>
       <visual name="2">
         <geometry>
@@ -36,10 +32,8 @@
             <size>1.07 0.02 0.44</size>
           </box>
         </geometry>
-        <name>2</name>
       </visual>
       <pose>0.0 -1.01 0.58 0 0 0</pose>
-      <name>2</name>
     </link>
     <link name="3">
       <collision name="3">
@@ -48,7 +42,6 @@
             <size>1.07 0.02 0.14</size>
           </box>
         </geometry>
-        <name>3</name>
       </collision>
       <visual name="3">
         <geometry>
@@ -56,10 +49,8 @@
             <size>1.07 0.02 0.14</size>
           </box>
         </geometry>
-        <name>3</name>
       </visual>
       <pose>0.0 1.01 0.43 0 0 0</pose>
-      <name>3</name>
     </link>
     <link name="on_top_of">
       <virtual_volume name="on_top_of">
@@ -69,9 +60,7 @@
           </box>
         </geometry>
         <pose>0.0 0.0 0.7 0 0 0</pose>
-        <name>on_top_of</name>
       </virtual_volume>
-      <name>on_top_of</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
@@ -81,11 +70,8 @@
           </box>
         </geometry>
         <pose>0.85 0.0 0.005 0 0 0</pose>
-        <name>in_front_of</name>
       </virtual_volume>
-      <name>in_front_of</name>
     </link>
     <static>true</static>
-    <name>rwc2017/bed</name>
   </model>
 </sdf>

--- a/models/rwc2017/cabinet_black/model.sdf
+++ b/models/rwc2017/cabinet_black/model.sdf
@@ -8,7 +8,6 @@
             <size>0.35 0.6 0.93</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -16,10 +15,8 @@
             <size>0.35 0.6 0.93</size>
           </box>
         </geometry>
-        <name>1</name>
       </visual>
       <pose>0 0 0.465 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="on_top_of">
       <virtual_volume name="on_top_of">
@@ -29,9 +26,7 @@
           </box>
         </geometry>
         <pose>0.0 0.0 1.075 0 0 0</pose>
-        <name>on_top_of</name>
       </virtual_volume>
-      <name>on_top_of</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
@@ -41,11 +36,8 @@
           </box>
         </geometry>
         <pose>0.6 0.0 0.005 0 0 0</pose>
-        <name>in_front_of</name>
       </virtual_volume>
-      <name>in_front_of</name>
     </link>
     <static>true</static>
-    <name>rwc2017/cabinet_black</name>
   </model>
 </sdf>

--- a/models/rwc2017/cabinet_brown_high/model.sdf
+++ b/models/rwc2017/cabinet_brown_high/model.sdf
@@ -8,7 +8,6 @@
             <size>0.44 1.2 1.74</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -16,10 +15,8 @@
             <size>0.44 1.2 1.74</size>
           </box>
         </geometry>
-        <name>1</name>
       </visual>
       <pose>0 0 0.87 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
@@ -29,11 +26,8 @@
           </box>
         </geometry>
         <pose>0.72 0.0 0.005 0 0 0</pose>
-        <name>in_front_of</name>
       </virtual_volume>
-      <name>in_front_of</name>
     </link>
     <static>true</static>
-    <name>rwc2017/cabinet_brown_high</name>
   </model>
 </sdf>

--- a/models/rwc2017/cabinet_brown_low/model.sdf
+++ b/models/rwc2017/cabinet_brown_low/model.sdf
@@ -8,7 +8,6 @@
             <size>0.44 0.015 0.9</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -16,10 +15,8 @@
             <size>0.44 0.015 0.9</size>
           </box>
         </geometry>
-        <name>1</name>
       </visual>
       <pose>0 -0.5925 0.45 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="2">
       <collision name="2">
@@ -28,7 +25,6 @@
             <size>0.44 0.015 0.9</size>
           </box>
         </geometry>
-        <name>2</name>
       </collision>
       <visual name="2">
         <geometry>
@@ -36,10 +32,8 @@
             <size>0.44 0.015 0.9</size>
           </box>
         </geometry>
-        <name>2</name>
       </visual>
       <pose>0 0.5925 0.45 0 0 0</pose>
-      <name>2</name>
     </link>
     <link name="3">
       <collision name="3">
@@ -48,7 +42,6 @@
             <size>0.015 1.2 0.9</size>
           </box>
         </geometry>
-        <name>3</name>
       </collision>
       <visual name="3">
         <geometry>
@@ -56,10 +49,8 @@
             <size>0.015 1.2 0.9</size>
           </box>
         </geometry>
-        <name>3</name>
       </visual>
       <pose>-0.2125 0 0.45 0 0 0</pose>
-      <name>3</name>
     </link>
     <link name="4">
       <collision name="4">
@@ -68,7 +59,6 @@
             <size>0.425 1.17 0.03</size>
           </box>
         </geometry>
-        <name>4</name>
       </collision>
       <visual name="4">
         <geometry>
@@ -76,10 +66,8 @@
             <size>0.425 1.17 0.03</size>
           </box>
         </geometry>
-        <name>4</name>
       </visual>
       <pose>0.0075 0 0.885 0 0 0</pose>
-      <name>4</name>
     </link>
     <link name="5">
       <collision name="5">
@@ -88,7 +76,6 @@
             <size>0.425 1.17 0.03</size>
           </box>
         </geometry>
-        <name>5</name>
       </collision>
       <visual name="5">
         <geometry>
@@ -96,10 +83,8 @@
             <size>0.425 1.17 0.03</size>
           </box>
         </geometry>
-        <name>5</name>
       </visual>
       <pose>0.0075 0 0.015 0 0 0</pose>
-      <name>5</name>
     </link>
     <link name="6">
       <collision name="6">
@@ -108,7 +93,6 @@
             <size>0.425 1.17 0.045</size>
           </box>
         </geometry>
-        <name>6</name>
       </collision>
       <visual name="6">
         <geometry>
@@ -116,10 +100,8 @@
             <size>0.425 1.17 0.045</size>
           </box>
         </geometry>
-        <name>6</name>
       </visual>
       <pose>0.0075 0 0.4625 0 0 0</pose>
-      <name>6</name>
     </link>
     <link name="7">
       <collision name="7">
@@ -128,7 +110,6 @@
             <size>0.425 0.045 0.855</size>
           </box>
         </geometry>
-        <name>7</name>
       </collision>
       <visual name="7">
         <geometry>
@@ -136,10 +117,8 @@
             <size>0.425 0.045 0.855</size>
           </box>
         </geometry>
-        <name>7</name>
       </visual>
       <pose>0.0075 0.0 0.4575 0 0 0</pose>
-      <name>7</name>
     </link>
     <link name="8">
       <collision name="8">
@@ -148,7 +127,6 @@
             <size>0.44 0.6 0.89</size>
           </box>
         </geometry>
-        <name>8</name>
       </collision>
       <visual name="8">
         <geometry>
@@ -156,10 +134,8 @@
             <size>0.44 0.6 0.89</size>
           </box>
         </geometry>
-        <name>8</name>
       </visual>
       <pose>0.0 -0.3 0.44 0 0 0</pose>
-      <name>8</name>
     </link>
     <link name="9">
       <collision name="9">
@@ -168,7 +144,6 @@
             <size>0.44 0.6 0.43</size>
           </box>
         </geometry>
-        <name>9</name>
       </collision>
       <visual name="9">
         <geometry>
@@ -176,10 +151,8 @@
             <size>0.44 0.6 0.43</size>
           </box>
         </geometry>
-        <name>9</name>
       </visual>
       <pose>0.0 0.3 0.22 0 0 0</pose>
-      <name>9</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
@@ -189,9 +162,7 @@
           </box>
         </geometry>
         <pose>0.72 0.15 0.005 0 0 0</pose>
-        <name>in_front_of</name>
       </virtual_volume>
-      <name>in_front_of</name>
     </link>
     <link name="on_top_of">
       <virtual_volume name="on_top_of">
@@ -201,9 +172,7 @@
           </box>
         </geometry>
         <pose>0.0075 0.0 1.0875 0 0 0</pose>
-        <name>on_top_of</name>
       </virtual_volume>
-      <name>on_top_of</name>
     </link>
     <link name="shelf1">
       <virtual_volume name="shelf1">
@@ -213,11 +182,8 @@
           </box>
         </geometry>
         <pose>0.0175 0.305 0.655 0 0 0</pose>
-        <name>shelf1</name>
       </virtual_volume>
-      <name>shelf1</name>
     </link>
     <static>true</static>
-    <name>rwc2017/cabinet_brown_low</name>
   </model>
 </sdf>

--- a/models/rwc2017/cabinet_desk/model.sdf
+++ b/models/rwc2017/cabinet_desk/model.sdf
@@ -8,7 +8,6 @@
             <size>0.39 0.3 0.56</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -19,10 +18,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>1</name>
       </visual>
       <pose>0 0 0.28 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="on_top_of">
       <virtual_volume name="on_top_of">
@@ -32,9 +29,7 @@
           </box>
         </geometry>
         <pose>0.0 0.0 0.705 0 0 0</pose>
-        <name>on_top_of</name>
       </virtual_volume>
-      <name>on_top_of</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
@@ -44,11 +39,8 @@
           </box>
         </geometry>
         <pose>0.695 0.0 0.005 0 0 0</pose>
-        <name>in_front_of</name>
       </virtual_volume>
-      <name>in_front_of</name>
     </link>
     <static>true</static>
-    <name>rwc2017/cabinet_desk</name>
   </model>
 </sdf>

--- a/models/rwc2017/cabinet_kast/model.sdf
+++ b/models/rwc2017/cabinet_kast/model.sdf
@@ -8,7 +8,6 @@
             <size>0.393 0.034 0.764</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -19,10 +18,8 @@
         <material>
           <ambient>1.0 1.0 1.0 1</ambient>
         </material>
-        <name>1</name>
       </visual>
       <pose>0 -0.366 0.382 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="2">
       <collision name="2">
@@ -31,7 +28,6 @@
             <size>0.393 0.034 0.764</size>
           </box>
         </geometry>
-        <name>2</name>
       </collision>
       <visual name="2">
         <geometry>
@@ -42,10 +38,8 @@
         <material>
           <ambient>1.0 1.0 1.0 1</ambient>
         </material>
-        <name>2</name>
       </visual>
       <pose>0 0.366 0.382 0 0 0</pose>
-      <name>2</name>
     </link>
     <link name="3">
       <collision name="3">
@@ -54,7 +48,6 @@
             <size>0.393 0.764 0.034</size>
           </box>
         </geometry>
-        <name>3</name>
       </collision>
       <visual name="3">
         <geometry>
@@ -65,10 +58,8 @@
         <material>
           <ambient>1.0 1.0 1.0 1</ambient>
         </material>
-        <name>3</name>
       </visual>
       <pose>0 0 0.747 0 0 0</pose>
-      <name>3</name>
     </link>
     <link name="4">
       <collision name="4">
@@ -77,7 +68,6 @@
             <size>0.393 0.764 0.034</size>
           </box>
         </geometry>
-        <name>4</name>
       </collision>
       <visual name="4">
         <geometry>
@@ -88,10 +78,8 @@
         <material>
           <ambient>1.0 1.0 1.0 1</ambient>
         </material>
-        <name>4</name>
       </visual>
       <pose>0 0 0.025 0 0 0</pose>
-      <name>4</name>
     </link>
     <link name="5">
       <collision name="5">
@@ -100,7 +88,6 @@
             <size>0.393 0.69 0.02</size>
           </box>
         </geometry>
-        <name>5</name>
       </collision>
       <visual name="5">
         <geometry>
@@ -111,10 +98,8 @@
         <material>
           <ambient>1.0 1.0 1.0 1</ambient>
         </material>
-        <name>5</name>
       </visual>
       <pose>0 0 0.382 0 0 0</pose>
-      <name>5</name>
     </link>
     <link name="6">
       <collision name="6">
@@ -123,7 +108,6 @@
             <size>0.393 0.02 0.69</size>
           </box>
         </geometry>
-        <name>6</name>
       </collision>
       <visual name="6">
         <geometry>
@@ -134,10 +118,8 @@
         <material>
           <ambient>1.0 1.0 1.0 1</ambient>
         </material>
-        <name>6</name>
       </visual>
       <pose>0 0 0.382 0 0 0</pose>
-      <name>6</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
@@ -147,9 +129,7 @@
           </box>
         </geometry>
         <pose>0.5 0.0 0.005 0 0 0</pose>
-        <name>in_front_of</name>
       </virtual_volume>
-      <name>in_front_of</name>
     </link>
     <link name="on_top_of">
       <virtual_volume name="on_top_of">
@@ -159,11 +139,8 @@
           </box>
         </geometry>
         <pose>0.0 0.0 1.46 0 0 0</pose>
-        <name>on_top_of</name>
       </virtual_volume>
-      <name>on_top_of</name>
     </link>
     <static>true</static>
-    <name>rwc2017/cabinet_kast</name>
   </model>
 </sdf>

--- a/models/rwc2017/cabinet_kitchen/model.sdf
+++ b/models/rwc2017/cabinet_kitchen/model.sdf
@@ -8,7 +8,6 @@
             <size>0.28 0.018 2.02</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -16,10 +15,8 @@
             <size>0.28 0.018 2.02</size>
           </box>
         </geometry>
-        <name>1</name>
       </visual>
       <pose>0 -0.371 1.01 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="2">
       <collision name="2">
@@ -28,7 +25,6 @@
             <size>0.28 0.018 2.02</size>
           </box>
         </geometry>
-        <name>2</name>
       </collision>
       <visual name="2">
         <geometry>
@@ -36,10 +32,8 @@
             <size>0.28 0.018 2.02</size>
           </box>
         </geometry>
-        <name>2</name>
       </visual>
       <pose>0 0.371 1.01 0 0 0</pose>
-      <name>2</name>
     </link>
     <link name="3">
       <collision name="3">
@@ -48,7 +42,6 @@
             <size>0.018 0.76 2.02</size>
           </box>
         </geometry>
-        <name>3</name>
       </collision>
       <visual name="3">
         <geometry>
@@ -56,10 +49,8 @@
             <size>0.018 0.76 2.02</size>
           </box>
         </geometry>
-        <name>3</name>
       </visual>
       <pose>-0.131 0 1.01 0 0 0</pose>
-      <name>3</name>
     </link>
     <link name="4">
       <collision name="4">
@@ -68,7 +59,6 @@
             <size>0.262 0.724 0.018</size>
           </box>
         </geometry>
-        <name>4</name>
       </collision>
       <visual name="4">
         <geometry>
@@ -76,10 +66,8 @@
             <size>0.262 0.724 0.018</size>
           </box>
         </geometry>
-        <name>4</name>
       </visual>
       <pose>0.009 0 2.011 0 0 0</pose>
-      <name>4</name>
     </link>
     <link name="5">
       <collision name="5">
@@ -88,7 +76,6 @@
             <size>0.262 0.724 0.098</size>
           </box>
         </geometry>
-        <name>5</name>
       </collision>
       <visual name="5">
         <geometry>
@@ -96,10 +83,8 @@
             <size>0.262 0.724 0.098</size>
           </box>
         </geometry>
-        <name>5</name>
       </visual>
       <pose>0.009 0 0.049 0 0 0</pose>
-      <name>5</name>
     </link>
     <link name="6">
       <collision name="6">
@@ -108,7 +93,6 @@
             <size>0.262 0.724 0.018</size>
           </box>
         </geometry>
-        <name>6</name>
       </collision>
       <visual name="6">
         <geometry>
@@ -116,10 +100,8 @@
             <size>0.262 0.724 0.018</size>
           </box>
         </geometry>
-        <name>6</name>
       </visual>
       <pose>0.009 0 0.399 0 0 0</pose>
-      <name>6</name>
     </link>
     <link name="7">
       <collision name="7">
@@ -128,7 +110,6 @@
             <size>0.262 0.724 0.018</size>
           </box>
         </geometry>
-        <name>7</name>
       </collision>
       <visual name="7">
         <geometry>
@@ -136,10 +117,8 @@
             <size>0.262 0.724 0.018</size>
           </box>
         </geometry>
-        <name>7</name>
       </visual>
       <pose>0.009 0 0.659 0 0 0</pose>
-      <name>7</name>
     </link>
     <link name="8">
       <collision name="8">
@@ -148,7 +127,6 @@
             <size>0.262 0.724 0.018</size>
           </box>
         </geometry>
-        <name>8</name>
       </collision>
       <visual name="8">
         <geometry>
@@ -156,10 +134,8 @@
             <size>0.262 0.724 0.018</size>
           </box>
         </geometry>
-        <name>8</name>
       </visual>
       <pose>0.009 0 1.049 0 0 0</pose>
-      <name>8</name>
     </link>
     <link name="9">
       <collision name="9">
@@ -168,7 +144,6 @@
             <size>0.262 0.724 0.018</size>
           </box>
         </geometry>
-        <name>9</name>
       </collision>
       <visual name="9">
         <geometry>
@@ -176,10 +151,8 @@
             <size>0.262 0.724 0.018</size>
           </box>
         </geometry>
-        <name>9</name>
       </visual>
       <pose>0.009 0 1.459 0 0 0</pose>
-      <name>9</name>
     </link>
     <link name="10">
       <collision name="10">
@@ -188,7 +161,6 @@
             <size>0.262 0.724 0.018</size>
           </box>
         </geometry>
-        <name>10</name>
       </collision>
       <visual name="10">
         <geometry>
@@ -196,10 +168,8 @@
             <size>0.262 0.724 0.018</size>
           </box>
         </geometry>
-        <name>10</name>
       </visual>
       <pose>0.009 0 1.684 0 0 0</pose>
-      <name>10</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
@@ -209,9 +179,7 @@
           </box>
         </geometry>
         <pose>0.64 0.0 0.005 0 0 0</pose>
-        <name>in_front_of</name>
       </virtual_volume>
-      <name>in_front_of</name>
     </link>
     <link name="shelf1">
       <virtual_volume name="shelf1">
@@ -221,9 +189,7 @@
           </box>
         </geometry>
         <pose>0.019 0.0 0.239 0 0 0</pose>
-        <name>shelf1</name>
       </virtual_volume>
-      <name>shelf1</name>
     </link>
     <link name="shelf2">
       <virtual_volume name="shelf2">
@@ -233,9 +199,7 @@
           </box>
         </geometry>
         <pose>0.019 0.0 0.529 0 0 0</pose>
-        <name>shelf2</name>
       </virtual_volume>
-      <name>shelf2</name>
     </link>
     <link name="shelf3">
       <virtual_volume name="shelf3">
@@ -245,9 +209,7 @@
           </box>
         </geometry>
         <pose>0.019 0.0 0.813 0 0 0</pose>
-        <name>shelf3</name>
       </virtual_volume>
-      <name>shelf3</name>
     </link>
     <link name="shelf4">
       <virtual_volume name="shelf4">
@@ -257,9 +219,7 @@
           </box>
         </geometry>
         <pose>0.019 0.0 1.203 0 0 0</pose>
-        <name>shelf4</name>
       </virtual_volume>
-      <name>shelf4</name>
     </link>
     <link name="shelf5">
       <virtual_volume name="shelf5">
@@ -269,9 +229,7 @@
           </box>
         </geometry>
         <pose>0.019 0.0 1.569 0 0 0</pose>
-        <name>shelf5</name>
       </virtual_volume>
-      <name>shelf5</name>
     </link>
     <link name="shelf6">
       <virtual_volume name="shelf6">
@@ -281,11 +239,8 @@
           </box>
         </geometry>
         <pose>0.019 0.0 1.838 0 0 0</pose>
-        <name>shelf6</name>
       </virtual_volume>
-      <name>shelf6</name>
     </link>
     <static>true</static>
-    <name>rwc2017/cabinet_kitchen</name>
   </model>
 </sdf>

--- a/models/rwc2017/cabinet_showcase/model.sdf
+++ b/models/rwc2017/cabinet_showcase/model.sdf
@@ -8,7 +8,6 @@
             <size>0.41 1.0 1.36</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -16,10 +15,8 @@
             <size>0.41 1.0 1.36</size>
           </box>
         </geometry>
-        <name>1</name>
       </visual>
       <pose>0 0 0.68 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="on_top_of">
       <virtual_volume name="on_top_of">
@@ -29,9 +26,7 @@
           </box>
         </geometry>
         <pose>0.0 0.0 1.505 0 0 0</pose>
-        <name>on_top_of</name>
       </virtual_volume>
-      <name>on_top_of</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
@@ -41,11 +36,8 @@
           </box>
         </geometry>
         <pose>0.705 0.0 0.005 0 0 0</pose>
-        <name>in_front_of</name>
       </virtual_volume>
-      <name>in_front_of</name>
     </link>
     <static>true</static>
-    <name>rwc2017/cabinet_showcase</name>
   </model>
 </sdf>

--- a/models/rwc2017/cabinet_simple/model.sdf
+++ b/models/rwc2017/cabinet_simple/model.sdf
@@ -8,7 +8,6 @@
             <size>0.29 0.01 0.9</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -19,10 +18,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>1</name>
       </visual>
       <pose>0 -0.22 0.45 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="2">
       <collision name="2">
@@ -31,7 +28,6 @@
             <size>0.29 0.01 0.9</size>
           </box>
         </geometry>
-        <name>2</name>
       </collision>
       <visual name="2">
         <geometry>
@@ -42,10 +38,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>2</name>
       </visual>
       <pose>0 0.22 0.45 0 0 0</pose>
-      <name>2</name>
     </link>
     <link name="3">
       <collision name="3">
@@ -54,7 +48,6 @@
             <size>0.01 0.45 0.9</size>
           </box>
         </geometry>
-        <name>3</name>
       </collision>
       <visual name="3">
         <geometry>
@@ -65,10 +58,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>3</name>
       </visual>
       <pose>-0.14 0 0.45 0 0 0</pose>
-      <name>3</name>
     </link>
     <link name="4">
       <collision name="4">
@@ -77,7 +68,6 @@
             <size>0.28 0.43 0.01</size>
           </box>
         </geometry>
-        <name>4</name>
       </collision>
       <visual name="4">
         <geometry>
@@ -88,10 +78,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>4</name>
       </visual>
       <pose>0.005 0 0.895 0 0 0</pose>
-      <name>4</name>
     </link>
     <link name="5">
       <collision name="5">
@@ -100,7 +88,6 @@
             <size>0.28 0.43 0.01</size>
           </box>
         </geometry>
-        <name>5</name>
       </collision>
       <visual name="5">
         <geometry>
@@ -111,10 +98,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>5</name>
       </visual>
       <pose>0.005 0 0.005 0 0 0</pose>
-      <name>5</name>
     </link>
     <link name="6">
       <collision name="6">
@@ -123,7 +108,6 @@
             <size>0.28 0.43 0.01</size>
           </box>
         </geometry>
-        <name>6</name>
       </collision>
       <visual name="6">
         <geometry>
@@ -134,10 +118,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>6</name>
       </visual>
       <pose>0.005 0 0.3 0 0 0</pose>
-      <name>6</name>
     </link>
     <link name="7">
       <collision name="7">
@@ -146,7 +128,6 @@
             <size>0.28 0.43 0.01</size>
           </box>
         </geometry>
-        <name>7</name>
       </collision>
       <visual name="7">
         <geometry>
@@ -157,10 +138,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>7</name>
       </visual>
       <pose>0.005 0 0.595 0 0 0</pose>
-      <name>7</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
@@ -170,9 +149,7 @@
           </box>
         </geometry>
         <pose>0.645 0.0 0.005 0 0 0</pose>
-        <name>in_front_of</name>
       </virtual_volume>
-      <name>in_front_of</name>
     </link>
     <link name="shelf1">
       <virtual_volume name="shelf1">
@@ -182,9 +159,7 @@
           </box>
         </geometry>
         <pose>0.005 0.0 0.155 0 0 0</pose>
-        <name>shelf1</name>
       </virtual_volume>
-      <name>shelf1</name>
     </link>
     <link name="shelf2">
       <virtual_volume name="shelf2">
@@ -194,9 +169,7 @@
           </box>
         </geometry>
         <pose>0.005 0.0 0.45 0 0 0</pose>
-        <name>shelf2</name>
       </virtual_volume>
-      <name>shelf2</name>
     </link>
     <link name="shelf3">
       <virtual_volume name="shelf3">
@@ -206,11 +179,8 @@
           </box>
         </geometry>
         <pose>0.005 0.0 0.745 0 0 0</pose>
-        <name>shelf3</name>
       </virtual_volume>
-      <name>shelf3</name>
     </link>
     <static>true</static>
-    <name>rwc2017/cabinet_simple</name>
   </model>
 </sdf>

--- a/models/rwc2017/cabinet_simple_no_areas/model.sdf
+++ b/models/rwc2017/cabinet_simple_no_areas/model.sdf
@@ -8,7 +8,6 @@
             <size>0.29 0.01 0.9</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -16,10 +15,8 @@
             <size>0.29 0.01 0.9</size>
           </box>
         </geometry>
-        <name>1</name>
       </visual>
       <pose>0 -0.22 0.45 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="2">
       <collision name="2">
@@ -28,7 +25,6 @@
             <size>0.29 0.01 0.9</size>
           </box>
         </geometry>
-        <name>2</name>
       </collision>
       <visual name="2">
         <geometry>
@@ -36,10 +32,8 @@
             <size>0.29 0.01 0.9</size>
           </box>
         </geometry>
-        <name>2</name>
       </visual>
       <pose>0 0.22 0.45 0 0 0</pose>
-      <name>2</name>
     </link>
     <link name="3">
       <collision name="3">
@@ -48,7 +42,6 @@
             <size>0.01 0.45 0.9</size>
           </box>
         </geometry>
-        <name>3</name>
       </collision>
       <visual name="3">
         <geometry>
@@ -56,10 +49,8 @@
             <size>0.01 0.45 0.9</size>
           </box>
         </geometry>
-        <name>3</name>
       </visual>
       <pose>-0.14 0 0.45 0 0 0</pose>
-      <name>3</name>
     </link>
     <link name="4">
       <collision name="4">
@@ -68,7 +59,6 @@
             <size>0.28 0.43 0.01</size>
           </box>
         </geometry>
-        <name>4</name>
       </collision>
       <visual name="4">
         <geometry>
@@ -76,10 +66,8 @@
             <size>0.28 0.43 0.01</size>
           </box>
         </geometry>
-        <name>4</name>
       </visual>
       <pose>0.005 0 0.895 0 0 0</pose>
-      <name>4</name>
     </link>
     <link name="5">
       <collision name="5">
@@ -88,7 +76,6 @@
             <size>0.28 0.43 0.01</size>
           </box>
         </geometry>
-        <name>5</name>
       </collision>
       <visual name="5">
         <geometry>
@@ -96,10 +83,8 @@
             <size>0.28 0.43 0.01</size>
           </box>
         </geometry>
-        <name>5</name>
       </visual>
       <pose>0.005 0 0.005 0 0 0</pose>
-      <name>5</name>
     </link>
     <link name="6">
       <collision name="6">
@@ -108,7 +93,6 @@
             <size>0.28 0.43 0.01</size>
           </box>
         </geometry>
-        <name>6</name>
       </collision>
       <visual name="6">
         <geometry>
@@ -116,10 +100,8 @@
             <size>0.28 0.43 0.01</size>
           </box>
         </geometry>
-        <name>6</name>
       </visual>
       <pose>0.005 0 0.3 0 0 0</pose>
-      <name>6</name>
     </link>
     <link name="7">
       <collision name="7">
@@ -128,7 +110,6 @@
             <size>0.28 0.43 0.01</size>
           </box>
         </geometry>
-        <name>7</name>
       </collision>
       <visual name="7">
         <geometry>
@@ -136,12 +117,9 @@
             <size>0.28 0.43 0.01</size>
           </box>
         </geometry>
-        <name>7</name>
       </visual>
       <pose>0.005 0 0.595 0 0 0</pose>
-      <name>7</name>
     </link>
     <static>true</static>
-    <name>rwc2017/cabinet_simple_no_areas</name>
   </model>
 </sdf>

--- a/models/rwc2017/carpet/model.sdf
+++ b/models/rwc2017/carpet/model.sdf
@@ -9,7 +9,6 @@
             <radius>0.9</radius>
           </cylinder>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -18,12 +17,9 @@
             <radius>0.9</radius>
           </cylinder>
         </geometry>
-        <name>1</name>
       </visual>
       <pose>0 0 0.015 0 0 0</pose>
-      <name>1</name>
     </link>
     <static>true</static>
-    <name>rwc2017/carpet</name>
   </model>
 </sdf>

--- a/models/rwc2017/desk/model.sdf
+++ b/models/rwc2017/desk/model.sdf
@@ -8,7 +8,6 @@
             <size>0.01 1.15 0.71</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -16,10 +15,8 @@
             <size>0.01 1.15 0.71</size>
           </box>
         </geometry>
-        <name>1</name>
       </visual>
       <pose>-0.295 0 0.355 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="2">
       <collision name="2">
@@ -28,7 +25,6 @@
             <size>0.6 1.15 0.03</size>
           </box>
         </geometry>
-        <name>2</name>
       </collision>
       <visual name="2">
         <geometry>
@@ -36,10 +32,8 @@
             <size>0.6 1.15 0.03</size>
           </box>
         </geometry>
-        <name>2</name>
       </visual>
       <pose>0 0 0.695 0 0 0</pose>
-      <name>2</name>
     </link>
     <link name="3">
       <collision name="3">
@@ -48,7 +42,6 @@
             <size>0.02 0.02 0.68</size>
           </box>
         </geometry>
-        <name>3</name>
       </collision>
       <visual name="3">
         <geometry>
@@ -56,10 +49,8 @@
             <size>0.02 0.02 0.68</size>
           </box>
         </geometry>
-        <name>3</name>
       </visual>
       <pose>-0.28 -0.555 0.34 0 0 0</pose>
-      <name>3</name>
     </link>
     <link name="4">
       <collision name="4">
@@ -68,7 +59,6 @@
             <size>0.02 0.02 0.68</size>
           </box>
         </geometry>
-        <name>4</name>
       </collision>
       <visual name="4">
         <geometry>
@@ -76,10 +66,8 @@
             <size>0.02 0.02 0.68</size>
           </box>
         </geometry>
-        <name>4</name>
       </visual>
       <pose>0.28 -0.555 0.34 0 0 0</pose>
-      <name>4</name>
     </link>
     <link name="5">
       <collision name="5">
@@ -88,7 +76,6 @@
             <size>0.02 0.02 0.68</size>
           </box>
         </geometry>
-        <name>5</name>
       </collision>
       <visual name="5">
         <geometry>
@@ -96,10 +83,8 @@
             <size>0.02 0.02 0.68</size>
           </box>
         </geometry>
-        <name>5</name>
       </visual>
       <pose>-0.28 0.555 0.34 0 0 0</pose>
-      <name>5</name>
     </link>
     <link name="6">
       <collision name="6">
@@ -108,7 +93,6 @@
             <size>0.02 0.02 0.68</size>
           </box>
         </geometry>
-        <name>6</name>
       </collision>
       <visual name="6">
         <geometry>
@@ -116,10 +100,8 @@
             <size>0.02 0.02 0.68</size>
           </box>
         </geometry>
-        <name>6</name>
       </visual>
       <pose>0.28 0.555 0.34 0 0 0</pose>
-      <name>6</name>
     </link>
     <link name="7">
       <collision name="7">
@@ -128,7 +110,6 @@
             <size>0.58 0.37 0.3</size>
           </box>
         </geometry>
-        <name>7</name>
       </collision>
       <visual name="7">
         <geometry>
@@ -136,10 +117,8 @@
             <size>0.58 0.37 0.3</size>
           </box>
         </geometry>
-        <name>7</name>
       </visual>
       <pose>-0.02 0.37 0.55 0 0 0</pose>
-      <name>7</name>
     </link>
     <link name="on_top_of">
       <virtual_volume name="on_top_of">
@@ -149,9 +128,7 @@
           </box>
         </geometry>
         <pose>0.0 0.0 0.855 0 0 0</pose>
-        <name>on_top_of</name>
       </virtual_volume>
-      <name>on_top_of</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
@@ -161,11 +138,8 @@
           </box>
         </geometry>
         <pose>0.8 0.0 0.005 0 0 0</pose>
-        <name>in_front_of</name>
       </virtual_volume>
-      <name>in_front_of</name>
     </link>
     <static>true</static>
-    <name>rwc2017/desk</name>
   </model>
 </sdf>

--- a/models/rwc2017/desk_little/model.sdf
+++ b/models/rwc2017/desk_little/model.sdf
@@ -8,7 +8,6 @@
             <size>0.58 0.98 0.1</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -16,10 +15,8 @@
             <size>0.58 0.98 0.1</size>
           </box>
         </geometry>
-        <name>1</name>
       </visual>
       <pose>0 0 0.65 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="2">
       <collision name="2">
@@ -28,7 +25,6 @@
             <size>0.18 0.98 0.3</size>
           </box>
         </geometry>
-        <name>2</name>
       </collision>
       <visual name="2">
         <geometry>
@@ -36,10 +32,8 @@
             <size>0.18 0.98 0.3</size>
           </box>
         </geometry>
-        <name>2</name>
       </visual>
       <pose>-0.2 0 0.85 0 0 0</pose>
-      <name>2</name>
     </link>
     <link name="3">
       <collision name="3">
@@ -48,7 +42,6 @@
             <size>0.1 0.1 0.6</size>
           </box>
         </geometry>
-        <name>3</name>
       </collision>
       <visual name="3">
         <geometry>
@@ -56,10 +49,8 @@
             <size>0.1 0.1 0.6</size>
           </box>
         </geometry>
-        <name>3</name>
       </visual>
       <pose>-0.24 -0.44 0.3 0 0 0</pose>
-      <name>3</name>
     </link>
     <link name="4">
       <collision name="4">
@@ -68,7 +59,6 @@
             <size>0.1 0.1 0.6</size>
           </box>
         </geometry>
-        <name>4</name>
       </collision>
       <visual name="4">
         <geometry>
@@ -76,10 +66,8 @@
             <size>0.1 0.1 0.6</size>
           </box>
         </geometry>
-        <name>4</name>
       </visual>
       <pose>0.24 -0.44 0.3 0 0 0</pose>
-      <name>4</name>
     </link>
     <link name="5">
       <collision name="5">
@@ -88,7 +76,6 @@
             <size>0.05 0.05 0.6</size>
           </box>
         </geometry>
-        <name>5</name>
       </collision>
       <visual name="5">
         <geometry>
@@ -96,10 +83,8 @@
             <size>0.05 0.05 0.6</size>
           </box>
         </geometry>
-        <name>5</name>
       </visual>
       <pose>-0.265 0.465 0.3 0 0 0</pose>
-      <name>5</name>
     </link>
     <link name="6">
       <collision name="6">
@@ -108,7 +93,6 @@
             <size>0.05 0.05 0.6</size>
           </box>
         </geometry>
-        <name>6</name>
       </collision>
       <visual name="6">
         <geometry>
@@ -116,10 +100,8 @@
             <size>0.05 0.05 0.6</size>
           </box>
         </geometry>
-        <name>6</name>
       </visual>
       <pose>0.265 0.465 0.3 0 0 0</pose>
-      <name>6</name>
     </link>
     <link name="on_top_of">
       <virtual_volume name="on_top_of">
@@ -129,9 +111,7 @@
           </box>
         </geometry>
         <pose>0.09 0.0 0.845 0 0 0</pose>
-        <name>on_top_of</name>
       </virtual_volume>
-      <name>on_top_of</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
@@ -141,11 +121,8 @@
           </box>
         </geometry>
         <pose>0.79 0.0 0.005 0 0 0</pose>
-        <name>in_front_of</name>
       </virtual_volume>
-      <name>in_front_of</name>
     </link>
     <static>true</static>
-    <name>rwc2017/desk_little</name>
   </model>
 </sdf>

--- a/models/rwc2017/foot_stool/model.sdf
+++ b/models/rwc2017/foot_stool/model.sdf
@@ -8,7 +8,6 @@
             <size>0.8 0.76 0.33</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -16,10 +15,8 @@
             <size>0.8 0.76 0.33</size>
           </box>
         </geometry>
-        <name>1</name>
       </visual>
       <pose>0 0 0.165 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="on_top_of">
       <virtual_volume name="on_top_of">
@@ -29,9 +26,7 @@
           </box>
         </geometry>
         <pose>0.0 0.0 0.475 0 0 0</pose>
-        <name>on_top_of</name>
       </virtual_volume>
-      <name>on_top_of</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
@@ -41,11 +36,8 @@
           </box>
         </geometry>
         <pose>0.0 0.9 0.005 0 0 0</pose>
-        <name>in_front_of</name>
       </virtual_volume>
-      <name>in_front_of</name>
     </link>
     <static>true</static>
-    <name>rwc2017/foot_stool</name>
   </model>
 </sdf>

--- a/models/rwc2017/fridge/model.sdf
+++ b/models/rwc2017/fridge/model.sdf
@@ -8,7 +8,6 @@
             <size>0.6 0.51 1.28</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -16,10 +15,8 @@
             <size>0.6 0.51 1.28</size>
           </box>
         </geometry>
-        <name>1</name>
       </visual>
       <pose>0.0 0.0 0.64 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="on_top_of">
       <virtual_volume name="on_top_of">
@@ -29,9 +26,7 @@
           </box>
         </geometry>
         <pose>0.0 0.0 1.525 0 0 0</pose>
-        <name>on_top_of</name>
       </virtual_volume>
-      <name>on_top_of</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
@@ -41,11 +36,8 @@
           </box>
         </geometry>
         <pose>0.65 0.0 0.005 0 0 0</pose>
-        <name>in_front_of</name>
       </virtual_volume>
-      <name>in_front_of</name>
     </link>
     <static>true</static>
-    <name>rwc2017/fridge</name>
   </model>
 </sdf>

--- a/models/rwc2017/kitchencounter/model.sdf
+++ b/models/rwc2017/kitchencounter/model.sdf
@@ -8,7 +8,6 @@
             <size>0.65 2.11 0.85</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -16,10 +15,8 @@
             <size>0.65 2.11 0.85</size>
           </box>
         </geometry>
-        <name>1</name>
       </visual>
       <pose>0.0 0.0 0.425 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="on_top_of">
       <virtual_volume name="on_top_of">
@@ -29,9 +26,7 @@
           </box>
         </geometry>
         <pose>0.005 0.06 1.04 0 0 0</pose>
-        <name>on_top_of</name>
       </virtual_volume>
-      <name>on_top_of</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
@@ -41,11 +36,8 @@
           </box>
         </geometry>
         <pose>0.7 0.0 0.005 0 0 0</pose>
-        <name>in_front_of</name>
       </virtual_volume>
-      <name>in_front_of</name>
     </link>
     <static>true</static>
-    <name>rwc2017/kitchencounter</name>
   </model>
 </sdf>

--- a/models/rwc2017/model.sdf
+++ b/models/rwc2017/model.sdf
@@ -4,7 +4,6 @@
     <light name="sun" type="directional">
       <direction>0.5 0.1 -0.9</direction>
       <pose>0 0 10 0 0 0</pose>
-      <name>sun</name>
       <specular>0.2 0.2 0.2 1</specular>
       <cast_shadows>true</cast_shadows>
       <diffuse>0.8 0.8 0.8 1</diffuse>
@@ -18,87 +17,70 @@
     <model name="initial_pose" type="waypoint">
       <pose>9.3 -7.3 0 0 0 2.35619449019</pose>
       <static>true</static>
-      <name>initial_pose</name>
     </model>
     <model name="exit" type="waypoint">
       <pose>0.0 1.0 0 0 0 1.57079632679</pose>
       <static>true</static>
-      <name>exit</name>
     </model>
     <model name="initial_pose_exit" type="waypoint">
       <pose>0.0 1.0 0.0 0 0 -1.570796</pose>
       <static>true</static>
-      <name>initial_pose_exit</name>
     </model>
     <model name="registration_table1" type="waypoint">
       <pose>4.16 -5.61 0 0 0 3.1415</pose>
       <static>true</static>
-      <name>registration_table1</name>
     </model>
     <model name="registration_table2" type="waypoint">
       <pose>6.12 -5.79 0 0 0 3.1415</pose>
       <static>true</static>
-      <name>registration_table2</name>
     </model>
     <model name="registration_table3" type="waypoint">
       <pose>2.55 -5.65 0 0 0 3.1415</pose>
       <static>true</static>
-      <name>registration_table3</name>
     </model>
     <model name="exit_1_rips" type="waypoint">
       <pose>0.0 1.0 0 0 0 1.5708</pose>
       <static>true</static>
-      <name>exit_1_rips</name>
     </model>
     <model name="exit_2_rips" type="waypoint">
       <pose>0.0 2.0 0 0 0 1.5708</pose>
       <static>true</static>
-      <name>exit_2_rips</name>
     </model>
     <model name="exit_3_rips" type="waypoint">
       <pose>0.0 -1.0 0 0 0 1.5708</pose>
       <static>true</static>
-      <name>exit_3_rips</name>
     </model>
     <model name="exit_4_rips" type="waypoint">
       <pose>0.0 -2.0 0 0 0 1.5708</pose>
       <static>true</static>
-      <name>exit_4_rips</name>
     </model>
     <model name="help_me_carry_start" type="waypoint">
       <pose>3.5 -5.6 0 0 0 0</pose>
       <static>true</static>
-      <name>help_me_carry_start</name>
     </model>
     <model name="gpsr_meeting_point" type="waypoint">
       <pose>-2.0 -1.4 0 0 0 0.0</pose>
       <static>true</static>
-      <name>gpsr_meeting_point</name>
     </model>
     <model name="gpsr_exit_door" type="waypoint">
       <pose>0.0 1.0 0 0 0 1.57079632679</pose>
       <static>true</static>
-      <name>gpsr_exit_door</name>
     </model>
     <model name="ssl_demo_waypoint" type="waypoint">
       <pose>0.0 -3.0 0 0 0 -1.5708</pose>
       <static>true</static>
-      <name>ssl_demo_waypoint</name>
     </model>
     <model name="laser_demo_waypoint" type="waypoint">
       <pose>2.0 -5.6 0 0 0 3.1415</pose>
       <static>true</static>
-      <name>laser_demo_waypoint</name>
     </model>
     <model name="order_counter_waypoint" type="waypoint">
       <pose>0.0 -6.0 0 0 0 -1.5708</pose>
       <static>true</static>
-      <name>order_counter_waypoint</name>
     </model>
     <model name="hsr_demo_waypoint" type="waypoint">
       <pose>4.278 -4.2286 0 0 0 -0.6158</pose>
       <static>true</static>
-      <name>hsr_demo_waypoint</name>
     </model>
     <model name="entrance" type="room">
       <link name="in">
@@ -109,13 +91,10 @@
             </box>
           </geometry>
           <pose>0.15 -0.15 0.005 0 0 0</pose>
-          <name>in</name>
         </virtual_volume>
-        <name>in</name>
       </link>
       <pose>7.8 -7.1 0 0 0 0</pose>
       <static>true</static>
-      <name>entrance</name>
     </model>
     <model name="living_room" type="room">
       <link name="in">
@@ -126,13 +105,10 @@
             </box>
           </geometry>
           <pose>-0.2 0.225 0.005 0 0 0</pose>
-          <name>in</name>
         </virtual_volume>
-        <name>in</name>
       </link>
       <pose>0.0 -2.8 0 0 0 0</pose>
       <static>true</static>
-      <name>living_room</name>
     </model>
     <model name="exit_area" type="room">
       <link name="in">
@@ -143,13 +119,10 @@
             </box>
           </geometry>
           <pose>0.0 0.0 0.005 0 0 0</pose>
-          <name>in</name>
         </virtual_volume>
-        <name>in</name>
       </link>
       <pose>0.0 -0.4 0 0 0 0</pose>
       <static>true</static>
-      <name>exit_area</name>
     </model>
     <model name="corridor" type="room">
       <link name="in">
@@ -160,13 +133,10 @@
             </box>
           </geometry>
           <pose>-0.45 0.025 0.005 0 0 0</pose>
-          <name>in</name>
         </virtual_volume>
-        <name>in</name>
       </link>
       <pose>6.5 -5.7 0 0 0 0</pose>
       <static>true</static>
-      <name>corridor</name>
     </model>
     <model name="bedroom" type="room">
       <link name="in">
@@ -177,13 +147,10 @@
             </box>
           </geometry>
           <pose>0.725 0.05 0.005 0 0 0</pose>
-          <name>in</name>
         </virtual_volume>
-        <name>in</name>
       </link>
       <pose>7.5 -2.5 0 0 0 0</pose>
       <static>true</static>
-      <name>bedroom</name>
     </model>
     <model name="kitchen" type="room">
       <link name="in">
@@ -194,13 +161,10 @@
             </box>
           </geometry>
           <pose>0.25 -0.825 0.005 0 0 0</pose>
-          <name>in</name>
         </virtual_volume>
-        <name>in</name>
       </link>
       <pose>4.0 -1.5 0 0 0 0</pose>
       <static>true</static>
-      <name>kitchen</name>
     </model>
     <model name="balcony" type="room">
       <link name="in">
@@ -211,170 +175,167 @@
             </box>
           </geometry>
           <pose>0.275 -0.85 0.005 0 0 0</pose>
-          <name>in</name>
         </virtual_volume>
-        <name>in</name>
       </link>
       <pose>-1.0 -7.2 0 0 0 0</pose>
       <static>true</static>
-      <name>balcony</name>
     </model>
-    <include name="walls">
+    <include>
       <pose>0 0 0 0 0 0</pose>
       <name>walls</name>
       <uri>model://rwc2017/walls</uri>
     </include>
-    <include name="floor">
+    <include>
       <pose>0 0 0 0 0 0</pose>
       <name>floor</name>
       <uri>model://floor</uri>
     </include>
-    <include name="wall_270">
+    <include>
       <pose>5.075 -4.93 0.0 0 0 0.0</pose>
       <name>wall_270</name>
       <uri>model://rwc2017/wall_270</uri>
     </include>
-    <include name="wall_240">
+    <include>
       <pose>2.15 -3.8 0.0 0 0 1.7</pose>
       <name>wall_240</name>
       <uri>model://rwc2017/wall_240</uri>
     </include>
-    <include name="wall_180">
+    <include>
       <pose>8.9 -4.93 0.0 0 0 0.0</pose>
       <name>wall_180</name>
       <uri>model://rwc2017/wall_180</uri>
     </include>
-    <include name="bed">
+    <include>
       <pose>9.26 -3.86 0.0 0 0 3.14159265359</pose>
       <name>bed</name>
       <uri>model://rwc2017/bed</uri>
     </include>
-    <include name="kitchen_counter">
+    <include>
       <pose>6.1 -3.6 0.0 0 0 3.14159265359</pose>
       <name>kitchen_counter</name>
       <uri>model://rwc2017/kitchencounter</uri>
     </include>
-    <include name="fridge">
+    <include>
       <pose>6.125 -2.175 0.0 0 0 3.14159265359</pose>
       <name>fridge</name>
       <uri>model://rwc2017/fridge</uri>
     </include>
-    <include name="entrance_shelf">
+    <include>
       <pose>6.655 -7.21 0.0 0 0 0.0</pose>
       <name>entrance_shelf</name>
       <uri>model://rwc2017/cabinet_black</uri>
     </include>
-    <include name="bookcase">
+    <include>
       <pose>1.92 -4.1 0.0 0 0 3.27079632679</pose>
       <name>bookcase</name>
       <uri>model://rwc2017/cabinet_showcase</uri>
     </include>
-    <include name="left_rack">
+    <include>
       <pose>-2.22 -0.18 0.0 0 0 -1.57079632679</pose>
       <name>left_rack</name>
       <uri>model://rwc2017/rack_left</uri>
     </include>
-    <include name="middle_rack">
+    <include>
       <pose>-1.545 -0.18 0.0 0 0 -1.57079632679</pose>
       <name>middle_rack</name>
       <uri>model://rwc2017/rack_middle</uri>
     </include>
-    <include name="right_rack">
+    <include>
       <pose>-0.87 -0.18 0.0 0 0 -1.57079632679</pose>
       <name>right_rack</name>
       <uri>model://rwc2017/rack_right</uri>
     </include>
-    <include name="bistro_table">
+    <include>
       <pose>1.1 -9.33 0.0 0 0 1.57079632679</pose>
       <name>bistro_table</name>
       <uri>model://rwc2017/table_balcony</uri>
     </include>
-    <include name="kitchen_table">
+    <include>
       <pose>4.16 -2.86 0.0 0 0 1.57079632679</pose>
       <name>kitchen_table</name>
       <uri>model://rwc2017/table_dinner</uri>
     </include>
-    <include name="sideboard">
+    <include>
       <pose>2.31 -0.255 0.0 0 0 -1.57079632679</pose>
       <name>sideboard</name>
       <uri>model://rwc2017/cabinet_brown_low</uri>
     </include>
-    <include name="sideboard_high">
+    <include>
       <pose>3.51 -0.255 0.0 0 0 -1.57079632679</pose>
       <name>sideboard_high</name>
       <uri>model://rwc2017/cabinet_brown_high</uri>
     </include>
-    <include name="tv_stand">
+    <include>
       <pose>-2.255 -5.02 0.0 0 0 0.0</pose>
       <name>tv_stand</name>
       <uri>model://rwc2017/tv_stand</uri>
     </include>
-    <include name="tv">
+    <include>
       <pose>-1.85 -5.1 0.45 0 0 -1.0</pose>
       <name>tv</name>
       <uri>model://rwc2017/tv</uri>
     </include>
-    <include name="desk">
+    <include>
       <pose>-2.15 -2.575 0.0 0 0 0.0</pose>
       <name>desk</name>
       <uri>model://rwc2017/desk</uri>
     </include>
-    <include name="kitchen_shelf">
+    <include>
       <pose>2.39 -4.125 0.0 0 0 0.1292036732</pose>
       <name>kitchen_shelf</name>
       <uri>model://rwc2017/cabinet_kitchen</uri>
     </include>
-    <include name="coffee_table">
+    <include>
       <pose>-1.55 -5.1 0.0 0 0 -1.57079632679</pose>
       <name>coffee_table</name>
       <uri>model://rwc2017/table_salon</uri>
     </include>
-    <include name="sofa">
+    <include>
       <pose>-0.85 -9.85 0.0 0 0 1.57079632679</pose>
       <name>sofa</name>
       <uri>model://rwc2017/sofa</uri>
     </include>
-    <include name="foot_stool">
+    <include>
       <pose>-2.0 -9.5 0.0 0 0 0.0</pose>
       <name>foot_stool</name>
       <uri>model://rwc2017/foot_stool</uri>
     </include>
-    <include name="kitchen_rack">
+    <include>
       <pose>2.29 -3.12 0.0 0 0 0.1292036732</pose>
       <name>kitchen_rack</name>
       <uri>model://rwc2017/shelf_black</uri>
     </include>
-    <include name="balcony_shelf">
+    <include>
       <pose>-2.27 -8.055 0.0 0 0 0.0</pose>
       <name>balcony_shelf</name>
       <uri>model://rwc2017/shelf_black</uri>
     </include>
-    <include name="teepee">
+    <include>
       <pose>8.85 -1.0 0.0 0 0 -1.75</pose>
       <name>teepee</name>
       <uri>model://rwc2017/teepee</uri>
     </include>
-    <include name="carpet">
+    <include>
       <pose>8.85 -1.0 0.0 0 0 0.0</pose>
       <name>carpet</name>
       <uri>model://rwc2017/carpet</uri>
     </include>
-    <include name="umbrella_holder">
+    <include>
       <pose>6.9 -8.6 0.0 0 0 0.78539816339</pose>
       <name>umbrella_holder</name>
       <uri>model://rwc2017/umbrella_holder</uri>
     </include>
-    <include name="left_planks">
+    <include>
       <pose>2.285 -7.4 0.0 0 0 3.14159265359</pose>
       <name>left_planks</name>
       <uri>model://rwc2017/shelf_light</uri>
     </include>
-    <include name="right_planks">
+    <include>
       <pose>1.96 -8.66 0.0 0 0 2.35619449019</pose>
       <name>right_planks</name>
       <uri>model://rwc2017/shelf_light</uri>
     </include>
-    <include name="little_desk">
+    <include>
       <pose>7.35 -0.34 0.0 0 0 -1.57079632679</pose>
       <name>little_desk</name>
       <uri>model://rwc2017/desk_little</uri>
@@ -391,6 +352,5 @@
         </solver>
       </ode>
     </physics>
-    <name>rwc2017</name>
   </world>
 </sdf>

--- a/models/rwc2017/rack_left/model.sdf
+++ b/models/rwc2017/rack_left/model.sdf
@@ -8,7 +8,6 @@
             <size>0.29 0.01 0.9</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -16,10 +15,8 @@
             <size>0.29 0.01 0.9</size>
           </box>
         </geometry>
-        <name>1</name>
       </visual>
       <pose>0 -0.22 0.45 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="2">
       <collision name="2">
@@ -28,7 +25,6 @@
             <size>0.29 0.01 0.9</size>
           </box>
         </geometry>
-        <name>2</name>
       </collision>
       <visual name="2">
         <geometry>
@@ -36,10 +32,8 @@
             <size>0.29 0.01 0.9</size>
           </box>
         </geometry>
-        <name>2</name>
       </visual>
       <pose>0 0.22 0.45 0 0 0</pose>
-      <name>2</name>
     </link>
     <link name="3">
       <collision name="3">
@@ -48,7 +42,6 @@
             <size>0.01 0.45 0.9</size>
           </box>
         </geometry>
-        <name>3</name>
       </collision>
       <visual name="3">
         <geometry>
@@ -56,10 +49,8 @@
             <size>0.01 0.45 0.9</size>
           </box>
         </geometry>
-        <name>3</name>
       </visual>
       <pose>-0.14 0 0.45 0 0 0</pose>
-      <name>3</name>
     </link>
     <link name="4">
       <collision name="4">
@@ -68,7 +59,6 @@
             <size>0.28 0.43 0.01</size>
           </box>
         </geometry>
-        <name>4</name>
       </collision>
       <visual name="4">
         <geometry>
@@ -76,10 +66,8 @@
             <size>0.28 0.43 0.01</size>
           </box>
         </geometry>
-        <name>4</name>
       </visual>
       <pose>0.005 0 0.895 0 0 0</pose>
-      <name>4</name>
     </link>
     <link name="5">
       <collision name="5">
@@ -88,7 +76,6 @@
             <size>0.28 0.43 0.01</size>
           </box>
         </geometry>
-        <name>5</name>
       </collision>
       <visual name="5">
         <geometry>
@@ -96,10 +83,8 @@
             <size>0.28 0.43 0.01</size>
           </box>
         </geometry>
-        <name>5</name>
       </visual>
       <pose>0.005 0 0.005 0 0 0</pose>
-      <name>5</name>
     </link>
     <link name="6">
       <collision name="6">
@@ -108,7 +93,6 @@
             <size>0.28 0.43 0.01</size>
           </box>
         </geometry>
-        <name>6</name>
       </collision>
       <visual name="6">
         <geometry>
@@ -116,10 +100,8 @@
             <size>0.28 0.43 0.01</size>
           </box>
         </geometry>
-        <name>6</name>
       </visual>
       <pose>0.005 0 0.3 0 0 0</pose>
-      <name>6</name>
     </link>
     <link name="7">
       <collision name="7">
@@ -128,7 +110,6 @@
             <size>0.28 0.43 0.01</size>
           </box>
         </geometry>
-        <name>7</name>
       </collision>
       <visual name="7">
         <geometry>
@@ -136,10 +117,8 @@
             <size>0.28 0.43 0.01</size>
           </box>
         </geometry>
-        <name>7</name>
       </visual>
       <pose>0.005 0 0.595 0 0 0</pose>
-      <name>7</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
@@ -149,9 +128,7 @@
           </box>
         </geometry>
         <pose>0.7 0.1375 0.005 0 0 0</pose>
-        <name>in_front_of</name>
       </virtual_volume>
-      <name>in_front_of</name>
     </link>
     <link name="on_top_of">
       <virtual_volume name="on_top_of">
@@ -161,9 +138,7 @@
           </box>
         </geometry>
         <pose>0.005 0.2325 1.1125 0 0 0</pose>
-        <name>on_top_of</name>
       </virtual_volume>
-      <name>on_top_of</name>
     </link>
     <link name="shelf1">
       <virtual_volume name="shelf1">
@@ -173,9 +148,7 @@
           </box>
         </geometry>
         <pose>0.005 0.0 0.155 0 0 0</pose>
-        <name>shelf1</name>
       </virtual_volume>
-      <name>shelf1</name>
     </link>
     <link name="shelf2">
       <virtual_volume name="shelf2">
@@ -185,9 +158,7 @@
           </box>
         </geometry>
         <pose>0.005 0.0 0.45 0 0 0</pose>
-        <name>shelf2</name>
       </virtual_volume>
-      <name>shelf2</name>
     </link>
     <link name="shelf3">
       <virtual_volume name="shelf3">
@@ -197,11 +168,8 @@
           </box>
         </geometry>
         <pose>0.005 0.0 0.745 0 0 0</pose>
-        <name>shelf3</name>
       </virtual_volume>
-      <name>shelf3</name>
     </link>
     <static>true</static>
-    <name>rwc2017/rack_left</name>
   </model>
 </sdf>

--- a/models/rwc2017/rack_middle/model.sdf
+++ b/models/rwc2017/rack_middle/model.sdf
@@ -4,7 +4,6 @@
     <light name="sun" type="directional">
       <direction>0.5 0.1 -0.9</direction>
       <pose>0 0 10 0 0 0</pose>
-      <name>sun</name>
       <specular>0.2 0.2 0.2 1</specular>
       <cast_shadows>true</cast_shadows>
       <diffuse>0.8 0.8 0.8 1</diffuse>
@@ -15,12 +14,12 @@
         <linear>0.01</linear>
       </attenuation>
     </light>
-    <include name="lower_part">
+    <include>
       <pose>0 -0.45 0.225 -1.57079632679 0 0</pose>
       <name>lower_part</name>
       <uri>model://rwc2017/cabinet_simple_no_areas</uri>
     </include>
-    <include name="top_part">
+    <include>
       <pose>0 -0.45 0.675 -1.57079632679 0 0</pose>
       <name>top_part</name>
       <uri>model://rwc2017/cabinet_simple_no_areas</uri>
@@ -37,6 +36,5 @@
         </solver>
       </ode>
     </physics>
-    <name>rwc2017/rack_middle</name>
   </world>
 </sdf>

--- a/models/rwc2017/rack_right/model.sdf
+++ b/models/rwc2017/rack_right/model.sdf
@@ -8,7 +8,6 @@
             <size>0.29 0.01 0.9</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -16,10 +15,8 @@
             <size>0.29 0.01 0.9</size>
           </box>
         </geometry>
-        <name>1</name>
       </visual>
       <pose>0 -0.22 0.45 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="2">
       <collision name="2">
@@ -28,7 +25,6 @@
             <size>0.29 0.01 0.9</size>
           </box>
         </geometry>
-        <name>2</name>
       </collision>
       <visual name="2">
         <geometry>
@@ -36,10 +32,8 @@
             <size>0.29 0.01 0.9</size>
           </box>
         </geometry>
-        <name>2</name>
       </visual>
       <pose>0 0.22 0.45 0 0 0</pose>
-      <name>2</name>
     </link>
     <link name="3">
       <collision name="3">
@@ -48,7 +42,6 @@
             <size>0.01 0.45 0.9</size>
           </box>
         </geometry>
-        <name>3</name>
       </collision>
       <visual name="3">
         <geometry>
@@ -56,10 +49,8 @@
             <size>0.01 0.45 0.9</size>
           </box>
         </geometry>
-        <name>3</name>
       </visual>
       <pose>-0.14 0 0.45 0 0 0</pose>
-      <name>3</name>
     </link>
     <link name="4">
       <collision name="4">
@@ -68,7 +59,6 @@
             <size>0.28 0.43 0.01</size>
           </box>
         </geometry>
-        <name>4</name>
       </collision>
       <visual name="4">
         <geometry>
@@ -76,10 +66,8 @@
             <size>0.28 0.43 0.01</size>
           </box>
         </geometry>
-        <name>4</name>
       </visual>
       <pose>0.005 0 0.895 0 0 0</pose>
-      <name>4</name>
     </link>
     <link name="5">
       <collision name="5">
@@ -88,7 +76,6 @@
             <size>0.28 0.43 0.01</size>
           </box>
         </geometry>
-        <name>5</name>
       </collision>
       <visual name="5">
         <geometry>
@@ -96,10 +83,8 @@
             <size>0.28 0.43 0.01</size>
           </box>
         </geometry>
-        <name>5</name>
       </visual>
       <pose>0.005 0 0.005 0 0 0</pose>
-      <name>5</name>
     </link>
     <link name="6">
       <collision name="6">
@@ -108,7 +93,6 @@
             <size>0.28 0.43 0.01</size>
           </box>
         </geometry>
-        <name>6</name>
       </collision>
       <visual name="6">
         <geometry>
@@ -116,10 +100,8 @@
             <size>0.28 0.43 0.01</size>
           </box>
         </geometry>
-        <name>6</name>
       </visual>
       <pose>0.005 0 0.3 0 0 0</pose>
-      <name>6</name>
     </link>
     <link name="7">
       <collision name="7">
@@ -128,7 +110,6 @@
             <size>0.28 0.43 0.01</size>
           </box>
         </geometry>
-        <name>7</name>
       </collision>
       <visual name="7">
         <geometry>
@@ -136,10 +117,8 @@
             <size>0.28 0.43 0.01</size>
           </box>
         </geometry>
-        <name>7</name>
       </visual>
       <pose>0.005 0 0.595 0 0 0</pose>
-      <name>7</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
@@ -149,9 +128,7 @@
           </box>
         </geometry>
         <pose>0.7 -0.1375 0.005 0 0 0</pose>
-        <name>in_front_of</name>
       </virtual_volume>
-      <name>in_front_of</name>
     </link>
     <link name="on_top_of">
       <virtual_volume name="on_top_of">
@@ -161,9 +138,7 @@
           </box>
         </geometry>
         <pose>0.005 -0.2325 1.1125 0 0 0</pose>
-        <name>on_top_of</name>
       </virtual_volume>
-      <name>on_top_of</name>
     </link>
     <link name="shelf1">
       <virtual_volume name="shelf1">
@@ -173,9 +148,7 @@
           </box>
         </geometry>
         <pose>0.005 0.0 0.155 0 0 0</pose>
-        <name>shelf1</name>
       </virtual_volume>
-      <name>shelf1</name>
     </link>
     <link name="shelf2">
       <virtual_volume name="shelf2">
@@ -185,9 +158,7 @@
           </box>
         </geometry>
         <pose>0.005 0.0 0.45 0 0 0</pose>
-        <name>shelf2</name>
       </virtual_volume>
-      <name>shelf2</name>
     </link>
     <link name="shelf3">
       <virtual_volume name="shelf3">
@@ -197,11 +168,8 @@
           </box>
         </geometry>
         <pose>0.005 0.0 0.745 0 0 0</pose>
-        <name>shelf3</name>
       </virtual_volume>
-      <name>shelf3</name>
     </link>
     <static>true</static>
-    <name>rwc2017/rack_right</name>
   </model>
 </sdf>

--- a/models/rwc2017/shelf_black/model.sdf
+++ b/models/rwc2017/shelf_black/model.sdf
@@ -8,7 +8,6 @@
             <size>0.01 0.59 1.4</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -16,10 +15,8 @@
             <size>0.01 0.59 1.4</size>
           </box>
         </geometry>
-        <name>1</name>
       </visual>
       <pose>-0.165 0.0 0.7 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="2">
       <collision name="2">
@@ -28,7 +25,6 @@
             <size>0.34 0.02 1.4</size>
           </box>
         </geometry>
-        <name>2</name>
       </collision>
       <visual name="2">
         <geometry>
@@ -36,10 +32,8 @@
             <size>0.34 0.02 1.4</size>
           </box>
         </geometry>
-        <name>2</name>
       </visual>
       <pose>0 -0.285 0.7 0 0 0</pose>
-      <name>2</name>
     </link>
     <link name="3">
       <collision name="3">
@@ -48,7 +42,6 @@
             <size>0.34 0.02 1.4</size>
           </box>
         </geometry>
-        <name>3</name>
       </collision>
       <visual name="3">
         <geometry>
@@ -56,10 +49,8 @@
             <size>0.34 0.02 1.4</size>
           </box>
         </geometry>
-        <name>3</name>
       </visual>
       <pose>0 0.285 0.7 0 0 0</pose>
-      <name>3</name>
     </link>
     <link name="4">
       <collision name="4">
@@ -68,7 +59,6 @@
             <size>0.34 0.55 0.04</size>
           </box>
         </geometry>
-        <name>4</name>
       </collision>
       <visual name="4">
         <geometry>
@@ -76,10 +66,8 @@
             <size>0.34 0.55 0.04</size>
           </box>
         </geometry>
-        <name>4</name>
       </visual>
       <pose>0 0 0.145 0 0 0</pose>
-      <name>4</name>
     </link>
     <link name="5">
       <collision name="5">
@@ -88,7 +76,6 @@
             <size>0.34 0.55 0.04</size>
           </box>
         </geometry>
-        <name>5</name>
       </collision>
       <visual name="5">
         <geometry>
@@ -96,10 +83,8 @@
             <size>0.34 0.55 0.04</size>
           </box>
         </geometry>
-        <name>5</name>
       </visual>
       <pose>0 0 0.53 0 0 0</pose>
-      <name>5</name>
     </link>
     <link name="6">
       <collision name="6">
@@ -108,7 +93,6 @@
             <size>0.34 0.55 0.04</size>
           </box>
         </geometry>
-        <name>6</name>
       </collision>
       <visual name="6">
         <geometry>
@@ -116,10 +100,8 @@
             <size>0.34 0.55 0.04</size>
           </box>
         </geometry>
-        <name>6</name>
       </visual>
       <pose>0 0 0.92 0 0 0</pose>
-      <name>6</name>
     </link>
     <link name="7">
       <collision name="7">
@@ -128,7 +110,6 @@
             <size>0.34 0.55 0.04</size>
           </box>
         </geometry>
-        <name>7</name>
       </collision>
       <visual name="7">
         <geometry>
@@ -136,10 +117,8 @@
             <size>0.34 0.55 0.04</size>
           </box>
         </geometry>
-        <name>7</name>
       </visual>
       <pose>0 0 1.3 0 0 0</pose>
-      <name>7</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
@@ -149,9 +128,7 @@
           </box>
         </geometry>
         <pose>0.67 0.0 0.005 0 0 0</pose>
-        <name>in_front_of</name>
       </virtual_volume>
-      <name>in_front_of</name>
     </link>
     <link name="shelf1">
       <virtual_volume name="shelf1">
@@ -161,9 +138,7 @@
           </box>
         </geometry>
         <pose>0.01 0.0 0.31 0 0 0</pose>
-        <name>shelf1</name>
       </virtual_volume>
-      <name>shelf1</name>
     </link>
     <link name="shelf2">
       <virtual_volume name="shelf2">
@@ -173,9 +148,7 @@
           </box>
         </geometry>
         <pose>0.01 0.0 0.695 0 0 0</pose>
-        <name>shelf2</name>
       </virtual_volume>
-      <name>shelf2</name>
     </link>
     <link name="shelf3">
       <virtual_volume name="shelf3">
@@ -185,9 +158,7 @@
           </box>
         </geometry>
         <pose>0.01 0.0 1.085 0 0 0</pose>
-        <name>shelf3</name>
       </virtual_volume>
-      <name>shelf3</name>
     </link>
     <link name="shelf4">
       <virtual_volume name="shelf4">
@@ -197,11 +168,8 @@
           </box>
         </geometry>
         <pose>0.01 0.0 1.445 0 0 0</pose>
-        <name>shelf4</name>
       </virtual_volume>
-      <name>shelf4</name>
     </link>
     <static>true</static>
-    <name>rwc2017/shelf_black</name>
   </model>
 </sdf>

--- a/models/rwc2017/shelf_light/model.sdf
+++ b/models/rwc2017/shelf_light/model.sdf
@@ -8,7 +8,6 @@
             <size>0.01 1.0 0.66</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -16,10 +15,8 @@
             <size>0.01 1.0 0.66</size>
           </box>
         </geometry>
-        <name>1</name>
       </visual>
       <pose>-0.145 0.0 0.33 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="2">
       <collision name="2">
@@ -28,7 +25,6 @@
             <size>0.28 1.0 0.03</size>
           </box>
         </geometry>
-        <name>2</name>
       </collision>
       <visual name="2">
         <geometry>
@@ -36,10 +32,8 @@
             <size>0.28 1.0 0.03</size>
           </box>
         </geometry>
-        <name>2</name>
       </visual>
       <pose>0.0 0 0.105 0 0 0</pose>
-      <name>2</name>
     </link>
     <link name="3">
       <collision name="3">
@@ -48,7 +42,6 @@
             <size>0.28 1.0 0.03</size>
           </box>
         </geometry>
-        <name>3</name>
       </collision>
       <visual name="3">
         <geometry>
@@ -56,10 +49,8 @@
             <size>0.28 1.0 0.03</size>
           </box>
         </geometry>
-        <name>3</name>
       </visual>
       <pose>0.0 0 0.475 0 0 0</pose>
-      <name>3</name>
     </link>
     <link name="4">
       <collision name="4">
@@ -68,7 +59,6 @@
             <size>0.025 0.025 0.66</size>
           </box>
         </geometry>
-        <name>4</name>
       </collision>
       <visual name="4">
         <geometry>
@@ -76,10 +66,8 @@
             <size>0.025 0.025 0.66</size>
           </box>
         </geometry>
-        <name>4</name>
       </visual>
       <pose>-0.1525 -0.3475 0.33 0 0 0</pose>
-      <name>4</name>
     </link>
     <link name="5">
       <collision name="5">
@@ -88,7 +76,6 @@
             <size>0.025 0.025 0.66</size>
           </box>
         </geometry>
-        <name>5</name>
       </collision>
       <visual name="5">
         <geometry>
@@ -96,10 +83,8 @@
             <size>0.025 0.025 0.66</size>
           </box>
         </geometry>
-        <name>5</name>
       </visual>
       <pose>0.1525 -0.3475 0.33 0 0 0</pose>
-      <name>5</name>
     </link>
     <link name="6">
       <collision name="6">
@@ -108,7 +93,6 @@
             <size>0.33 0.025 0.01</size>
           </box>
         </geometry>
-        <name>6</name>
       </collision>
       <visual name="6">
         <geometry>
@@ -116,10 +100,8 @@
             <size>0.33 0.025 0.01</size>
           </box>
         </geometry>
-        <name>6</name>
       </visual>
       <pose>0.0 -0.3475 0.005 0 0 0</pose>
-      <name>6</name>
     </link>
     <link name="7">
       <collision name="7">
@@ -128,7 +110,6 @@
             <size>0.33 0.025 0.01</size>
           </box>
         </geometry>
-        <name>7</name>
       </collision>
       <visual name="7">
         <geometry>
@@ -136,10 +117,8 @@
             <size>0.33 0.025 0.01</size>
           </box>
         </geometry>
-        <name>7</name>
       </visual>
       <pose>0.0 -0.3475 0.655 0 0 0</pose>
-      <name>7</name>
     </link>
     <link name="8">
       <collision name="8">
@@ -148,7 +127,6 @@
             <size>0.025 0.025 0.66</size>
           </box>
         </geometry>
-        <name>8</name>
       </collision>
       <visual name="8">
         <geometry>
@@ -156,10 +134,8 @@
             <size>0.025 0.025 0.66</size>
           </box>
         </geometry>
-        <name>8</name>
       </visual>
       <pose>-0.1525 0.3475 0.33 0 0 0</pose>
-      <name>8</name>
     </link>
     <link name="9">
       <collision name="9">
@@ -168,7 +144,6 @@
             <size>0.025 0.025 0.66</size>
           </box>
         </geometry>
-        <name>9</name>
       </collision>
       <visual name="9">
         <geometry>
@@ -176,10 +151,8 @@
             <size>0.025 0.025 0.66</size>
           </box>
         </geometry>
-        <name>9</name>
       </visual>
       <pose>0.1525 0.3475 0.33 0 0 0</pose>
-      <name>9</name>
     </link>
     <link name="10">
       <collision name="10">
@@ -188,7 +161,6 @@
             <size>0.33 0.025 0.01</size>
           </box>
         </geometry>
-        <name>10</name>
       </collision>
       <visual name="10">
         <geometry>
@@ -196,10 +168,8 @@
             <size>0.33 0.025 0.01</size>
           </box>
         </geometry>
-        <name>10</name>
       </visual>
       <pose>0.0 0.3475 0.005 0 0 0</pose>
-      <name>10</name>
     </link>
     <link name="11">
       <collision name="11">
@@ -208,7 +178,6 @@
             <size>0.33 0.025 0.01</size>
           </box>
         </geometry>
-        <name>11</name>
       </collision>
       <visual name="11">
         <geometry>
@@ -216,10 +185,8 @@
             <size>0.33 0.025 0.01</size>
           </box>
         </geometry>
-        <name>11</name>
       </visual>
       <pose>0.0 0.3475 0.655 0 0 0</pose>
-      <name>11</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
@@ -229,9 +196,7 @@
           </box>
         </geometry>
         <pose>0.665 0.0 0.005 0 0 0</pose>
-        <name>in_front_of</name>
       </virtual_volume>
-      <name>in_front_of</name>
     </link>
     <link name="on_top_of">
       <virtual_volume name="on_top_of">
@@ -241,11 +206,8 @@
           </box>
         </geometry>
         <pose>0.0 0.0 0.68 0 0 0</pose>
-        <name>on_top_of</name>
       </virtual_volume>
-      <name>on_top_of</name>
     </link>
     <static>true</static>
-    <name>rwc2017/shelf_light</name>
   </model>
 </sdf>

--- a/models/rwc2017/sofa/model.sdf
+++ b/models/rwc2017/sofa/model.sdf
@@ -8,7 +8,6 @@
             <size>0.88 1.45 0.33</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -16,10 +15,8 @@
             <size>0.88 1.45 0.33</size>
           </box>
         </geometry>
-        <name>1</name>
       </visual>
       <pose>0.44 0.0 0.165 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="2">
       <collision name="2">
@@ -28,7 +25,6 @@
             <size>1.55 0.76 0.33</size>
           </box>
         </geometry>
-        <name>2</name>
       </collision>
       <visual name="2">
         <geometry>
@@ -36,10 +32,8 @@
             <size>1.55 0.76 0.33</size>
           </box>
         </geometry>
-        <name>2</name>
       </visual>
       <pose>0.775 -1.105 0.165 0 0 0</pose>
-      <name>2</name>
     </link>
     <link name="3">
       <collision name="3">
@@ -48,7 +42,6 @@
             <size>0.35 2.21 0.37</size>
           </box>
         </geometry>
-        <name>3</name>
       </collision>
       <visual name="3">
         <geometry>
@@ -56,10 +49,8 @@
             <size>0.35 2.21 0.37</size>
           </box>
         </geometry>
-        <name>3</name>
       </visual>
       <pose>0.175 -0.38 0.515 0 0 0</pose>
-      <name>3</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
@@ -69,11 +60,8 @@
           </box>
         </geometry>
         <pose>1.25 -0.35 0.005 0 0 0</pose>
-        <name>in_front_of</name>
       </virtual_volume>
-      <name>in_front_of</name>
     </link>
     <static>true</static>
-    <name>rwc2017/sofa</name>
   </model>
 </sdf>

--- a/models/rwc2017/table_balcony/model.sdf
+++ b/models/rwc2017/table_balcony/model.sdf
@@ -9,7 +9,6 @@
             <radius>0.3</radius>
           </cylinder>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -18,10 +17,8 @@
             <radius>0.3</radius>
           </cylinder>
         </geometry>
-        <name>1</name>
       </visual>
       <pose>0 0 0.65 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
@@ -31,9 +28,7 @@
           </box>
         </geometry>
         <pose>0.7 0.0 0.005 0 0 0</pose>
-        <name>in_front_of</name>
       </virtual_volume>
-      <name>in_front_of</name>
     </link>
     <link name="on_top_of">
       <virtual_volume name="on_top_of">
@@ -43,11 +38,8 @@
           </box>
         </geometry>
         <pose>0.0 0.0 0.9125 0 0 0</pose>
-        <name>on_top_of</name>
       </virtual_volume>
-      <name>on_top_of</name>
     </link>
     <static>true</static>
-    <name>rwc2017/table_balcony</name>
   </model>
 </sdf>

--- a/models/rwc2017/table_dinner/model.sdf
+++ b/models/rwc2017/table_dinner/model.sdf
@@ -8,7 +8,6 @@
             <size>1.6 0.76 0.035</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -16,10 +15,8 @@
             <size>1.6 0.76 0.035</size>
           </box>
         </geometry>
-        <name>1</name>
       </visual>
       <pose>0 0 0.7825 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="2">
       <collision name="2">
@@ -28,7 +25,6 @@
             <size>0.025 0.025 0.765</size>
           </box>
         </geometry>
-        <name>2</name>
       </collision>
       <visual name="2">
         <geometry>
@@ -36,10 +32,8 @@
             <size>0.025 0.025 0.765</size>
           </box>
         </geometry>
-        <name>2</name>
       </visual>
       <pose>-0.7775 -0.3575 0.3825 0 0 0</pose>
-      <name>2</name>
     </link>
     <link name="3">
       <collision name="3">
@@ -48,7 +42,6 @@
             <size>0.025 0.025 0.765</size>
           </box>
         </geometry>
-        <name>3</name>
       </collision>
       <visual name="3">
         <geometry>
@@ -56,10 +49,8 @@
             <size>0.025 0.025 0.765</size>
           </box>
         </geometry>
-        <name>3</name>
       </visual>
       <pose>0.7775 -0.3575 0.3825 0 0 0</pose>
-      <name>3</name>
     </link>
     <link name="4">
       <collision name="4">
@@ -68,7 +59,6 @@
             <size>0.025 0.025 0.765</size>
           </box>
         </geometry>
-        <name>4</name>
       </collision>
       <visual name="4">
         <geometry>
@@ -76,10 +66,8 @@
             <size>0.025 0.025 0.765</size>
           </box>
         </geometry>
-        <name>4</name>
       </visual>
       <pose>-0.7775 0.3575 0.3825 0 0 0</pose>
-      <name>4</name>
     </link>
     <link name="5">
       <collision name="5">
@@ -88,7 +76,6 @@
             <size>0.025 0.025 0.765</size>
           </box>
         </geometry>
-        <name>5</name>
       </collision>
       <visual name="5">
         <geometry>
@@ -96,10 +83,8 @@
             <size>0.025 0.025 0.765</size>
           </box>
         </geometry>
-        <name>5</name>
       </visual>
       <pose>0.7775 0.3575 0.3825 0 0 0</pose>
-      <name>5</name>
     </link>
     <link name="on_top_of">
       <virtual_volume name="on_top_of">
@@ -109,9 +94,7 @@
           </box>
         </geometry>
         <pose>0.59 0.0 0.945 0 0 0</pose>
-        <name>on_top_of</name>
       </virtual_volume>
-      <name>on_top_of</name>
     </link>
     <link name="on_top_of_back">
       <virtual_volume name="on_top_of_back">
@@ -121,9 +104,7 @@
           </box>
         </geometry>
         <pose>-0.59 0.0 0.945 0 0 0</pose>
-        <name>on_top_of_back</name>
       </virtual_volume>
-      <name>on_top_of_back</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
@@ -133,11 +114,8 @@
           </box>
         </geometry>
         <pose>1.55 0.0 0.005 0 0 0</pose>
-        <name>in_front_of</name>
       </virtual_volume>
-      <name>in_front_of</name>
     </link>
     <static>true</static>
-    <name>rwc2017/table_dinner</name>
   </model>
 </sdf>

--- a/models/rwc2017/table_salon/model.sdf
+++ b/models/rwc2017/table_salon/model.sdf
@@ -8,7 +8,6 @@
             <size>1.1 0.6 0.05</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -16,10 +15,8 @@
             <size>1.1 0.6 0.05</size>
           </box>
         </geometry>
-        <name>1</name>
       </visual>
       <pose>0 0 0.435 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="2">
       <collision name="2">
@@ -28,7 +25,6 @@
             <size>0.03 0.03 0.41</size>
           </box>
         </geometry>
-        <name>2</name>
       </collision>
       <visual name="2">
         <geometry>
@@ -36,10 +32,8 @@
             <size>0.03 0.03 0.41</size>
           </box>
         </geometry>
-        <name>2</name>
       </visual>
       <pose>-0.525 -0.275 0.205 0 0 0</pose>
-      <name>2</name>
     </link>
     <link name="3">
       <collision name="3">
@@ -48,7 +42,6 @@
             <size>0.03 0.03 0.41</size>
           </box>
         </geometry>
-        <name>3</name>
       </collision>
       <visual name="3">
         <geometry>
@@ -56,10 +49,8 @@
             <size>0.03 0.03 0.41</size>
           </box>
         </geometry>
-        <name>3</name>
       </visual>
       <pose>0.525 -0.275 0.205 0 0 0</pose>
-      <name>3</name>
     </link>
     <link name="4">
       <collision name="4">
@@ -68,7 +59,6 @@
             <size>0.03 0.03 0.41</size>
           </box>
         </geometry>
-        <name>4</name>
       </collision>
       <visual name="4">
         <geometry>
@@ -76,10 +66,8 @@
             <size>0.03 0.03 0.41</size>
           </box>
         </geometry>
-        <name>4</name>
       </visual>
       <pose>-0.525 0.275 0.205 0 0 0</pose>
-      <name>4</name>
     </link>
     <link name="5">
       <collision name="5">
@@ -88,7 +76,6 @@
             <size>0.03 0.03 0.41</size>
           </box>
         </geometry>
-        <name>5</name>
       </collision>
       <visual name="5">
         <geometry>
@@ -96,10 +83,8 @@
             <size>0.03 0.03 0.41</size>
           </box>
         </geometry>
-        <name>5</name>
       </visual>
       <pose>0.525 0.275 0.205 0 0 0</pose>
-      <name>5</name>
     </link>
     <link name="6">
       <collision name="6">
@@ -108,7 +93,6 @@
             <size>0.03 0.55 0.03</size>
           </box>
         </geometry>
-        <name>6</name>
       </collision>
       <visual name="6">
         <geometry>
@@ -116,10 +100,8 @@
             <size>0.03 0.55 0.03</size>
           </box>
         </geometry>
-        <name>6</name>
       </visual>
       <pose>0.525 0.0 0.015 0 0 0</pose>
-      <name>6</name>
     </link>
     <link name="7">
       <collision name="7">
@@ -128,7 +110,6 @@
             <size>0.03 0.55 0.03</size>
           </box>
         </geometry>
-        <name>7</name>
       </collision>
       <visual name="7">
         <geometry>
@@ -136,10 +117,8 @@
             <size>0.03 0.55 0.03</size>
           </box>
         </geometry>
-        <name>7</name>
       </visual>
       <pose>-0.525 0.0 0.015 0 0 0</pose>
-      <name>7</name>
     </link>
     <link name="on_top_of">
       <virtual_volume name="on_top_of">
@@ -149,9 +128,7 @@
           </box>
         </geometry>
         <pose>0.0 0.0 0.605 0 0 0</pose>
-        <name>on_top_of</name>
       </virtual_volume>
-      <name>on_top_of</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
@@ -161,11 +138,8 @@
           </box>
         </geometry>
         <pose>1.05 0.0 0.005 0 0 0</pose>
-        <name>in_front_of</name>
       </virtual_volume>
-      <name>in_front_of</name>
     </link>
     <static>true</static>
-    <name>rwc2017/table_salon</name>
   </model>
 </sdf>

--- a/models/rwc2017/teepee/model.sdf
+++ b/models/rwc2017/teepee/model.sdf
@@ -8,7 +8,6 @@
             <size>0.84 0.84 1.3</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -16,10 +15,8 @@
             <size>0.84 0.84 1.3</size>
           </box>
         </geometry>
-        <name>1</name>
       </visual>
       <pose>0 0 0.65 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
@@ -29,11 +26,8 @@
           </box>
         </geometry>
         <pose>1.1 0.0 0.005 0 0 0</pose>
-        <name>in_front_of</name>
       </virtual_volume>
-      <name>in_front_of</name>
     </link>
     <static>true</static>
-    <name>rwc2017/teepee</name>
   </model>
 </sdf>

--- a/models/rwc2017/tv/model.sdf
+++ b/models/rwc2017/tv/model.sdf
@@ -8,7 +8,6 @@
             <size>0.1 1.25 0.9</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -19,10 +18,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>1</name>
       </visual>
       <pose>0 0 0.45 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="on_top_of">
       <virtual_volume name="on_top_of">
@@ -32,9 +29,7 @@
           </box>
         </geometry>
         <pose>0.0 0.0 1.045 0 0 0</pose>
-        <name>on_top_of</name>
       </virtual_volume>
-      <name>on_top_of</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
@@ -44,11 +39,8 @@
           </box>
         </geometry>
         <pose>0.55 0.0 0.005 0 0 0</pose>
-        <name>in_front_of</name>
       </virtual_volume>
-      <name>in_front_of</name>
     </link>
     <static>true</static>
-    <name>rwc2017/tv</name>
   </model>
 </sdf>

--- a/models/rwc2017/tv_stand/model.sdf
+++ b/models/rwc2017/tv_stand/model.sdf
@@ -8,7 +8,6 @@
             <size>0.39 1.01 0.135</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -16,10 +15,8 @@
             <size>0.39 1.01 0.135</size>
           </box>
         </geometry>
-        <name>1</name>
       </visual>
       <pose>0 0.425 0.2325 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="2">
       <collision name="2">
@@ -28,7 +25,6 @@
             <size>0.39 1.05 0.15</size>
           </box>
         </geometry>
-        <name>2</name>
       </collision>
       <visual name="2">
         <geometry>
@@ -36,10 +32,8 @@
             <size>0.39 1.05 0.15</size>
           </box>
         </geometry>
-        <name>2</name>
       </visual>
       <pose>0 -0.45 0.375 0 0 0</pose>
-      <name>2</name>
     </link>
     <link name="3">
       <collision name="3">
@@ -48,7 +42,6 @@
             <size>0.01 1.8 0.3</size>
           </box>
         </geometry>
-        <name>3</name>
       </collision>
       <visual name="3">
         <geometry>
@@ -56,10 +49,8 @@
             <size>0.01 1.8 0.3</size>
           </box>
         </geometry>
-        <name>3</name>
       </visual>
       <pose>-0.19 0.0 0.15 0 0 0</pose>
-      <name>3</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
@@ -69,11 +60,8 @@
           </box>
         </geometry>
         <pose>0.55 0.0 0.005 0 0 0</pose>
-        <name>in_front_of</name>
       </virtual_volume>
-      <name>in_front_of</name>
     </link>
     <static>true</static>
-    <name>rwc2017/tv_stand</name>
   </model>
 </sdf>

--- a/models/rwc2017/umbrella_holder/model.sdf
+++ b/models/rwc2017/umbrella_holder/model.sdf
@@ -8,7 +8,6 @@
             <size>0.27 0.35 0.1</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -16,10 +15,8 @@
             <size>0.27 0.35 0.1</size>
           </box>
         </geometry>
-        <name>1</name>
       </visual>
       <pose>0 0 0.05 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
@@ -29,11 +26,8 @@
           </box>
         </geometry>
         <pose>0.9 0.0 0.005 0 0 0</pose>
-        <name>in_front_of</name>
       </virtual_volume>
-      <name>in_front_of</name>
     </link>
     <static>true</static>
-    <name>rwc2017/umbrella_holder</name>
   </model>
 </sdf>

--- a/models/rwc2017/wall_180/model.sdf
+++ b/models/rwc2017/wall_180/model.sdf
@@ -8,7 +8,6 @@
             <size>1.8 0.1 0.6</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -19,12 +18,9 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>1</name>
       </visual>
       <pose>0 0 0.3 0 0 0</pose>
-      <name>1</name>
     </link>
     <static>true</static>
-    <name>rwc2017/wall_180</name>
   </model>
 </sdf>

--- a/models/rwc2017/wall_240/model.sdf
+++ b/models/rwc2017/wall_240/model.sdf
@@ -8,7 +8,6 @@
             <size>2.4 0.1 0.6</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -19,12 +18,9 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>1</name>
       </visual>
       <pose>0 0 0.3 0 0 0</pose>
-      <name>1</name>
     </link>
     <static>true</static>
-    <name>rwc2017/wall_240</name>
   </model>
 </sdf>

--- a/models/rwc2017/wall_270/model.sdf
+++ b/models/rwc2017/wall_270/model.sdf
@@ -8,7 +8,6 @@
             <size>2.7 0.1 0.6</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -19,12 +18,9 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>1</name>
       </visual>
       <pose>0 0 0.3 0 0 0</pose>
-      <name>1</name>
     </link>
     <static>true</static>
-    <name>rwc2017/wall_270</name>
   </model>
 </sdf>

--- a/models/rwc2017/walls/model.sdf
+++ b/models/rwc2017/walls/model.sdf
@@ -8,7 +8,6 @@
             <uri>model://rwc2017/walls/shape/heightmap.stl</uri>
           </mesh>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -16,12 +15,9 @@
             <uri>model://rwc2017/walls/shape/heightmap.stl</uri>
           </mesh>
         </geometry>
-        <name>1</name>
       </visual>
       <pose>0 0 0 0 0 0</pose>
-      <name>1</name>
     </link>
     <static>true</static>
-    <name>rwc2017/walls</name>
   </model>
 </sdf>

--- a/models/rwc2018/bed/model.sdf
+++ b/models/rwc2018/bed/model.sdf
@@ -8,7 +8,6 @@
             <size>2.0 1.5 0.55</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -16,10 +15,8 @@
             <size>2.0 1.5 0.55</size>
           </box>
         </geometry>
-        <name>1</name>
       </visual>
       <pose>0 0 0.275 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="on_top_of">
       <virtual_volume name="on_top_of">
@@ -29,9 +26,7 @@
           </box>
         </geometry>
         <pose>0.0 0.0 0.695 0 0 0</pose>
-        <name>on_top_of</name>
       </virtual_volume>
-      <name>on_top_of</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
@@ -41,11 +36,8 @@
           </box>
         </geometry>
         <pose>1.0 -0.5 0.005 0 0 0</pose>
-        <name>in_front_of</name>
       </virtual_volume>
-      <name>in_front_of</name>
     </link>
     <static>true</static>
-    <name>rwc2018/bed</name>
   </model>
 </sdf>

--- a/models/rwc2018/bookcase/model.sdf
+++ b/models/rwc2018/bookcase/model.sdf
@@ -8,7 +8,6 @@
             <size>0.23 0.018 1.82</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -16,10 +15,8 @@
             <size>0.23 0.018 1.82</size>
           </box>
         </geometry>
-        <name>1</name>
       </visual>
       <pose>0 -0.291 0.91 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="2">
       <collision name="2">
@@ -28,7 +25,6 @@
             <size>0.23 0.018 1.82</size>
           </box>
         </geometry>
-        <name>2</name>
       </collision>
       <visual name="2">
         <geometry>
@@ -36,10 +32,8 @@
             <size>0.23 0.018 1.82</size>
           </box>
         </geometry>
-        <name>2</name>
       </visual>
       <pose>0 0.291 0.91 0 0 0</pose>
-      <name>2</name>
     </link>
     <link name="3">
       <collision name="3">
@@ -48,7 +42,6 @@
             <size>0.018 0.6 1.82</size>
           </box>
         </geometry>
-        <name>3</name>
       </collision>
       <visual name="3">
         <geometry>
@@ -56,10 +49,8 @@
             <size>0.018 0.6 1.82</size>
           </box>
         </geometry>
-        <name>3</name>
       </visual>
       <pose>-0.106 0 0.91 0 0 0</pose>
-      <name>3</name>
     </link>
     <link name="4">
       <collision name="4">
@@ -68,7 +59,6 @@
             <size>0.212 0.564 0.018</size>
           </box>
         </geometry>
-        <name>4</name>
       </collision>
       <visual name="4">
         <geometry>
@@ -76,10 +66,8 @@
             <size>0.212 0.564 0.018</size>
           </box>
         </geometry>
-        <name>4</name>
       </visual>
       <pose>0.009 0 1.811 0 0 0</pose>
-      <name>4</name>
     </link>
     <link name="5">
       <collision name="5">
@@ -88,7 +76,6 @@
             <size>0.212 0.564 0.065</size>
           </box>
         </geometry>
-        <name>5</name>
       </collision>
       <visual name="5">
         <geometry>
@@ -96,10 +83,8 @@
             <size>0.212 0.564 0.065</size>
           </box>
         </geometry>
-        <name>5</name>
       </visual>
       <pose>0.009 0 0.001 0 0 0</pose>
-      <name>5</name>
     </link>
     <link name="6">
       <collision name="6">
@@ -108,7 +93,6 @@
             <size>0.212 0.564 0.015</size>
           </box>
         </geometry>
-        <name>6</name>
       </collision>
       <visual name="6">
         <geometry>
@@ -116,10 +100,8 @@
             <size>0.212 0.564 0.015</size>
           </box>
         </geometry>
-        <name>6</name>
       </visual>
       <pose>0.009 0 0.38 0 0 0</pose>
-      <name>6</name>
     </link>
     <link name="7">
       <collision name="7">
@@ -128,7 +110,6 @@
             <size>0.212 0.564 0.015</size>
           </box>
         </geometry>
-        <name>7</name>
       </collision>
       <visual name="7">
         <geometry>
@@ -136,10 +117,8 @@
             <size>0.212 0.564 0.015</size>
           </box>
         </geometry>
-        <name>7</name>
       </visual>
       <pose>0.009 0 0.68 0 0 0</pose>
-      <name>7</name>
     </link>
     <link name="8">
       <collision name="8">
@@ -148,7 +127,6 @@
             <size>0.212 0.564 0.015</size>
           </box>
         </geometry>
-        <name>8</name>
       </collision>
       <visual name="8">
         <geometry>
@@ -156,10 +134,8 @@
             <size>0.212 0.564 0.015</size>
           </box>
         </geometry>
-        <name>8</name>
       </visual>
       <pose>0.009 0 0.92 0 0 0</pose>
-      <name>8</name>
     </link>
     <link name="9">
       <collision name="9">
@@ -168,7 +144,6 @@
             <size>0.212 0.564 0.015</size>
           </box>
         </geometry>
-        <name>9</name>
       </collision>
       <visual name="9">
         <geometry>
@@ -176,10 +151,8 @@
             <size>0.212 0.564 0.015</size>
           </box>
         </geometry>
-        <name>9</name>
       </visual>
       <pose>0.009 0 1.225 0 0 0</pose>
-      <name>9</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
@@ -189,9 +162,7 @@
           </box>
         </geometry>
         <pose>0.615 0.0 0.005 0 0 0</pose>
-        <name>in_front_of</name>
       </virtual_volume>
-      <name>in_front_of</name>
     </link>
     <link name="shelf1">
       <virtual_volume name="shelf1">
@@ -201,9 +172,7 @@
           </box>
         </geometry>
         <pose>0.009 0.0 0.17 0 0 0</pose>
-        <name>shelf1</name>
       </virtual_volume>
-      <name>shelf1</name>
     </link>
     <link name="shelf2">
       <virtual_volume name="shelf2">
@@ -213,9 +182,7 @@
           </box>
         </geometry>
         <pose>0.009 0.0 0.5 0 0 0</pose>
-        <name>shelf2</name>
       </virtual_volume>
-      <name>shelf2</name>
     </link>
     <link name="shelf3">
       <virtual_volume name="shelf3">
@@ -225,9 +192,7 @@
           </box>
         </geometry>
         <pose>0.009 0.0 0.8 0 0 0</pose>
-        <name>shelf3</name>
       </virtual_volume>
-      <name>shelf3</name>
     </link>
     <link name="shelf4">
       <virtual_volume name="shelf4">
@@ -237,9 +202,7 @@
           </box>
         </geometry>
         <pose>0.009 0.0 1.04 0 0 0</pose>
-        <name>shelf4</name>
       </virtual_volume>
-      <name>shelf4</name>
     </link>
     <link name="shelf5">
       <virtual_volume name="shelf5">
@@ -249,9 +212,7 @@
           </box>
         </geometry>
         <pose>0.009 0.0 1.345 0 0 0</pose>
-        <name>shelf5</name>
       </virtual_volume>
-      <name>shelf5</name>
     </link>
     <link name="on_top_of">
       <virtual_volume name="on_top_of">
@@ -261,11 +222,8 @@
           </box>
         </geometry>
         <pose>0.009 0.0 0.795 0 0 0</pose>
-        <name>on_top_of</name>
       </virtual_volume>
-      <name>on_top_of</name>
     </link>
     <static>true</static>
-    <name>rwc2018/bookcase</name>
   </model>
 </sdf>

--- a/models/rwc2018/couch/model.sdf
+++ b/models/rwc2018/couch/model.sdf
@@ -8,7 +8,6 @@
             <size>0.8 1.7 0.2</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -16,10 +15,8 @@
             <size>0.8 1.7 0.2</size>
           </box>
         </geometry>
-        <name>1</name>
       </visual>
       <pose>0 0 0.3 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="2">
       <collision name="2">
@@ -28,7 +25,6 @@
             <size>0.3 1.7 0.4</size>
           </box>
         </geometry>
-        <name>2</name>
       </collision>
       <visual name="2">
         <geometry>
@@ -36,10 +32,8 @@
             <size>0.3 1.7 0.4</size>
           </box>
         </geometry>
-        <name>2</name>
       </visual>
       <pose>-0.25 0 0.6 0 0 0</pose>
-      <name>2</name>
     </link>
     <link name="on_top_of">
       <virtual_volume name="on_top_of">
@@ -49,9 +43,7 @@
           </box>
         </geometry>
         <pose>0.135 0.0 0.58 0 0 0</pose>
-        <name>on_top_of</name>
       </virtual_volume>
-      <name>on_top_of</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
@@ -61,11 +53,8 @@
           </box>
         </geometry>
         <pose>0.9 0.0 0.005 0 0 0</pose>
-        <name>in_front_of</name>
       </virtual_volume>
-      <name>in_front_of</name>
     </link>
     <static>true</static>
-    <name>rwc2018/couch</name>
   </model>
 </sdf>

--- a/models/rwc2018/counter/model.sdf
+++ b/models/rwc2018/counter/model.sdf
@@ -8,7 +8,6 @@
             <size>0.61 1.63 0.05</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -16,10 +15,8 @@
             <size>0.61 1.63 0.05</size>
           </box>
         </geometry>
-        <name>1</name>
       </visual>
       <pose>0 0 0.885 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="on_top_of">
       <virtual_volume name="on_top_of">
@@ -29,9 +26,7 @@
           </box>
         </geometry>
         <pose>0.0 0.0 1.055 0 0 0</pose>
-        <name>on_top_of</name>
       </virtual_volume>
-      <name>on_top_of</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
@@ -41,11 +36,8 @@
           </box>
         </geometry>
         <pose>0.8 0.0 0.005 0 0 0</pose>
-        <name>in_front_of</name>
       </virtual_volume>
-      <name>in_front_of</name>
     </link>
     <static>true</static>
-    <name>rwc2018/counter</name>
   </model>
 </sdf>

--- a/models/rwc2018/cupboard/model.sdf
+++ b/models/rwc2018/cupboard/model.sdf
@@ -8,7 +8,6 @@
             <size>0.26 0.018 2.02</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -16,10 +15,8 @@
             <size>0.26 0.018 2.02</size>
           </box>
         </geometry>
-        <name>1</name>
       </visual>
       <pose>0 -0.391 1.01 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="2">
       <collision name="2">
@@ -28,7 +25,6 @@
             <size>0.26 0.018 2.02</size>
           </box>
         </geometry>
-        <name>2</name>
       </collision>
       <visual name="2">
         <geometry>
@@ -36,10 +32,8 @@
             <size>0.26 0.018 2.02</size>
           </box>
         </geometry>
-        <name>2</name>
       </visual>
       <pose>0 0.391 1.01 0 0 0</pose>
-      <name>2</name>
     </link>
     <link name="3">
       <collision name="3">
@@ -48,7 +42,6 @@
             <size>0.018 0.8 2.02</size>
           </box>
         </geometry>
-        <name>3</name>
       </collision>
       <visual name="3">
         <geometry>
@@ -56,10 +49,8 @@
             <size>0.018 0.8 2.02</size>
           </box>
         </geometry>
-        <name>3</name>
       </visual>
       <pose>-0.121 0 1.01 0 0 0</pose>
-      <name>3</name>
     </link>
     <link name="4">
       <collision name="4">
@@ -68,7 +59,6 @@
             <size>0.242 0.764 0.018</size>
           </box>
         </geometry>
-        <name>4</name>
       </collision>
       <visual name="4">
         <geometry>
@@ -76,10 +66,8 @@
             <size>0.242 0.764 0.018</size>
           </box>
         </geometry>
-        <name>4</name>
       </visual>
       <pose>0.009 0 2.011 0 0 0</pose>
-      <name>4</name>
     </link>
     <link name="5">
       <collision name="5">
@@ -88,7 +76,6 @@
             <size>0.242 0.764 0.018</size>
           </box>
         </geometry>
-        <name>5</name>
       </collision>
       <visual name="5">
         <geometry>
@@ -96,10 +83,8 @@
             <size>0.242 0.764 0.018</size>
           </box>
         </geometry>
-        <name>5</name>
       </visual>
       <pose>0.009 0 0.091 0 0 0</pose>
-      <name>5</name>
     </link>
     <link name="6">
       <collision name="6">
@@ -108,7 +93,6 @@
             <size>0.242 0.764 0.018</size>
           </box>
         </geometry>
-        <name>6</name>
       </collision>
       <visual name="6">
         <geometry>
@@ -116,10 +100,8 @@
             <size>0.242 0.764 0.018</size>
           </box>
         </geometry>
-        <name>6</name>
       </visual>
       <pose>0.009 0 0.276 0 0 0</pose>
-      <name>6</name>
     </link>
     <link name="7">
       <collision name="7">
@@ -128,7 +110,6 @@
             <size>0.242 0.764 0.018</size>
           </box>
         </geometry>
-        <name>7</name>
       </collision>
       <visual name="7">
         <geometry>
@@ -136,10 +117,8 @@
             <size>0.242 0.764 0.018</size>
           </box>
         </geometry>
-        <name>7</name>
       </visual>
       <pose>0.009 0 0.631 0 0 0</pose>
-      <name>7</name>
     </link>
     <link name="8">
       <collision name="8">
@@ -148,7 +127,6 @@
             <size>0.242 0.764 0.018</size>
           </box>
         </geometry>
-        <name>8</name>
       </collision>
       <visual name="8">
         <geometry>
@@ -156,10 +134,8 @@
             <size>0.242 0.764 0.018</size>
           </box>
         </geometry>
-        <name>8</name>
       </visual>
       <pose>0.009 0 1.051 0 0 0</pose>
-      <name>8</name>
     </link>
     <link name="9">
       <collision name="9">
@@ -168,7 +144,6 @@
             <size>0.242 0.764 0.018</size>
           </box>
         </geometry>
-        <name>9</name>
       </collision>
       <visual name="9">
         <geometry>
@@ -176,10 +151,8 @@
             <size>0.242 0.764 0.018</size>
           </box>
         </geometry>
-        <name>9</name>
       </visual>
       <pose>0.009 0 1.401 0 0 0</pose>
-      <name>9</name>
     </link>
     <link name="10">
       <collision name="10">
@@ -188,7 +161,6 @@
             <size>0.242 0.764 0.018</size>
           </box>
         </geometry>
-        <name>10</name>
       </collision>
       <visual name="10">
         <geometry>
@@ -196,10 +168,8 @@
             <size>0.242 0.764 0.018</size>
           </box>
         </geometry>
-        <name>10</name>
       </visual>
       <pose>0.009 0 1.751 0 0 0</pose>
-      <name>10</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
@@ -209,9 +179,7 @@
           </box>
         </geometry>
         <pose>0.63 0.0 0.005 0 0 0</pose>
-        <name>in_front_of</name>
       </virtual_volume>
-      <name>in_front_of</name>
     </link>
     <link name="shelf1">
       <virtual_volume name="shelf1">
@@ -221,9 +189,7 @@
           </box>
         </geometry>
         <pose>0.015 0.0 0.2 0 0 0</pose>
-        <name>shelf1</name>
       </virtual_volume>
-      <name>shelf1</name>
     </link>
     <link name="shelf2">
       <virtual_volume name="shelf2">
@@ -233,9 +199,7 @@
           </box>
         </geometry>
         <pose>0.015 0.0 0.43 0 0 0</pose>
-        <name>shelf2</name>
       </virtual_volume>
-      <name>shelf2</name>
     </link>
     <link name="shelf3">
       <virtual_volume name="shelf3">
@@ -245,9 +209,7 @@
           </box>
         </geometry>
         <pose>0.015 0.0 0.785 0 0 0</pose>
-        <name>shelf3</name>
       </virtual_volume>
-      <name>shelf3</name>
     </link>
     <link name="shelf4">
       <virtual_volume name="shelf4">
@@ -257,9 +219,7 @@
           </box>
         </geometry>
         <pose>0.015 0.0 1.205 0 0 0</pose>
-        <name>shelf4</name>
       </virtual_volume>
-      <name>shelf4</name>
     </link>
     <link name="shelf5">
       <virtual_volume name="shelf5">
@@ -269,9 +229,7 @@
           </box>
         </geometry>
         <pose>0.015 0.0 1.555 0 0 0</pose>
-        <name>shelf5</name>
       </virtual_volume>
-      <name>shelf5</name>
     </link>
     <link name="shelf6">
       <virtual_volume name="shelf6">
@@ -281,9 +239,7 @@
           </box>
         </geometry>
         <pose>0.015 0.0 1.86 0 0 0</pose>
-        <name>shelf6</name>
       </virtual_volume>
-      <name>shelf6</name>
     </link>
     <link name="on_top_of">
       <virtual_volume name="on_top_of">
@@ -293,11 +249,8 @@
           </box>
         </geometry>
         <pose>0.015 0.0 1.205 0 0 0</pose>
-        <name>on_top_of</name>
       </virtual_volume>
-      <name>on_top_of</name>
     </link>
     <static>true</static>
-    <name>rwc2018/cupboard</name>
   </model>
 </sdf>

--- a/models/rwc2018/desk/model.sdf
+++ b/models/rwc2018/desk/model.sdf
@@ -8,7 +8,6 @@
             <size>0.6 0.705 0.018</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -16,10 +15,8 @@
             <size>0.6 0.705 0.018</size>
           </box>
         </geometry>
-        <name>1</name>
       </visual>
       <pose>0 0 0.711 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="2">
       <collision name="2">
@@ -28,7 +25,6 @@
             <size>0.025 0.025 0.702</size>
           </box>
         </geometry>
-        <name>2</name>
       </collision>
       <visual name="2">
         <geometry>
@@ -36,10 +32,8 @@
             <size>0.025 0.025 0.702</size>
           </box>
         </geometry>
-        <name>2</name>
       </visual>
       <pose>-0.2325 -0.3 0.351 0 0 0</pose>
-      <name>2</name>
     </link>
     <link name="3">
       <collision name="3">
@@ -48,7 +42,6 @@
             <size>0.025 0.025 0.702</size>
           </box>
         </geometry>
-        <name>3</name>
       </collision>
       <visual name="3">
         <geometry>
@@ -56,10 +49,8 @@
             <size>0.025 0.025 0.702</size>
           </box>
         </geometry>
-        <name>3</name>
       </visual>
       <pose>0.2325 -0.3 0.351 0 0 0</pose>
-      <name>3</name>
     </link>
     <link name="4">
       <collision name="4">
@@ -68,7 +59,6 @@
             <size>0.025 0.025 0.702</size>
           </box>
         </geometry>
-        <name>4</name>
       </collision>
       <visual name="4">
         <geometry>
@@ -76,10 +66,8 @@
             <size>0.025 0.025 0.702</size>
           </box>
         </geometry>
-        <name>4</name>
       </visual>
       <pose>-0.2325 0.3 0.351 0 0 0</pose>
-      <name>4</name>
     </link>
     <link name="5">
       <collision name="5">
@@ -88,7 +76,6 @@
             <size>0.025 0.025 0.702</size>
           </box>
         </geometry>
-        <name>5</name>
       </collision>
       <visual name="5">
         <geometry>
@@ -96,10 +83,8 @@
             <size>0.025 0.025 0.702</size>
           </box>
         </geometry>
-        <name>5</name>
       </visual>
       <pose>0.2325 0.3 0.351 0 0 0</pose>
-      <name>5</name>
     </link>
     <link name="on_top_of">
       <virtual_volume name="on_top_of">
@@ -109,9 +94,7 @@
           </box>
         </geometry>
         <pose>-0.005 0.0 0.865 0 0 0</pose>
-        <name>on_top_of</name>
       </virtual_volume>
-      <name>on_top_of</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
@@ -121,11 +104,8 @@
           </box>
         </geometry>
         <pose>0.8 0.0 0.005 0 0 0</pose>
-        <name>in_front_of</name>
       </virtual_volume>
-      <name>in_front_of</name>
     </link>
     <static>true</static>
-    <name>rwc2018/desk</name>
   </model>
 </sdf>

--- a/models/rwc2018/diningtable/model.sdf
+++ b/models/rwc2018/diningtable/model.sdf
@@ -8,7 +8,6 @@
             <size>0.6 1.4 0.035</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -16,10 +15,8 @@
             <size>0.6 1.4 0.035</size>
           </box>
         </geometry>
-        <name>1</name>
       </visual>
       <pose>0 0 0.7175 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="2">
       <collision name="2">
@@ -28,7 +25,6 @@
             <size>0.04 0.04 0.7</size>
           </box>
         </geometry>
-        <name>2</name>
       </collision>
       <visual name="2">
         <geometry>
@@ -36,10 +32,8 @@
             <size>0.04 0.04 0.7</size>
           </box>
         </geometry>
-        <name>2</name>
       </visual>
       <pose>-0.22 -0.42 0.35 0 0 0</pose>
-      <name>2</name>
     </link>
     <link name="3">
       <collision name="3">
@@ -48,7 +42,6 @@
             <size>0.04 0.04 0.7</size>
           </box>
         </geometry>
-        <name>3</name>
       </collision>
       <visual name="3">
         <geometry>
@@ -56,10 +49,8 @@
             <size>0.04 0.04 0.7</size>
           </box>
         </geometry>
-        <name>3</name>
       </visual>
       <pose>-0.22 0.42 0.35 0 0 0</pose>
-      <name>3</name>
     </link>
     <link name="4">
       <collision name="4">
@@ -68,7 +59,6 @@
             <size>0.04 0.04 0.7</size>
           </box>
         </geometry>
-        <name>4</name>
       </collision>
       <visual name="4">
         <geometry>
@@ -76,10 +66,8 @@
             <size>0.04 0.04 0.7</size>
           </box>
         </geometry>
-        <name>4</name>
       </visual>
       <pose>0.22 -0.42 0.35 0 0 0</pose>
-      <name>4</name>
     </link>
     <link name="5">
       <collision name="5">
@@ -88,7 +76,6 @@
             <size>0.04 0.04 0.7</size>
           </box>
         </geometry>
-        <name>5</name>
       </collision>
       <visual name="5">
         <geometry>
@@ -96,10 +83,8 @@
             <size>0.04 0.04 0.7</size>
           </box>
         </geometry>
-        <name>5</name>
       </visual>
       <pose>0.22 0.42 0.35 0 0 0</pose>
-      <name>5</name>
     </link>
     <link name="on_top_of">
       <virtual_volume name="on_top_of">
@@ -109,9 +94,7 @@
           </box>
         </geometry>
         <pose>0.0 0.0 0.88 0 0 0</pose>
-        <name>on_top_of</name>
       </virtual_volume>
-      <name>on_top_of</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
@@ -121,9 +104,7 @@
           </box>
         </geometry>
         <pose>0.95 0.0 0.005 0 0 0</pose>
-        <name>in_front_of</name>
       </virtual_volume>
-      <name>in_front_of</name>
     </link>
     <link name="on_right_of">
       <virtual_volume name="on_right_of">
@@ -133,9 +114,7 @@
           </box>
         </geometry>
         <pose>0.0 1.2 0.005 0 0 0</pose>
-        <name>on_right_of</name>
       </virtual_volume>
-      <name>on_right_of</name>
     </link>
     <link name="in_back_of">
       <virtual_volume name="in_back_of">
@@ -145,11 +124,8 @@
           </box>
         </geometry>
         <pose>-0.95 0.0 0.005 0 0 0</pose>
-        <name>in_back_of</name>
       </virtual_volume>
-      <name>in_back_of</name>
     </link>
     <static>true</static>
-    <name>rwc2018/diningtable</name>
   </model>
 </sdf>

--- a/models/rwc2018/dishwasher/model.sdf
+++ b/models/rwc2018/dishwasher/model.sdf
@@ -8,7 +8,6 @@
             <size>0.61 0.69 0.91</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -16,10 +15,8 @@
             <size>0.61 0.69 0.91</size>
           </box>
         </geometry>
-        <name>1</name>
       </visual>
       <pose>0 0 0.455 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="on_top_of">
       <virtual_volume name="on_top_of">
@@ -29,9 +26,7 @@
           </box>
         </geometry>
         <pose>0.0 0.0 1.055 0 0 0</pose>
-        <name>on_top_of</name>
       </virtual_volume>
-      <name>on_top_of</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
@@ -41,9 +36,7 @@
           </box>
         </geometry>
         <pose>0.805 0.0 0.005 0 0 0</pose>
-        <name>in_front_of</name>
       </virtual_volume>
-      <name>in_front_of</name>
     </link>
     <link name="to_the_side_of">
       <virtual_volume name="to_the_side_of">
@@ -53,11 +46,8 @@
           </box>
         </geometry>
         <pose>0.9125 -0.85 0.005 0 0 0</pose>
-        <name>to_the_side_of</name>
       </virtual_volume>
-      <name>to_the_side_of</name>
     </link>
     <static>true</static>
-    <name>rwc2018/dishwasher</name>
   </model>
 </sdf>

--- a/models/rwc2018/dustbin1/model.sdf
+++ b/models/rwc2018/dustbin1/model.sdf
@@ -8,7 +8,6 @@
             <size>0.23 0.3 0.33</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -16,10 +15,8 @@
             <size>0.23 0.3 0.33</size>
           </box>
         </geometry>
-        <name>1</name>
       </visual>
       <pose>0 0 0.165 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="on_top_of">
       <virtual_volume name="on_top_of">
@@ -29,9 +26,7 @@
           </box>
         </geometry>
         <pose>0.0 0.0 0.475 0 0 0</pose>
-        <name>on_top_of</name>
       </virtual_volume>
-      <name>on_top_of</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
@@ -41,11 +36,8 @@
           </box>
         </geometry>
         <pose>0.615 0.0 0.005 0 0 0</pose>
-        <name>in_front_of</name>
       </virtual_volume>
-      <name>in_front_of</name>
     </link>
     <static>true</static>
-    <name>rwc2018/dustbin1</name>
   </model>
 </sdf>

--- a/models/rwc2018/dustbin2/model.sdf
+++ b/models/rwc2018/dustbin2/model.sdf
@@ -8,7 +8,6 @@
             <size>0.3 0.3 0.52</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -16,10 +15,8 @@
             <size>0.3 0.3 0.52</size>
           </box>
         </geometry>
-        <name>1</name>
       </visual>
       <pose>0 0 0.26 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="on_top_of">
       <virtual_volume name="on_top_of">
@@ -29,9 +26,7 @@
           </box>
         </geometry>
         <pose>0.0 0.0 0.665 0 0 0</pose>
-        <name>on_top_of</name>
       </virtual_volume>
-      <name>on_top_of</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
@@ -41,11 +36,8 @@
           </box>
         </geometry>
         <pose>0.65 0.0 0.005 0 0 0</pose>
-        <name>in_front_of</name>
       </virtual_volume>
-      <name>in_front_of</name>
     </link>
     <static>true</static>
-    <name>rwc2018/dustbin2</name>
   </model>
 </sdf>

--- a/models/rwc2018/endtable/model.sdf
+++ b/models/rwc2018/endtable/model.sdf
@@ -8,7 +8,6 @@
             <size>1.1 0.55 0.05</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -19,10 +18,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>1</name>
       </visual>
       <pose>0 0 0.425 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="2">
       <collision name="2">
@@ -31,7 +28,6 @@
             <size>0.05 0.05 0.4</size>
           </box>
         </geometry>
-        <name>2</name>
       </collision>
       <visual name="2">
         <geometry>
@@ -42,10 +38,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>2</name>
       </visual>
       <pose>-0.525 -0.25 0.2 0 0 0</pose>
-      <name>2</name>
     </link>
     <link name="3">
       <collision name="3">
@@ -54,7 +48,6 @@
             <size>0.05 0.05 0.4</size>
           </box>
         </geometry>
-        <name>3</name>
       </collision>
       <visual name="3">
         <geometry>
@@ -65,10 +58,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>3</name>
       </visual>
       <pose>0.525 -0.25 0.2 0 0 0</pose>
-      <name>3</name>
     </link>
     <link name="4">
       <collision name="4">
@@ -77,7 +68,6 @@
             <size>0.05 0.05 0.4</size>
           </box>
         </geometry>
-        <name>4</name>
       </collision>
       <visual name="4">
         <geometry>
@@ -88,10 +78,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>4</name>
       </visual>
       <pose>-0.525 0.25 0.2 0 0 0</pose>
-      <name>4</name>
     </link>
     <link name="5">
       <collision name="5">
@@ -100,7 +88,6 @@
             <size>0.05 0.05 0.4</size>
           </box>
         </geometry>
-        <name>5</name>
       </collision>
       <visual name="5">
         <geometry>
@@ -111,10 +98,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>5</name>
       </visual>
       <pose>0.525 0.25 0.2 0 0 0</pose>
-      <name>5</name>
     </link>
     <link name="6">
       <collision name="6">
@@ -123,7 +108,6 @@
             <size>0.1 0.05 0.4</size>
           </box>
         </geometry>
-        <name>6</name>
       </collision>
       <visual name="6">
         <geometry>
@@ -134,10 +118,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>6</name>
       </visual>
       <pose>0 0.25 0.2 0 0 0</pose>
-      <name>6</name>
     </link>
     <link name="7">
       <collision name="7">
@@ -146,7 +128,6 @@
             <size>0.1 0.05 0.4</size>
           </box>
         </geometry>
-        <name>7</name>
       </collision>
       <visual name="7">
         <geometry>
@@ -157,10 +138,8 @@
         <material>
           <ambient>0.75 0.75 0.75 1</ambient>
         </material>
-        <name>7</name>
       </visual>
       <pose>0 -0.25 0.2 0 0 0</pose>
-      <name>7</name>
     </link>
     <link name="on_top_of">
       <virtual_volume name="on_top_of">
@@ -170,9 +149,7 @@
           </box>
         </geometry>
         <pose>0.0 0.0 0.595 0 0 0</pose>
-        <name>on_top_of</name>
       </virtual_volume>
-      <name>on_top_of</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
@@ -182,11 +159,8 @@
           </box>
         </geometry>
         <pose>0.0 0.8 0.005 0 0 0</pose>
-        <name>in_front_of</name>
       </virtual_volume>
-      <name>in_front_of</name>
     </link>
     <static>true</static>
-    <name>rwc2018/endtable</name>
   </model>
 </sdf>

--- a/models/rwc2018/fridge/model.sdf
+++ b/models/rwc2018/fridge/model.sdf
@@ -8,7 +8,6 @@
             <size>0.45 0.47 0.86</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -16,10 +15,8 @@
             <size>0.45 0.47 0.86</size>
           </box>
         </geometry>
-        <name>1</name>
       </visual>
       <pose>0 0 0.43 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="on_top_of">
       <virtual_volume name="on_top_of">
@@ -29,9 +26,7 @@
           </box>
         </geometry>
         <pose>0.0075 0.0 1.055 0 0 0</pose>
-        <name>on_top_of</name>
       </virtual_volume>
-      <name>on_top_of</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
@@ -41,11 +36,8 @@
           </box>
         </geometry>
         <pose>0.725 0.0 0.005 0 0 0</pose>
-        <name>in_front_of</name>
       </virtual_volume>
-      <name>in_front_of</name>
     </link>
     <static>true</static>
-    <name>rwc2018/fridge</name>
   </model>
 </sdf>

--- a/models/rwc2018/hatstand/model.sdf
+++ b/models/rwc2018/hatstand/model.sdf
@@ -8,7 +8,6 @@
             <size>0.4 0.4 1.7</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -16,10 +15,8 @@
             <size>0.4 0.4 1.7</size>
           </box>
         </geometry>
-        <name>1</name>
       </visual>
       <pose>0 0 0.85 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="on_top_of">
       <virtual_volume name="on_top_of">
@@ -29,9 +26,7 @@
           </box>
         </geometry>
         <pose>0.0 0.0 1.845 0 0 0</pose>
-        <name>on_top_of</name>
       </virtual_volume>
-      <name>on_top_of</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
@@ -41,11 +36,8 @@
           </box>
         </geometry>
         <pose>0.7 0.0 0.005 0 0 0</pose>
-        <name>in_front_of</name>
       </virtual_volume>
-      <name>in_front_of</name>
     </link>
     <static>true</static>
-    <name>rwc2018/hatstand</name>
   </model>
 </sdf>

--- a/models/rwc2018/model.sdf
+++ b/models/rwc2018/model.sdf
@@ -4,7 +4,6 @@
     <light name="sun" type="directional">
       <direction>0.5 0.1 -0.9</direction>
       <pose>0 0 10 0 0 0</pose>
-      <name>sun</name>
       <specular>0.2 0.2 0.2 1</specular>
       <cast_shadows>true</cast_shadows>
       <diffuse>0.8 0.8 0.8 1</diffuse>
@@ -18,77 +17,62 @@
     <model name="initial_pose" type="waypoint">
       <pose>-11.0 8.5 0 0 0 0.0</pose>
       <static>true</static>
-      <name>initial_pose</name>
     </model>
     <model name="registration_table1" type="waypoint">
       <pose>-2.5 3.5 0 0 0 -1.57079632679</pose>
       <static>true</static>
-      <name>registration_table1</name>
     </model>
     <model name="registration_table2" type="waypoint">
       <pose>-3.5 4.5 0 0 0 -1.57079632679</pose>
       <static>true</static>
-      <name>registration_table2</name>
     </model>
     <model name="registration_table3" type="waypoint">
       <pose>-4.5 5.5 0 0 0 -1.57079632679</pose>
       <static>true</static>
-      <name>registration_table3</name>
     </model>
     <model name="exit_1_rips" type="waypoint">
       <pose>0.0 -1.2 0 0 0 -1.57079632679</pose>
       <static>true</static>
-      <name>exit_1_rips</name>
     </model>
     <model name="exit_2_rips" type="waypoint">
       <pose>0.0 -0.8 0 0 0 -1.57079632679</pose>
       <static>true</static>
-      <name>exit_2_rips</name>
     </model>
     <model name="exit_3_rips" type="waypoint">
       <pose>0.0 -0.4 0 0 0 -1.57079632679</pose>
       <static>true</static>
-      <name>exit_3_rips</name>
     </model>
     <model name="help_me_carry_starting_point" type="waypoint">
       <pose>-5.5 7.0 0 0 0 0.0</pose>
       <static>true</static>
-      <name>help_me_carry_starting_point</name>
     </model>
     <model name="gpsr_starting_point" type="waypoint">
       <pose>-5.5 7.0 0 0 0 0.0</pose>
       <static>true</static>
-      <name>gpsr_starting_point</name>
     </model>
     <model name="gpsr_meeting_point" type="waypoint">
       <pose>-5.5 7.0 0 0 0 0.0</pose>
       <static>true</static>
-      <name>gpsr_meeting_point</name>
     </model>
     <model name="gpsr_exit_door" type="waypoint">
       <pose>0.0 -1.2 0 0 0 -1.57079632679</pose>
       <static>true</static>
-      <name>gpsr_exit_door</name>
     </model>
     <model name="gpsr_entrance" type="waypoint">
       <pose>-9.0 8.0 0 0 0 3.14</pose>
       <static>true</static>
-      <name>gpsr_entrance</name>
     </model>
     <model name="eegpsr_starting_point1" type="waypoint">
       <pose>-4.25 8.5 0 0 0 -1.57079632679</pose>
       <static>true</static>
-      <name>eegpsr_starting_point1</name>
     </model>
     <model name="eegpsr_starting_point2" type="waypoint">
       <pose>-6 0.75 0 0 0 1.57079632679</pose>
       <static>true</static>
-      <name>eegpsr_starting_point2</name>
     </model>
     <model name="door" type="waypoint">
       <pose>-9.5 8.5 0 0 0 3.14159265359</pose>
       <static>true</static>
-      <name>door</name>
     </model>
     <model name="corridor" type="room">
       <link name="in">
@@ -99,13 +83,10 @@
             </box>
           </geometry>
           <pose>2.0 -0.5 1.005 0 0 0</pose>
-          <name>in</name>
         </virtual_volume>
-        <name>in</name>
       </link>
       <pose>-10.5 8.5 0 0 0 0</pose>
       <static>true</static>
-      <name>corridor</name>
     </model>
     <model name="kitchen" type="room">
       <link name="in">
@@ -116,13 +97,10 @@
             </box>
           </geometry>
           <pose>-0.65 1.0 1.005 0 0 0</pose>
-          <name>in</name>
         </virtual_volume>
-        <name>in</name>
       </link>
       <pose>-4.0 6.0 0 0 0 0</pose>
       <static>true</static>
-      <name>kitchen</name>
     </model>
     <model name="bedroom" type="room">
       <link name="in">
@@ -133,13 +111,10 @@
             </box>
           </geometry>
           <pose>0.75 0.25 1.005 0 0 0</pose>
-          <name>in</name>
         </virtual_volume>
-        <name>in</name>
       </link>
       <pose>-1.0 7.0 0 0 0 0</pose>
       <static>true</static>
-      <name>bedroom</name>
     </model>
     <model name="dining_room" type="room">
       <link name="in">
@@ -150,13 +125,10 @@
             </box>
           </geometry>
           <pose>-0.5 -0.5 1.005 0 0 0</pose>
-          <name>in</name>
         </virtual_volume>
-        <name>in</name>
       </link>
       <pose>-4.0 3.0 0 0 0 0</pose>
       <static>true</static>
-      <name>dining_room</name>
     </model>
     <model name="living_room" type="room">
       <link name="in">
@@ -167,85 +139,82 @@
             </box>
           </geometry>
           <pose>0.5 -0.5 1.005 0 0 0</pose>
-          <name>in</name>
         </virtual_volume>
-        <name>in</name>
       </link>
       <pose>-1.0 3.0 0 0 0 0</pose>
       <static>true</static>
-      <name>living_room</name>
     </model>
-    <include name="floor">
+    <include>
       <pose>0 0 0 0 0 0</pose>
       <name>floor</name>
       <uri>model://floor</uri>
     </include>
-    <include name="walls">
+    <include>
       <pose>0 0 0 0 0 0</pose>
       <name>walls</name>
       <uri>model://rwc2018/walls</uri>
     </include>
-    <include name="bed">
+    <include>
       <pose>0.68 7.9 0.0 0 0 -1.57079632679</pose>
       <name>bed</name>
       <uri>model://rwc2018/bed</uri>
     </include>
-    <include name="side_table">
+    <include>
       <pose>-0.45 8.68 0.0 0 0 -1.57079632679</pose>
       <name>side_table</name>
       <uri>model://rwc2018/sidetable</uri>
     </include>
-    <include name="desk">
+    <include>
       <pose>1.11 5.8 0.0 0 0 3.14159265359</pose>
       <name>desk</name>
       <uri>model://rwc2018/desk</uri>
     </include>
-    <include name="bookcase">
+    <include>
       <pose>-1.46 0.24 0.0 0 0 1.57079632679</pose>
       <name>bookcase</name>
       <uri>model://rwc2018/bookcase</uri>
     </include>
-    <include name="cupboard">
+    <include>
       <pose>-2.69 6.45 0.0 0 0 3.14159265359</pose>
       <name>cupboard</name>
       <uri>model://rwc2018/cupboard</uri>
     </include>
-    <include name="storage_table">
+    <include>
       <pose>-2.82 5.73 0.0 0 0 3.14159265359</pose>
       <name>storage_table</name>
       <uri>model://rwc2018/sidetable</uri>
     </include>
-    <include name="dining_table">
+    <include>
       <pose>-4.4 2.1 0.0 0 0 1.57079632679</pose>
       <name>dining_table</name>
       <uri>model://rwc2018/diningtable</uri>
     </include>
-    <include name="counter">
+    <include>
       <pose>-5.7 4.3 0.0 0 0 1.57079632679</pose>
       <name>counter</name>
       <uri>model://rwc2018/counter</uri>
     </include>
-    <include name="dishwasher">
+    <include>
       <pose>-5.22 4.3 0.0 0 0 1.57079632679</pose>
       <name>dishwasher</name>
       <uri>model://rwc2018/dishwasher</uri>
     </include>
-    <include name="fridge">
+    <include>
       <pose>-5.98 4.36 0.0 0 0 1.57079632679</pose>
       <name>fridge</name>
       <uri>model://rwc2018/fridge</uri>
     </include>
-    <include name="sink">
+    <include>
       <pose>-4.64 4.3 0.0 0 0 1.57079632679</pose>
       <name>sink</name>
       <uri>model://rwc2018/sink</uri>
     </include>
-    <include name="end_table">
+    <include>
       <pose>-0.3 2.8 0.0 0 0 1.57079632679</pose>
       <name>end_table</name>
       <uri>model://rwc2018/endtable</uri>
     </include>
-    <include name="couch">
+    <include>
       <pose>0.9 2.8 0.0 0 0 3.14159265359</pose>
       <name>couch</name>
       <uri>model://rwc2018/couch</uri>
@@ -262,6 +231,5 @@
         </solver>
       </ode>
     </physics>
-    <name>rwc2018</name>
   </world>
 </sdf>

--- a/models/rwc2018/planter/model.sdf
+++ b/models/rwc2018/planter/model.sdf
@@ -8,7 +8,6 @@
             <size>0.3 0.3 0.46</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -16,10 +15,8 @@
             <size>0.3 0.3 0.46</size>
           </box>
         </geometry>
-        <name>1</name>
       </visual>
       <pose>0 0 0.23 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="on_top_of">
       <virtual_volume name="on_top_of">
@@ -29,9 +26,7 @@
           </box>
         </geometry>
         <pose>0.0 0.0 0.605 0 0 0</pose>
-        <name>on_top_of</name>
       </virtual_volume>
-      <name>on_top_of</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
@@ -41,11 +36,8 @@
           </box>
         </geometry>
         <pose>0.65 0.0 0.005 0 0 0</pose>
-        <name>in_front_of</name>
       </virtual_volume>
-      <name>in_front_of</name>
     </link>
     <static>true</static>
-    <name>rwc2018/planter</name>
   </model>
 </sdf>

--- a/models/rwc2018/sidetable/model.sdf
+++ b/models/rwc2018/sidetable/model.sdf
@@ -8,7 +8,6 @@
             <size>0.55 0.55 0.05</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -16,10 +15,8 @@
             <size>0.55 0.55 0.05</size>
           </box>
         </geometry>
-        <name>1</name>
       </visual>
       <pose>0 0 0.425 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="2">
       <collision name="2">
@@ -28,7 +25,6 @@
             <size>0.05 0.05 0.4</size>
           </box>
         </geometry>
-        <name>2</name>
       </collision>
       <visual name="2">
         <geometry>
@@ -36,10 +32,8 @@
             <size>0.05 0.05 0.4</size>
           </box>
         </geometry>
-        <name>2</name>
       </visual>
       <pose>-0.25 -0.25 0.2 0 0 0</pose>
-      <name>2</name>
     </link>
     <link name="3">
       <collision name="3">
@@ -48,7 +42,6 @@
             <size>0.05 0.05 0.4</size>
           </box>
         </geometry>
-        <name>3</name>
       </collision>
       <visual name="3">
         <geometry>
@@ -56,10 +49,8 @@
             <size>0.05 0.05 0.4</size>
           </box>
         </geometry>
-        <name>3</name>
       </visual>
       <pose>0.25 -0.25 0.2 0 0 0</pose>
-      <name>3</name>
     </link>
     <link name="4">
       <collision name="4">
@@ -68,7 +59,6 @@
             <size>0.05 0.05 0.4</size>
           </box>
         </geometry>
-        <name>4</name>
       </collision>
       <visual name="4">
         <geometry>
@@ -76,10 +66,8 @@
             <size>0.05 0.05 0.4</size>
           </box>
         </geometry>
-        <name>4</name>
       </visual>
       <pose>-0.25 0.25 0.2 0 0 0</pose>
-      <name>4</name>
     </link>
     <link name="5">
       <collision name="5">
@@ -88,7 +76,6 @@
             <size>0.05 0.05 0.4</size>
           </box>
         </geometry>
-        <name>5</name>
       </collision>
       <visual name="5">
         <geometry>
@@ -96,10 +83,8 @@
             <size>0.05 0.05 0.4</size>
           </box>
         </geometry>
-        <name>5</name>
       </visual>
       <pose>0.25 0.25 0.2 0 0 0</pose>
-      <name>5</name>
     </link>
     <link name="on_top_of">
       <virtual_volume name="on_top_of">
@@ -109,9 +94,7 @@
           </box>
         </geometry>
         <pose>0.0 0.0 0.595 0 0 0</pose>
-        <name>on_top_of</name>
       </virtual_volume>
-      <name>on_top_of</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
@@ -121,9 +104,7 @@
           </box>
         </geometry>
         <pose>0.8125 0.0 0.005 0 0 0</pose>
-        <name>in_front_of</name>
       </virtual_volume>
-      <name>in_front_of</name>
     </link>
     <link name="on_right_of">
       <virtual_volume name="on_right_of">
@@ -133,9 +114,7 @@
           </box>
         </geometry>
         <pose>0.8125 0.0 0.005 0 0 0</pose>
-        <name>on_right_of</name>
       </virtual_volume>
-      <name>on_right_of</name>
     </link>
     <link name="in_back_of">
       <virtual_volume name="in_back_of">
@@ -145,11 +124,8 @@
           </box>
         </geometry>
         <pose>0.8125 0.0 0.005 0 0 0</pose>
-        <name>in_back_of</name>
       </virtual_volume>
-      <name>in_back_of</name>
     </link>
     <static>true</static>
-    <name>rwc2018/sidetable</name>
   </model>
 </sdf>

--- a/models/rwc2018/sink/model.sdf
+++ b/models/rwc2018/sink/model.sdf
@@ -8,7 +8,6 @@
             <size>0.62 0.46 0.37</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -16,10 +15,8 @@
             <size>0.62 0.46 0.37</size>
           </box>
         </geometry>
-        <name>1</name>
       </visual>
       <pose>0 0 0.635 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="2">
       <collision name="2">
@@ -28,7 +25,6 @@
             <size>0.06 0.06 0.45</size>
           </box>
         </geometry>
-        <name>2</name>
       </collision>
       <visual name="2">
         <geometry>
@@ -36,10 +32,8 @@
             <size>0.06 0.06 0.45</size>
           </box>
         </geometry>
-        <name>2</name>
       </visual>
       <pose>-0.2 -0.12 0.225 0 0 0</pose>
-      <name>2</name>
     </link>
     <link name="3">
       <collision name="3">
@@ -48,7 +42,6 @@
             <size>0.06 0.06 0.45</size>
           </box>
         </geometry>
-        <name>3</name>
       </collision>
       <visual name="3">
         <geometry>
@@ -56,10 +49,8 @@
             <size>0.06 0.06 0.45</size>
           </box>
         </geometry>
-        <name>3</name>
       </visual>
       <pose>-0.2 0.12 0.225 0 0 0</pose>
-      <name>3</name>
     </link>
     <link name="4">
       <collision name="4">
@@ -68,7 +59,6 @@
             <size>0.06 0.06 0.45</size>
           </box>
         </geometry>
-        <name>4</name>
       </collision>
       <visual name="4">
         <geometry>
@@ -76,10 +66,8 @@
             <size>0.06 0.06 0.45</size>
           </box>
         </geometry>
-        <name>4</name>
       </visual>
       <pose>0.2 -0.12 0.225 0 0 0</pose>
-      <name>4</name>
     </link>
     <link name="5">
       <collision name="5">
@@ -88,7 +76,6 @@
             <size>0.06 0.06 0.45</size>
           </box>
         </geometry>
-        <name>5</name>
       </collision>
       <visual name="5">
         <geometry>
@@ -96,10 +83,8 @@
             <size>0.06 0.06 0.45</size>
           </box>
         </geometry>
-        <name>5</name>
       </visual>
       <pose>0.2 0.12 0.225 0 0 0</pose>
-      <name>5</name>
     </link>
     <link name="on_top_of">
       <virtual_volume name="on_top_of">
@@ -109,9 +94,7 @@
           </box>
         </geometry>
         <pose>0.0 0.0 0.965 0 0 0</pose>
-        <name>on_top_of</name>
       </virtual_volume>
-      <name>on_top_of</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
@@ -121,11 +104,8 @@
           </box>
         </geometry>
         <pose>0.8 0.0 0.005 0 0 0</pose>
-        <name>in_front_of</name>
       </virtual_volume>
-      <name>in_front_of</name>
     </link>
     <static>true</static>
-    <name>rwc2018/sink</name>
   </model>
 </sdf>

--- a/models/rwc2018/walls/model.sdf
+++ b/models/rwc2018/walls/model.sdf
@@ -8,7 +8,6 @@
             <uri>model://rwc2018/walls/map_rwc2018_clean_small.stl</uri>
           </mesh>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -16,12 +15,9 @@
             <uri>model://rwc2018/walls/map_rwc2018_clean_small.stl</uri>
           </mesh>
         </geometry>
-        <name>1</name>
       </visual>
       <pose>0 0 0 0 0 0</pose>
-      <name>1</name>
     </link>
     <static>true</static>
-    <name>rwc2018/walls</name>
   </model>
 </sdf>

--- a/models/rwc2019/armchair/model.sdf
+++ b/models/rwc2019/armchair/model.sdf
@@ -8,7 +8,6 @@
             <size>0.5 0.66 0.44</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -16,10 +15,8 @@
             <size>0.5 0.66 0.44</size>
           </box>
         </geometry>
-        <name>1</name>
       </visual>
       <pose>0.0 0.0 0.22 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="back">
       <collision name="back">
@@ -28,7 +25,6 @@
             <size>0.25 0.66 0.75</size>
           </box>
         </geometry>
-        <name>back</name>
       </collision>
       <visual name="back">
         <geometry>
@@ -36,10 +32,8 @@
             <size>0.25 0.66 0.75</size>
           </box>
         </geometry>
-        <name>back</name>
       </visual>
       <pose>-0.375 0.0 0.375 0 0 0</pose>
-      <name>back</name>
     </link>
     <link name="on_top_of">
       <virtual_volume name="on_top_of">
@@ -49,9 +43,7 @@
           </box>
         </geometry>
         <pose>0.02 0.0 0.685 0 0 0</pose>
-        <name>on_top_of</name>
       </virtual_volume>
-      <name>on_top_of</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
@@ -61,11 +53,8 @@
           </box>
         </geometry>
         <pose>0.75 0.0 0.005 0 0 0</pose>
-        <name>in_front_of</name>
       </virtual_volume>
-      <name>in_front_of</name>
     </link>
     <static>true</static>
-    <name>rwc2019/armchair</name>
   </model>
 </sdf>

--- a/models/rwc2019/bed/model.sdf
+++ b/models/rwc2019/bed/model.sdf
@@ -8,7 +8,6 @@
             <size>0.76 2.42 0.1</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -16,10 +15,8 @@
             <size>0.76 2.42 0.1</size>
           </box>
         </geometry>
-        <name>1</name>
       </visual>
       <pose>0.0 0.0 0.75 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="2">
       <collision name="2">
@@ -28,7 +25,6 @@
             <size>0.1 2.42 0.7</size>
           </box>
         </geometry>
-        <name>2</name>
       </collision>
       <visual name="2">
         <geometry>
@@ -36,10 +32,8 @@
             <size>0.1 2.42 0.7</size>
           </box>
         </geometry>
-        <name>2</name>
       </visual>
       <pose>0.33 0.0 0.45 0 0 0</pose>
-      <name>2</name>
     </link>
     <link name="on_top_of">
       <virtual_volume name="on_top_of">
@@ -49,9 +43,7 @@
           </box>
         </geometry>
         <pose>0.02 0.0 0.945 0 0 0</pose>
-        <name>on_top_of</name>
       </virtual_volume>
-      <name>on_top_of</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
@@ -61,11 +53,8 @@
           </box>
         </geometry>
         <pose>0.88 0.0 0.005 0 0 0</pose>
-        <name>in_front_of</name>
       </virtual_volume>
-      <name>in_front_of</name>
     </link>
     <static>true</static>
-    <name>rwc2019/bed</name>
   </model>
 </sdf>

--- a/models/rwc2019/bedroom_chest/model.sdf
+++ b/models/rwc2019/bedroom_chest/model.sdf
@@ -8,7 +8,6 @@
             <size>0.49 1.01 0.75</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -16,10 +15,8 @@
             <size>0.49 1.01 0.75</size>
           </box>
         </geometry>
-        <name>1</name>
       </visual>
       <pose>0.0 0.0 0.375 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="on_top_of">
       <virtual_volume name="on_top_of">
@@ -29,9 +26,7 @@
           </box>
         </geometry>
         <pose>0.02 0.0 0.895 0 0 0</pose>
-        <name>on_top_of</name>
       </virtual_volume>
-      <name>on_top_of</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
@@ -41,11 +36,8 @@
           </box>
         </geometry>
         <pose>0.745 0.0 0.005 0 0 0</pose>
-        <name>in_front_of</name>
       </virtual_volume>
-      <name>in_front_of</name>
     </link>
     <static>true</static>
-    <name>rwc2019/bedroom_chest</name>
   </model>
 </sdf>

--- a/models/rwc2019/coat_hanger/model.sdf
+++ b/models/rwc2019/coat_hanger/model.sdf
@@ -8,7 +8,6 @@
             <size>0.35 0.35 0.05</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -16,10 +15,8 @@
             <size>0.35 0.35 0.05</size>
           </box>
         </geometry>
-        <name>1</name>
       </visual>
       <pose>0.0 0.0 0.025 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="2">
       <collision name="2">
@@ -28,7 +25,6 @@
             <size>0.05 0.05 1.3</size>
           </box>
         </geometry>
-        <name>2</name>
       </collision>
       <visual name="2">
         <geometry>
@@ -36,10 +32,8 @@
             <size>0.05 0.05 1.3</size>
           </box>
         </geometry>
-        <name>2</name>
       </visual>
       <pose>0.0 0.0 0.65 0 0 0</pose>
-      <name>2</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
@@ -49,11 +43,8 @@
           </box>
         </geometry>
         <pose>0.675 0.0 0.005 0 0 0</pose>
-        <name>in_front_of</name>
       </virtual_volume>
-      <name>in_front_of</name>
     </link>
     <static>true</static>
-    <name>rwc2019/coat_hanger</name>
   </model>
 </sdf>

--- a/models/rwc2019/coffee_table/model.sdf
+++ b/models/rwc2019/coffee_table/model.sdf
@@ -8,7 +8,6 @@
             <size>0.9 0.45 0.043</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -16,10 +15,8 @@
             <size>0.9 0.45 0.043</size>
           </box>
         </geometry>
-        <name>1</name>
       </visual>
       <pose>0.0 0.0 0.4085 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="2">
       <collision name="2">
@@ -28,7 +25,6 @@
             <size>0.043 0.043 0.387</size>
           </box>
         </geometry>
-        <name>2</name>
       </collision>
       <visual name="2">
         <geometry>
@@ -36,10 +32,8 @@
             <size>0.043 0.043 0.387</size>
           </box>
         </geometry>
-        <name>2</name>
       </visual>
       <pose>-0.4285 -0.2035 0.1935 0 0 0</pose>
-      <name>2</name>
     </link>
     <link name="3">
       <collision name="3">
@@ -48,7 +42,6 @@
             <size>0.043 0.043 0.387</size>
           </box>
         </geometry>
-        <name>3</name>
       </collision>
       <visual name="3">
         <geometry>
@@ -56,10 +49,8 @@
             <size>0.043 0.043 0.387</size>
           </box>
         </geometry>
-        <name>3</name>
       </visual>
       <pose>0.4285 -0.2035 0.1935 0 0 0</pose>
-      <name>3</name>
     </link>
     <link name="4">
       <collision name="4">
@@ -68,7 +59,6 @@
             <size>0.043 0.043 0.387</size>
           </box>
         </geometry>
-        <name>4</name>
       </collision>
       <visual name="4">
         <geometry>
@@ -76,10 +66,8 @@
             <size>0.043 0.043 0.387</size>
           </box>
         </geometry>
-        <name>4</name>
       </visual>
       <pose>-0.4285 0.2035 0.1935 0 0 0</pose>
-      <name>4</name>
     </link>
     <link name="5">
       <collision name="5">
@@ -88,7 +76,6 @@
             <size>0.043 0.043 0.387</size>
           </box>
         </geometry>
-        <name>5</name>
       </collision>
       <visual name="5">
         <geometry>
@@ -96,10 +83,8 @@
             <size>0.043 0.043 0.387</size>
           </box>
         </geometry>
-        <name>5</name>
       </visual>
       <pose>0.4285 0.2035 0.1935 0 0 0</pose>
-      <name>5</name>
     </link>
     <link name="on_top_of">
       <virtual_volume name="on_top_of">
@@ -109,9 +94,7 @@
           </box>
         </geometry>
         <pose>0.0 0.0 0.575 0 0 0</pose>
-        <name>on_top_of</name>
       </virtual_volume>
-      <name>on_top_of</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
@@ -121,11 +104,8 @@
           </box>
         </geometry>
         <pose>0.0 -0.725 0.005 0 0 0</pose>
-        <name>in_front_of</name>
       </virtual_volume>
-      <name>in_front_of</name>
     </link>
     <static>true</static>
-    <name>rwc2019/coffee_table</name>
   </model>
 </sdf>

--- a/models/rwc2019/couch/model.sdf
+++ b/models/rwc2019/couch/model.sdf
@@ -8,7 +8,6 @@
             <size>0.5 1.36 0.44</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -16,10 +15,8 @@
             <size>0.5 1.36 0.44</size>
           </box>
         </geometry>
-        <name>1</name>
       </visual>
       <pose>0.0 0.0 0.22 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="back">
       <collision name="back">
@@ -28,7 +25,6 @@
             <size>0.25 1.36 0.75</size>
           </box>
         </geometry>
-        <name>back</name>
       </collision>
       <visual name="back">
         <geometry>
@@ -36,10 +32,8 @@
             <size>0.25 1.36 0.75</size>
           </box>
         </geometry>
-        <name>back</name>
       </visual>
       <pose>-0.375 0.0 0.375 0 0 0</pose>
-      <name>back</name>
     </link>
     <link name="on_top_of">
       <virtual_volume name="on_top_of">
@@ -49,9 +43,7 @@
           </box>
         </geometry>
         <pose>0.02 0.0 0.685 0 0 0</pose>
-        <name>on_top_of</name>
       </virtual_volume>
-      <name>on_top_of</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
@@ -61,11 +53,8 @@
           </box>
         </geometry>
         <pose>0.75 0.0 0.005 0 0 0</pose>
-        <name>in_front_of</name>
       </virtual_volume>
-      <name>in_front_of</name>
     </link>
     <static>true</static>
-    <name>rwc2019/couch</name>
   </model>
 </sdf>

--- a/models/rwc2019/desk/model.sdf
+++ b/models/rwc2019/desk/model.sdf
@@ -8,7 +8,6 @@
             <size>1.2 0.6 0.027</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -16,10 +15,8 @@
             <size>1.2 0.6 0.027</size>
           </box>
         </geometry>
-        <name>1</name>
       </visual>
       <pose>0.0 0.0 0.7185 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="2">
       <collision name="2">
@@ -28,7 +25,6 @@
             <size>0.015 0.56 0.705</size>
           </box>
         </geometry>
-        <name>2</name>
       </collision>
       <visual name="2">
         <geometry>
@@ -36,10 +32,8 @@
             <size>0.015 0.56 0.705</size>
           </box>
         </geometry>
-        <name>2</name>
       </visual>
       <pose>-0.5725 0.0 0.3525 0 0 0</pose>
-      <name>2</name>
     </link>
     <link name="3">
       <collision name="3">
@@ -48,7 +42,6 @@
             <size>0.015 0.56 0.705</size>
           </box>
         </geometry>
-        <name>3</name>
       </collision>
       <visual name="3">
         <geometry>
@@ -56,10 +49,8 @@
             <size>0.015 0.56 0.705</size>
           </box>
         </geometry>
-        <name>3</name>
       </visual>
       <pose>0.5725 0.0 0.3525 0 0 0</pose>
-      <name>3</name>
     </link>
     <link name="on_top_of">
       <virtual_volume name="on_top_of">
@@ -69,9 +60,7 @@
           </box>
         </geometry>
         <pose>0.02 0.0 0.877 0 0 0</pose>
-        <name>on_top_of</name>
       </virtual_volume>
-      <name>on_top_of</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
@@ -81,11 +70,8 @@
           </box>
         </geometry>
         <pose>0.0 0.8 0.005 0 0 0</pose>
-        <name>in_front_of</name>
       </virtual_volume>
-      <name>in_front_of</name>
     </link>
     <static>true</static>
-    <name>rwc2019/desk</name>
   </model>
 </sdf>

--- a/models/rwc2019/dishwasher/model.sdf
+++ b/models/rwc2019/dishwasher/model.sdf
@@ -8,7 +8,6 @@
             <size>0.6 0.6 0.84</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -16,10 +15,8 @@
             <size>0.6 0.6 0.84</size>
           </box>
         </geometry>
-        <name>1</name>
       </visual>
       <pose>0.0 0.0 0.42 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="on_top_of">
       <virtual_volume name="on_top_of">
@@ -29,9 +26,7 @@
           </box>
         </geometry>
         <pose>0.0 0.0 0.985 0 0 0</pose>
-        <name>on_top_of</name>
       </virtual_volume>
-      <name>on_top_of</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
@@ -41,11 +36,8 @@
           </box>
         </geometry>
         <pose>0.82 0.0 0.005 0 0 0</pose>
-        <name>in_front_of</name>
       </virtual_volume>
-      <name>in_front_of</name>
     </link>
     <static>true</static>
-    <name>rwc2019/dishwasher</name>
   </model>
 </sdf>

--- a/models/rwc2019/display_cabinet/model.sdf
+++ b/models/rwc2019/display_cabinet/model.sdf
@@ -8,7 +8,6 @@
             <size>0.513 2.0 0.75</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -16,10 +15,8 @@
             <size>0.513 2.0 0.75</size>
           </box>
         </geometry>
-        <name>1</name>
       </visual>
       <pose>0.0 0.0 0.375 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="on_top_of">
       <virtual_volume name="on_top_of">
@@ -29,9 +26,7 @@
           </box>
         </geometry>
         <pose>0.0 -0.48 0.895 0 0 0</pose>
-        <name>on_top_of</name>
       </virtual_volume>
-      <name>on_top_of</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
@@ -41,11 +36,8 @@
           </box>
         </geometry>
         <pose>0.7565 -0.8 0.005 0 0 0</pose>
-        <name>in_front_of</name>
       </virtual_volume>
-      <name>in_front_of</name>
     </link>
     <static>true</static>
-    <name>rwc2019/display_cabinet</name>
   </model>
 </sdf>

--- a/models/rwc2019/fridge/model.sdf
+++ b/models/rwc2019/fridge/model.sdf
@@ -8,7 +8,6 @@
             <size>0.635 0.6 1.63</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -16,10 +15,8 @@
             <size>0.635 0.6 1.63</size>
           </box>
         </geometry>
-        <name>1</name>
       </visual>
       <pose>0.0 0.0 0.815 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="on_top_of">
       <virtual_volume name="on_top_of">
@@ -29,9 +26,7 @@
           </box>
         </geometry>
         <pose>0.02 0.0 1.775 0 0 0</pose>
-        <name>on_top_of</name>
       </virtual_volume>
-      <name>on_top_of</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
@@ -41,11 +36,8 @@
           </box>
         </geometry>
         <pose>0.8175 0.0 0.005 0 0 0</pose>
-        <name>in_front_of</name>
       </virtual_volume>
-      <name>in_front_of</name>
     </link>
     <static>true</static>
-    <name>rwc2019/fridge</name>
   </model>
 </sdf>

--- a/models/rwc2019/island/model.sdf
+++ b/models/rwc2019/island/model.sdf
@@ -8,7 +8,6 @@
             <size>0.51 1.006 0.753</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -16,10 +15,8 @@
             <size>0.51 1.006 0.753</size>
           </box>
         </geometry>
-        <name>1</name>
       </visual>
       <pose>0.0 0.0 0.3765 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="on_top_of">
       <virtual_volume name="on_top_of">
@@ -29,9 +26,7 @@
           </box>
         </geometry>
         <pose>0.02 0.0 0.898 0 0 0</pose>
-        <name>on_top_of</name>
       </virtual_volume>
-      <name>on_top_of</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
@@ -41,11 +36,8 @@
           </box>
         </geometry>
         <pose>0.755 0.0 0.005 0 0 0</pose>
-        <name>in_front_of</name>
       </virtual_volume>
-      <name>in_front_of</name>
     </link>
     <static>true</static>
-    <name>rwc2019/island</name>
   </model>
 </sdf>

--- a/models/rwc2019/kitchen_cabinet/model.sdf
+++ b/models/rwc2019/kitchen_cabinet/model.sdf
@@ -8,7 +8,6 @@
             <size>0.34 0.018 1.98</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -16,10 +15,8 @@
             <size>0.34 0.018 1.98</size>
           </box>
         </geometry>
-        <name>1</name>
       </visual>
       <pose>0.0 -0.441 0.99 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="2">
       <collision name="2">
@@ -28,7 +25,6 @@
             <size>0.34 0.018 1.98</size>
           </box>
         </geometry>
-        <name>2</name>
       </collision>
       <visual name="2">
         <geometry>
@@ -36,10 +32,8 @@
             <size>0.34 0.018 1.98</size>
           </box>
         </geometry>
-        <name>2</name>
       </visual>
       <pose>0.0 0.441 0.99 0 0 0</pose>
-      <name>2</name>
     </link>
     <link name="3">
       <collision name="3">
@@ -48,7 +42,6 @@
             <size>0.018 0.9 1.98</size>
           </box>
         </geometry>
-        <name>3</name>
       </collision>
       <visual name="3">
         <geometry>
@@ -56,10 +49,8 @@
             <size>0.018 0.9 1.98</size>
           </box>
         </geometry>
-        <name>3</name>
       </visual>
       <pose>-0.161 0.0 0.99 0 0 0</pose>
-      <name>3</name>
     </link>
     <link name="4">
       <collision name="4">
@@ -68,7 +59,6 @@
             <size>0.322 0.864 0.07</size>
           </box>
         </geometry>
-        <name>4</name>
       </collision>
       <visual name="4">
         <geometry>
@@ -76,10 +66,8 @@
             <size>0.322 0.864 0.07</size>
           </box>
         </geometry>
-        <name>4</name>
       </visual>
       <pose>0.009 0.0 1.945 0 0 0</pose>
-      <name>4</name>
     </link>
     <link name="5">
       <collision name="5">
@@ -88,7 +76,6 @@
             <size>0.322 0.864 0.7</size>
           </box>
         </geometry>
-        <name>5</name>
       </collision>
       <visual name="5">
         <geometry>
@@ -96,10 +83,8 @@
             <size>0.322 0.864 0.7</size>
           </box>
         </geometry>
-        <name>5</name>
       </visual>
       <pose>0.009 0.0 0.47 0 0 0</pose>
-      <name>5</name>
     </link>
     <link name="6">
       <collision name="6">
@@ -108,7 +93,6 @@
             <size>0.322 0.864 0.018</size>
           </box>
         </geometry>
-        <name>6</name>
       </collision>
       <visual name="6">
         <geometry>
@@ -116,10 +100,8 @@
             <size>0.322 0.864 0.018</size>
           </box>
         </geometry>
-        <name>6</name>
       </visual>
       <pose>0.009 0.0 1.143 0 0 0</pose>
-      <name>6</name>
     </link>
     <link name="7">
       <collision name="7">
@@ -128,7 +110,6 @@
             <size>0.322 0.864 0.018</size>
           </box>
         </geometry>
-        <name>7</name>
       </collision>
       <visual name="7">
         <geometry>
@@ -136,10 +117,8 @@
             <size>0.322 0.864 0.018</size>
           </box>
         </geometry>
-        <name>7</name>
       </visual>
       <pose>0.009 0.0 1.419 0 0 0</pose>
-      <name>7</name>
     </link>
     <link name="8">
       <collision name="8">
@@ -148,7 +127,6 @@
             <size>0.322 0.864 0.018</size>
           </box>
         </geometry>
-        <name>8</name>
       </collision>
       <visual name="8">
         <geometry>
@@ -156,10 +134,8 @@
             <size>0.322 0.864 0.018</size>
           </box>
         </geometry>
-        <name>8</name>
       </visual>
       <pose>0.009 0.0 1.716 0 0 0</pose>
-      <name>8</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
@@ -169,9 +145,7 @@
           </box>
         </geometry>
         <pose>0.67 0.0 0.005 0 0 0</pose>
-        <name>in_front_of</name>
       </virtual_volume>
-      <name>in_front_of</name>
     </link>
     <link name="shelf1">
       <virtual_volume name="shelf1">
@@ -181,9 +155,7 @@
           </box>
         </geometry>
         <pose>0.029 0.0 0.965 0 0 0</pose>
-        <name>shelf1</name>
       </virtual_volume>
-      <name>shelf1</name>
     </link>
     <link name="shelf2">
       <virtual_volume name="shelf2">
@@ -193,9 +165,7 @@
           </box>
         </geometry>
         <pose>0.029 0.0 1.297 0 0 0</pose>
-        <name>shelf2</name>
       </virtual_volume>
-      <name>shelf2</name>
     </link>
     <link name="shelf3">
       <virtual_volume name="shelf3">
@@ -205,9 +175,8 @@
           </box>
         </geometry>
         <pose>0.029 0.0 1.573 0 0 0</pose>
-        <name>shelf3</name>
-      </virtual_volume>r
-      <name>shelf3</name>
+      </virtual_volume>
+      r
     </link>
     <link name="shelf4">
       <virtual_volume name="shelf4">
@@ -217,9 +186,7 @@
           </box>
         </geometry>
         <pose>0.029 0.0 1.82 0 0 0</pose>
-        <name>shelf4</name>
       </virtual_volume>
-      <name>shelf4</name>
     </link>
     <link name="on_top_of">
       <virtual_volume name="on_top_of">
@@ -229,11 +196,8 @@
           </box>
         </geometry>
         <pose>0.029 0.0 0.965 0 0 0</pose>
-        <name>on_top_of</name>
       </virtual_volume>
-      <name>on_top_of</name>
     </link>
     <static>true</static>
-    <name>rwc2019/kitchen_cabinet</name>
   </model>
 </sdf>

--- a/models/rwc2019/kitchen_table/model.sdf
+++ b/models/rwc2019/kitchen_table/model.sdf
@@ -8,7 +8,6 @@
             <size>0.8 0.8 0.008</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -16,10 +15,8 @@
             <size>0.8 0.8 0.008</size>
           </box>
         </geometry>
-        <name>1</name>
       </visual>
       <pose>0.0 0.0 0.756 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="2">
       <collision name="2">
@@ -28,7 +25,6 @@
             <size>0.05 0.05 0.752</size>
           </box>
         </geometry>
-        <name>2</name>
       </collision>
       <visual name="2">
         <geometry>
@@ -36,10 +32,8 @@
             <size>0.05 0.05 0.752</size>
           </box>
         </geometry>
-        <name>2</name>
       </visual>
       <pose>-0.305 -0.305 0.376 0 0 0</pose>
-      <name>2</name>
     </link>
     <link name="3">
       <collision name="3">
@@ -48,7 +42,6 @@
             <size>0.05 0.05 0.752</size>
           </box>
         </geometry>
-        <name>3</name>
       </collision>
       <visual name="3">
         <geometry>
@@ -56,10 +49,8 @@
             <size>0.05 0.05 0.752</size>
           </box>
         </geometry>
-        <name>3</name>
       </visual>
       <pose>0.305 -0.305 0.376 0 0 0</pose>
-      <name>3</name>
     </link>
     <link name="4">
       <collision name="4">
@@ -68,7 +59,6 @@
             <size>0.05 0.05 0.752</size>
           </box>
         </geometry>
-        <name>4</name>
       </collision>
       <visual name="4">
         <geometry>
@@ -76,10 +66,8 @@
             <size>0.05 0.05 0.752</size>
           </box>
         </geometry>
-        <name>4</name>
       </visual>
       <pose>-0.305 0.305 0.376 0 0 0</pose>
-      <name>4</name>
     </link>
     <link name="5">
       <collision name="5">
@@ -88,7 +76,6 @@
             <size>0.05 0.05 0.752</size>
           </box>
         </geometry>
-        <name>5</name>
       </collision>
       <visual name="5">
         <geometry>
@@ -96,10 +83,8 @@
             <size>0.05 0.05 0.752</size>
           </box>
         </geometry>
-        <name>5</name>
       </visual>
       <pose>0.305 0.305 0.376 0 0 0</pose>
-      <name>5</name>
     </link>
     <link name="on_top_of">
       <virtual_volume name="on_top_of">
@@ -109,9 +94,7 @@
           </box>
         </geometry>
         <pose>0.0 0.0 0.905 0 0 0</pose>
-        <name>on_top_of</name>
       </virtual_volume>
-      <name>on_top_of</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
@@ -121,9 +104,7 @@
           </box>
         </geometry>
         <pose>0.9 0.0 0.005 0 0 0</pose>
-        <name>in_front_of</name>
       </virtual_volume>
-      <name>in_front_of</name>
     </link>
     <link name="behind">
       <virtual_volume name="behind">
@@ -133,9 +114,7 @@
           </box>
         </geometry>
         <pose>-0.9 0.0 0.005 0 0 0</pose>
-        <name>behind</name>
       </virtual_volume>
-      <name>behind</name>
     </link>
     <link name="left_of">
       <virtual_volume name="left_of">
@@ -145,9 +124,7 @@
           </box>
         </geometry>
         <pose>0 -0.9 0.005 0 0 1.57</pose>
-        <name>left_of</name>
       </virtual_volume>
-      <name>left_of</name>
     </link>
     <link name="right_of">
       <virtual_volume name="right_of">
@@ -157,9 +134,7 @@
           </box>
         </geometry>
         <pose>0 0.9 0.005 0 0 1.57</pose>
-        <name>right_of</name>
       </virtual_volume>
-      <name>right_of</name>
     </link>
     <link name="in_front_of_close">
       <virtual_volume name="in_front_of_close">
@@ -169,9 +144,7 @@
           </box>
         </geometry>
         <pose>0.7 0.0 0.005 0 0 0</pose>
-        <name>in_front_of_clos</name>
       </virtual_volume>
-      <name>in_front_of_close</name>
     </link>
     <link name="behind_close">
       <virtual_volume name="behind_close">
@@ -181,9 +154,7 @@
           </box>
         </geometry>
         <pose>-0.7 0.0 0.005 0 0 0</pose>
-        <name>behind_clos</name>
       </virtual_volume>
-      <name>behind_close</name>
     </link>
     <link name="left_of_close">
       <virtual_volume name="left_of_close">
@@ -193,9 +164,7 @@
           </box>
         </geometry>
         <pose>0 -0.7 0.005 0 0 1.57</pose>
-        <name>left_of_clos</name>
       </virtual_volume>
-      <name>left_of_close</name>
     </link>
     <link name="right_of_close">
       <virtual_volume name="right_of_close">
@@ -205,11 +174,8 @@
           </box>
         </geometry>
         <pose>0 0.7 0.005 0 0 1.57</pose>
-        <name>right_of_clos</name>
       </virtual_volume>
-      <name>right_of_close</name>
     </link>
     <static>true</static>
-    <name>rwc2019/kitchen_table</name>
   </model>
 </sdf>

--- a/models/rwc2019/model.sdf
+++ b/models/rwc2019/model.sdf
@@ -4,7 +4,6 @@
     <light name="sun" type="directional">
       <direction>0.5 0.1 -0.9</direction>
       <pose>0 0 10 0 0 0</pose>
-      <name>sun</name>
       <specular>0.2 0.2 0.2 1</specular>
       <cast_shadows>true</cast_shadows>
       <diffuse>0.8 0.8 0.8 1</diffuse>
@@ -15,18 +14,16 @@
         <linear>0.01</linear>
       </attenuation>
     </light>
-    <include name="floor">
+    <include>
       <pose>0 0 0 0 0 0</pose>
       <name>floor</name>
       <uri>model://floor</uri>
     </include>
-    <include name="walls">
+    <include>
       <pose>0 0 0 0 0 0</pose>
       <name>walls</name>
       <uri>model://rwc2019/walls</uri>
     </include>
-
-    <!-- ROOMS -->
     <model name="office" type="room">
       <link name="in">
         <virtual_volume name="in">
@@ -36,13 +33,10 @@
             </box>
           </geometry>
           <pose>0.0 0.0 1.0 0 0 0</pose>
-          <name>in</name>
         </virtual_volume>
-        <name>in</name>
       </link>
       <pose>2.15542 -0.0369384 0 0 0 0</pose>
       <static>true</static>
-      <name>office</name>
     </model>
     <model name="living_room" type="room">
       <link name="in">
@@ -53,13 +47,10 @@
             </box>
           </geometry>
           <pose>0.0 0.25 1.0 0 0 0</pose>
-          <name>in</name>
         </virtual_volume>
-        <name>in</name>
       </link>
       <pose>6.13249 0.196431 0 0 0 0</pose>
       <static>true</static>
-      <name>living_room</name>
     </model>
     <model name="kitchen" type="room">
       <link name="in">
@@ -70,13 +61,10 @@
             </box>
           </geometry>
           <pose>0.0 0.25 1.0 0 0 0</pose>
-          <name>in</name>
         </virtual_volume>
-        <name>in</name>
       </link>
       <pose>6.13249 3.92289 0 0 0 0</pose>
       <static>true</static>
-      <name>kitchen</name>
     </model>
     <model name="bedroom" type="room">
       <link name="in">
@@ -87,274 +75,196 @@
             </box>
           </geometry>
           <pose>0.0 0.0 1.0 0 0 0</pose>
-          <name>in</name>
         </virtual_volume>
-        <name>in</name>
       </link>
       <pose>2.15542 3.692984223365 0 0 0 0</pose>
       <static>true</static>
-      <name>bedroom</name>
     </model>
-
-    <!-- WAYPOINTS -->
     <model name="initial_pose" type="waypoint">
       <pose>0.0 0.0 0 0 0 0</pose>
       <static>true</static>
-      <name>initial_pose</name>
     </model>
-    <model name="registration_table1" type="waypoint"><!-- ToDo: verify -->
+    <model name="registration_table1" type="waypoint">
       <pose>5.5 2.0 0 0 0 1.5707963267948966</pose>
       <static>true</static>
-      <name>registration_table1</name>
     </model>
-    <model name="registration_table2" type="waypoint"><!-- ToDo: verify -->
+    <model name="registration_table2" type="waypoint">
       <pose>5.5 1.25 0 0 0 1.5707963267948966</pose>
       <static>true</static>
-      <name>registration_table2</name>
     </model>
-    <model name="registration_table3" type="waypoint"><!-- ToDo: verify -->
+    <model name="registration_table3" type="waypoint">
       <pose>5.5 2.75 0 0 0 1.5707963267948966</pose>
       <static>true</static>
-      <name>registration_table3</name>
     </model>
-    <model name="exit_1_rips" type="waypoint"><!-- ToDo: verify -->
+    <model name="exit_1_rips" type="waypoint">
       <pose>7.0 7.5 0 0 0 1.5707963267948966</pose>
       <static>true</static>
-      <name>exit_1_rips</name>
     </model>
-    <model name="exit_2_rips" type="waypoint"><!-- ToDo: verify -->
+    <model name="exit_2_rips" type="waypoint">
       <pose>7.0 6.5 0 0 0 1.5707963267948966</pose>
       <static>true</static>
-      <name>exit_2_rips</name>
     </model>
-    <model name="exit_3_rips" type="waypoint"><!-- ToDo: verify -->
+    <model name="exit_3_rips" type="waypoint">
       <pose>7.0 6.0 0 0 0 1.5707963267948966</pose>
       <static>true</static>
-      <name>exit_3_rips</name>
     </model>
     <model name="serving_drinks_initial" type="waypoint">
       <pose>5.5 1.25 0 0 0 1.5707963267948966</pose>
       <static>true</static>
-      <name>serving_drinks_initial</name>
     </model>
-
     <model name="cleanup_initial" type="waypoint">
       <pose>2.0 0 0 0 0 0</pose>
       <static>true</static>
-      <name>cleanup_initial</name>
     </model>
-
-    <model name="receptionist_start" type="waypoint"><!-- ToDo: verify -->
+    <model name="receptionist_start" type="waypoint">
       <pose>3.0 1.0 0 0 0 -3.1415</pose>
       <static>true</static>
-      <name>receptionist_start</name>
     </model>
-    <model name="look_at_entry_door_wp" type="waypoint"><!-- ToDo: verify -->
+    <model name="look_at_entry_door_wp" type="waypoint">
       <pose>1.5 0.0 0 0 0 -3.1415</pose>
       <static>true</static>
-      <name>look_at_entry_door_wp</name>
     </model>
-     <model name="helper_take_out_garbage" type="waypoint"><!-- ToDo: verify -->
+    <model name="helper_take_out_garbage" type="waypoint">
       <pose>5 0.70 0 0 0 2.7</pose>
       <static>true</static>
-      <name>helper_take_out_garbage</name>
     </model>
-     <model name="take_out_garbage_drop_zone" type="waypoint"><!-- ToDo: verify -->
+    <model name="take_out_garbage_drop_zone" type="waypoint">
       <pose>6 6.55555 0 0 0 3.1415926535</pose>
       <static>true</static>
-      <name>take_out_garbage_drop_zone</name>
     </model>
-
-    <model name="find_mates_search" type="waypoint"><!-- ToDo: verify -->
+    <model name="find_mates_search" type="waypoint">
       <pose>4.5 0 0 0 0 0</pose>
       <static>true</static>
-      <name>find_mates_search</name>
     </model>
-
-    <model name="find_mates_operator_point" type="waypoint"><!-- ToDo: verify -->
+    <model name="find_mates_operator_point" type="waypoint">
       <pose>1.76876688004 0.547140717506 0 0 0 0</pose>
       <static>true</static>
-      <name>find_mates_operator_point</name>
     </model>
-
-    <model name="where_is_this_information_point" type="waypoint"><!-- ToDo: verify -->
+    <model name="where_is_this_information_point" type="waypoint">
       <pose>2.5 0.0 0 0 0 1.5707963267948966</pose>
       <static>true</static>
-      <name>where_is_this_information_point</name>
     </model>
-
-    <model name="set_the_table_inspect" type="waypoint"><!-- ToDo: verify -->
+    <model name="set_the_table_inspect" type="waypoint">
       <pose>5 3 0 0 0 0</pose>
       <static>true</static>
-      <name>set_the_table_inspect</name>
     </model>
-
-     <model name="find_people_waypoint" type="waypoint">
-      <pose> 6.0 1.2 0.0 0.0 0.0 -1.5707963267948966</pose>
+    <model name="find_people_waypoint" type="waypoint">
+      <pose>6.0 1.2 0.0 0.0 0.0 -1.5707963267948966</pose>
       <static>true</static>
-      <name>find_people_waypoint</name>
     </model>
-
     <model name="hand_that_home_location" type="waypoint">
       <pose>5.0 1.0 0 0 0  0.8539816339</pose>
       <static>true</static>
-      <name>hand_that_home_location</name>
     </model>
-
-    <!-- final -->
     <model name="final_fridge_waypoint" type="waypoint">
       <pose>5.75 4.65 0 0 0 2.3</pose>
       <static>true</static>
-      <name>final_fridge_waypoint</name>
     </model>
-
-    <!-- FURNITURE -->
-    <!-- OFFICE -->
-    <include name="coat_hanger">
+    <include>
       <pose>1.28 1.1 0.0 0 0 0.0</pose>
       <name>coat_hanger</name>
       <uri>model://rwc2019/coat_hanger</uri>
     </include>
-    <include name="shoe_rack">
+    <include>
       <pose>0.68 -1.0 0.0 0 0 0.0</pose>
       <name>shoe_rack</name>
       <uri>model://rwc2019/shoe_rack</uri>
     </include>
-    <include name="safe">
+    <include>
       <pose>0.68 1.0 0.0 0 0 0.0</pose>
       <name>safe</name>
       <uri>model://rwc2019/safe</uri>
     </include>
-    <include name="desk">
+    <include>
       <pose>2.6 -1.16 0.0 0 0 0.0</pose>
       <name>desk</name>
       <uri>model://rwc2019/desk</uri>
     </include>
-
-    <!-- BEDROOM -->
-    <include name="bed">
+    <include>
       <pose>0.8 4.6 0.0 0 0 0.0</pose>
       <name>bed</name>
       <uri>model://rwc2019/bed</uri>
     </include>
-    <include name="shelf">
+    <include>
       <pose>3.70 5.1 0.0 0 0 3.141592653589793</pose>
       <name>shelf</name>
       <uri>model://rwc2019/shelf</uri>
     </include>
-    <include name="sidetable">
+    <include>
       <pose>3.6 4.05 0.0 0 0 3.141592653589793</pose>
       <name>sidetable</name>
       <uri>model://rwc2019/sidetable</uri>
     </include>
-    <include name="bedroom_chest">
+    <include>
       <pose>3.6 2.0 0.0 0 0 3.141592653589793</pose>
       <name>bedroom_chest</name>
       <uri>model://rwc2019/bedroom_chest</uri>
     </include>
-
-    <!-- LIVING ROOM -->
-    <include name="rack">
+    <include>
       <pose>4.15 1.1 0.0 0 0 0</pose>
       <name>rack</name>
       <uri>model://rwc2019/rack</uri>
     </include>
-    <include name="coffee_table">
+    <include>
       <pose>6.0 0.0 0.0 0 0 3.141592653589793</pose>
       <name>coffee_table</name>
       <uri>model://rwc2019/coffee_table</uri>
     </include>
-    <include name="couch">
+    <include>
       <pose>6.0 -0.97 0 0 0 1.5707963267948966</pose>
       <name>couch</name>
       <uri>model://rwc2019/couch</uri>
     </include>
-    <include name="armchair">
+    <include>
       <pose>7.75 0.0 0.0 0 0 3.141592653589793</pose>
       <name>armchair</name>
       <uri>model://rwc2019/armchair</uri>
     </include>
-    <include name="sideboard">
+    <include>
       <pose>4.18 2.0 0.0 0 0 0.0</pose>
       <name>sideboard</name>
       <uri>model://rwc2019/sideboard</uri>
     </include>
-    <include name="display_cabinet">
+    <include>
       <pose>7.35 2.07 0.0 0 0 -1.5707963267948966</pose>
       <name>display_cabinet</name>
       <uri>model://rwc2019/display_cabinet</uri>
     </include>
-
-    <!-- KITCHEN -->
-    <include name="kitchen_table">
+    <include>
       <pose>6.75 2.75 0.0 0 0 -1.5707963267948966</pose>
       <name>kitchen_table</name>
       <uri>model://rwc2019/kitchen_table</uri>
     </include>
-    <include name="sink">
+    <include>
       <pose>4.17 4.05 0.0 0 0 0.0</pose>
       <name>sink</name>
       <uri>model://rwc2019/sink</uri>
     </include>
-    <include name="dishwasher">
+    <include>
       <pose>4.24 4.9 0.0 0 0 0.0</pose>
       <name>dishwasher</name>
       <uri>model://rwc2019/dishwasher</uri>
     </include>
-    <include name="fridge">
+    <include>
       <pose>4.27 5.57 0.0 0 0 0.0</pose>
       <name>fridge</name>
       <uri>model://rwc2019/fridge</uri>
     </include>
-    <include name="island">
+    <include>
       <pose>5.9 5.62 0.0 0 0 -1.5707963267948966</pose>
       <name>island</name>
       <uri>model://rwc2019/island</uri>
     </include>
-    <include name="kitchen_cabinet">
+    <include>
       <pose>7.8 5.18 0.0 0 0 -1.5707963267948966</pose>
       <name>kitchen_cabinet</name>
       <uri>model://rwc2019/kitchen_cabinet</uri>
     </include>
-    <include name="trash_bin">
+    <include>
       <pose>8.0 2.6 0.0 0 0 -1.5707963267948966</pose>
       <name>trash_bin</name>
       <uri>model://rwc2019/trashbin</uri>
     </include>
-    <!--
-    <include name="trash_bin1">
-      <pose>4.15 1.27 0.0 0 0 1.5707963267948966</pose>
-      <name>trash_bin1</name>
-      <uri>model://rwc2019/trashbin</uri>
-    </include>
-    -->
-    <!--
-    Office:
-    * shoe_rack (a)
-    * safe (a)
-    * coat_hanger (a)
-    * desk (a)
-    Bedroom:
-    * bed (a)
-    * shelf (a)
-    * sidetable (a)
-    * bedroom_chest (a)
-    Living room:
-    * rack (a)
-    * coffee_table (a)
-    * couch (a)
-    * armchair (a)
-    * sideboard (a)
-    * display_cabinet (a)
-    Kitchen:
-    * kitchen_table (a)
-    * sink (a)
-    * dishwasher (a)
-    * fridge (a)
-    * island (a)
-    * kitchen_cabinet (a)
-    * thrashbin (a)
-    -->
     <physics type="ode">
       <real_time_update_rate>333.0</real_time_update_rate>
       <max_step_size>0.003</max_step_size>
@@ -367,6 +277,5 @@
         </solver>
       </ode>
     </physics>
-    <name>rwc2019</name>
   </world>
 </sdf>

--- a/models/rwc2019/rack/model.sdf
+++ b/models/rwc2019/rack/model.sdf
@@ -8,7 +8,6 @@
             <size>0.015 0.015 0.77</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -16,10 +15,8 @@
             <size>0.015 0.015 0.77</size>
           </box>
         </geometry>
-        <name>1</name>
       </visual>
       <pose>0.12 -0.2325 0.385 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="1_1">
       <collision name="1_1">
@@ -28,7 +25,6 @@
             <size>0.015 0.015 0.77</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1_1">
         <geometry>
@@ -36,10 +32,8 @@
             <size>0.015 0.015 0.77</size>
           </box>
         </geometry>
-        <name>1_1</name>
       </visual>
       <pose>-0.12 -0.2325 0.385 0 0 0</pose>
-      <name>1_1</name>
     </link>
     <link name="1_2">
       <collision name="1_2">
@@ -48,7 +42,6 @@
             <size>0.24 0.015 0.015</size>
           </box>
         </geometry>
-        <name>1_2</name>
       </collision>
       <visual name="1_2">
         <geometry>
@@ -56,10 +49,8 @@
             <size>0.24 0.015 0.015</size>
           </box>
         </geometry>
-        <name>1_2</name>
       </visual>
       <pose>0 -0.2325 0.7625 0 0 0</pose>
-      <name>1_2</name>
     </link>
     <link name="2">
       <collision name="2">
@@ -68,7 +59,6 @@
             <size>0.015 0.015 0.77</size>
           </box>
         </geometry>
-        <name>2</name>
       </collision>
       <visual name="2">
         <geometry>
@@ -76,10 +66,8 @@
             <size>0.015 0.015 0.77</size>
           </box>
         </geometry>
-        <name>2</name>
       </visual>
       <pose>0.12 0.2325 0.385 0 0 0</pose>
-      <name>2</name>
     </link>
     <link name="2_2">
       <collision name="2_2">
@@ -88,7 +76,6 @@
             <size>0.015 0.015 0.77</size>
           </box>
         </geometry>
-        <name>2_2</name>
       </collision>
       <visual name="2_2">
         <geometry>
@@ -96,10 +83,8 @@
             <size>0.015 0.015 0.77</size>
           </box>
         </geometry>
-        <name>2_2</name>
       </visual>
       <pose>-0.12 0.2325 0.385 0 0 0</pose>
-      <name>2_2</name>
     </link>
     <link name="2_3">
       <collision name="2_3">
@@ -108,7 +93,6 @@
             <size>0.24 0.015 0.015</size>
           </box>
         </geometry>
-        <name>2_3</name>
       </collision>
       <visual name="2_3">
         <geometry>
@@ -116,10 +100,8 @@
             <size>0.24 0.015 0.015</size>
           </box>
         </geometry>
-        <name>2_3</name>
       </visual>
       <pose>0 0.2325 0.7625 0 0 0</pose>
-      <name>2_3</name>
     </link>
     <link name="6">
       <collision name="6">
@@ -128,7 +110,6 @@
             <size>0.245 0.45 0.05</size>
           </box>
         </geometry>
-        <name>6</name>
       </collision>
       <visual name="6">
         <geometry>
@@ -136,10 +117,8 @@
             <size>0.245 0.45 0.05</size>
           </box>
         </geometry>
-        <name>6</name>
       </visual>
       <pose>0.0 0.0 0.445 0 0 0</pose>
-      <name>6</name>
     </link>
     <link name="7">
       <collision name="7">
@@ -148,7 +127,6 @@
             <size>0.245 0.45 0.05</size>
           </box>
         </geometry>
-        <name>7</name>
       </collision>
       <visual name="7">
         <geometry>
@@ -156,24 +134,19 @@
             <size>0.245 0.45 0.05</size>
           </box>
         </geometry>
-        <name>7</name>
       </visual>
       <pose>0.0 0.0 0.655 0 0 0</pose>
-      <name>7</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
         <geometry>
           <box>
-            <size>0.2 0.15 0.01</size> <!-- SIZE -->
+            <size>0.2 0.15 0.01</size>
           </box>
         </geometry>
-        <pose>0.63 0.05 0.005 0 0 0</pose> <!-- POSE -->
-        <name>in_front_of</name>
+        <pose>0.63 0.05 0.005 0 0 0</pose>
       </virtual_volume>
-      <name>in_front_of</name>
     </link>
     <static>true</static>
-    <name>rack/rack</name>
   </model>
 </sdf>

--- a/models/rwc2019/safe/model.sdf
+++ b/models/rwc2019/safe/model.sdf
@@ -8,7 +8,6 @@
             <size>0.492 1.007 0.75</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -16,10 +15,8 @@
             <size>0.492 1.007 0.75</size>
           </box>
         </geometry>
-        <name>1</name>
       </visual>
       <pose>0.0 0.0 0.375 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="on_top_of">
       <virtual_volume name="on_top_of">
@@ -29,9 +26,7 @@
           </box>
         </geometry>
         <pose>0.02 0.0 0.895 0 0 0</pose>
-        <name>on_top_of</name>
       </virtual_volume>
-      <name>on_top_of</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
@@ -41,11 +36,8 @@
           </box>
         </geometry>
         <pose>0.746 -0.1 0.005 0 0 0</pose>
-        <name>in_front_of</name>
       </virtual_volume>
-      <name>in_front_of</name>
     </link>
     <static>true</static>
-    <name>rwc2019/safe</name>
   </model>
 </sdf>

--- a/models/rwc2019/shelf/model.sdf
+++ b/models/rwc2019/shelf/model.sdf
@@ -8,7 +8,6 @@
             <size>0.28 0.018 2.02</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -16,10 +15,8 @@
             <size>0.28 0.018 2.02</size>
           </box>
         </geometry>
-        <name>1</name>
       </visual>
       <pose>0.0 -0.391 1.01 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="2">
       <collision name="2">
@@ -28,7 +25,6 @@
             <size>0.28 0.018 2.02</size>
           </box>
         </geometry>
-        <name>2</name>
       </collision>
       <visual name="2">
         <geometry>
@@ -36,10 +32,8 @@
             <size>0.28 0.018 2.02</size>
           </box>
         </geometry>
-        <name>2</name>
       </visual>
       <pose>0.0 0.391 1.01 0 0 0</pose>
-      <name>2</name>
     </link>
     <link name="3">
       <collision name="3">
@@ -48,7 +42,6 @@
             <size>0.018 0.8 2.02</size>
           </box>
         </geometry>
-        <name>3</name>
       </collision>
       <visual name="3">
         <geometry>
@@ -56,10 +49,8 @@
             <size>0.018 0.8 2.02</size>
           </box>
         </geometry>
-        <name>3</name>
       </visual>
       <pose>-0.131 0.0 1.01 0 0 0</pose>
-      <name>3</name>
     </link>
     <link name="4">
       <collision name="4">
@@ -68,7 +59,6 @@
             <size>0.262 0.764 0.018</size>
           </box>
         </geometry>
-        <name>4</name>
       </collision>
       <visual name="4">
         <geometry>
@@ -76,10 +66,8 @@
             <size>0.262 0.764 0.018</size>
           </box>
         </geometry>
-        <name>4</name>
       </visual>
       <pose>0.009 0.0 2.011 0 0 0</pose>
-      <name>4</name>
     </link>
     <link name="5">
       <collision name="5">
@@ -88,7 +76,6 @@
             <size>0.262 0.764 0.018</size>
           </box>
         </geometry>
-        <name>5</name>
       </collision>
       <visual name="5">
         <geometry>
@@ -96,10 +83,8 @@
             <size>0.262 0.764 0.018</size>
           </box>
         </geometry>
-        <name>5</name>
       </visual>
       <pose>0.009 0.0 0.109 0 0 0</pose>
-      <name>5</name>
     </link>
     <link name="6">
       <collision name="6">
@@ -108,7 +93,6 @@
             <size>0.262 0.764 0.018</size>
           </box>
         </geometry>
-        <name>6</name>
       </collision>
       <visual name="6">
         <geometry>
@@ -116,10 +100,8 @@
             <size>0.262 0.764 0.018</size>
           </box>
         </geometry>
-        <name>6</name>
       </visual>
       <pose>0.009 0.0 0.489 0 0 0</pose>
-      <name>6</name>
     </link>
     <link name="7">
       <collision name="7">
@@ -128,7 +110,6 @@
             <size>0.262 0.764 0.018</size>
           </box>
         </geometry>
-        <name>7</name>
       </collision>
       <visual name="7">
         <geometry>
@@ -136,10 +117,8 @@
             <size>0.262 0.764 0.018</size>
           </box>
         </geometry>
-        <name>7</name>
       </visual>
       <pose>0.009 0.0 0.749 0 0 0</pose>
-      <name>7</name>
     </link>
     <link name="8">
       <collision name="8">
@@ -148,7 +127,6 @@
             <size>0.262 0.764 0.018</size>
           </box>
         </geometry>
-        <name>8</name>
       </collision>
       <visual name="8">
         <geometry>
@@ -156,10 +134,8 @@
             <size>0.262 0.764 0.018</size>
           </box>
         </geometry>
-        <name>8</name>
       </visual>
       <pose>0.009 0.0 1.071 0 0 0</pose>
-      <name>8</name>
     </link>
     <link name="9">
       <collision name="9">
@@ -168,7 +144,6 @@
             <size>0.262 0.764 0.018</size>
           </box>
         </geometry>
-        <name>9</name>
       </collision>
       <visual name="9">
         <geometry>
@@ -176,10 +151,8 @@
             <size>0.262 0.764 0.018</size>
           </box>
         </geometry>
-        <name>9</name>
       </visual>
       <pose>0.009 0.0 1.389 0 0 0</pose>
-      <name>9</name>
     </link>
     <link name="10">
       <collision name="10">
@@ -188,7 +161,6 @@
             <size>0.262 0.764 0.018</size>
           </box>
         </geometry>
-        <name>10</name>
       </collision>
       <visual name="10">
         <geometry>
@@ -196,10 +168,8 @@
             <size>0.262 0.764 0.018</size>
           </box>
         </geometry>
-        <name>10</name>
       </visual>
       <pose>0.009 0.0 1.679 0 0 0</pose>
-      <name>10</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
@@ -209,9 +179,7 @@
           </box>
         </geometry>
         <pose>0.64 0.0 0.005 0 0 0</pose>
-        <name>in_front_of</name>
       </virtual_volume>
-      <name>in_front_of</name>
     </link>
     <link name="shelf1">
       <virtual_volume name="shelf1">
@@ -221,9 +189,7 @@
           </box>
         </geometry>
         <pose>0.029 0.0 0.263 0 0 0</pose>
-        <name>shelf1</name>
       </virtual_volume>
-      <name>shelf1</name>
     </link>
     <link name="shelf2">
       <virtual_volume name="shelf2">
@@ -233,9 +199,7 @@
           </box>
         </geometry>
         <pose>0.029 0.0 0.643 0 0 0</pose>
-        <name>shelf2</name>
       </virtual_volume>
-      <name>shelf2</name>
     </link>
     <link name="shelf3">
       <virtual_volume name="shelf3">
@@ -245,9 +209,7 @@
           </box>
         </geometry>
         <pose>0.029 0.0 0.903 0 0 0</pose>
-        <name>shelf3</name>
       </virtual_volume>
-      <name>shelf3</name>
     </link>
     <link name="shelf4">
       <virtual_volume name="shelf4">
@@ -257,9 +219,7 @@
           </box>
         </geometry>
         <pose>0.029 0.0 1.225 0 0 0</pose>
-        <name>shelf4</name>
       </virtual_volume>
-      <name>shelf4</name>
     </link>
     <link name="shelf5">
       <virtual_volume name="shelf5">
@@ -269,9 +229,7 @@
           </box>
         </geometry>
         <pose>0.029 0.0 1.543 0 0 0</pose>
-        <name>shelf5</name>
       </virtual_volume>
-      <name>shelf5</name>
     </link>
     <link name="shelf6">
       <virtual_volume name="shelf6">
@@ -281,11 +239,8 @@
           </box>
         </geometry>
         <pose>0.029 0.0 1.833 0 0 0</pose>
-        <name>shelf6</name>
       </virtual_volume>
-      <name>shelf6</name>
     </link>
     <static>true</static>
-    <name>rwc2019/shelf</name>
   </model>
 </sdf>

--- a/models/rwc2019/shoe_rack/model.sdf
+++ b/models/rwc2019/shoe_rack/model.sdf
@@ -8,7 +8,6 @@
             <size>0.496 0.991 0.752</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -16,10 +15,8 @@
             <size>0.496 0.991 0.752</size>
           </box>
         </geometry>
-        <name>1</name>
       </visual>
       <pose>0.0 0.0 0.376 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="on_top_of">
       <virtual_volume name="on_top_of">
@@ -29,9 +26,7 @@
           </box>
         </geometry>
         <pose>0.02 0.0 0.897 0 0 0</pose>
-        <name>on_top_of</name>
       </virtual_volume>
-      <name>on_top_of</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
@@ -41,11 +36,8 @@
           </box>
         </geometry>
         <pose>0.748 0.0 0.005 0 0 0</pose>
-        <name>in_front_of</name>
       </virtual_volume>
-      <name>in_front_of</name>
     </link>
     <static>true</static>
-    <name>rwc2019/shoe_rack</name>
   </model>
 </sdf>

--- a/models/rwc2019/sideboard/model.sdf
+++ b/models/rwc2019/sideboard/model.sdf
@@ -8,7 +8,6 @@
             <size>0.5 1.01 0.753</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -16,10 +15,8 @@
             <size>0.5 1.01 0.753</size>
           </box>
         </geometry>
-        <name>1</name>
       </visual>
       <pose>0.0 0.0 0.3765 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="on_top_of">
       <virtual_volume name="on_top_of">
@@ -29,9 +26,7 @@
           </box>
         </geometry>
         <pose>0.03 0.0 0.898 0 0 0</pose>
-        <name>on_top_of</name>
       </virtual_volume>
-      <name>on_top_of</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
@@ -41,11 +36,8 @@
           </box>
         </geometry>
         <pose>0.75 0.0 0.005 0 0 0</pose>
-        <name>in_front_of</name>
       </virtual_volume>
-      <name>in_front_of</name>
     </link>
     <static>true</static>
-    <name>rwc2019/sideboard</name>
   </model>
 </sdf>

--- a/models/rwc2019/sidetable/model.sdf
+++ b/models/rwc2019/sidetable/model.sdf
@@ -8,7 +8,6 @@
             <size>0.5 1.008 0.75</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -16,10 +15,8 @@
             <size>0.5 1.008 0.75</size>
           </box>
         </geometry>
-        <name>1</name>
       </visual>
       <pose>0.0 0.0 0.375 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="on_top_of">
       <virtual_volume name="on_top_of">
@@ -29,9 +26,7 @@
           </box>
         </geometry>
         <pose>0.03 0.0 0.895 0 0 0</pose>
-        <name>on_top_of</name>
       </virtual_volume>
-      <name>on_top_of</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
@@ -41,11 +36,8 @@
           </box>
         </geometry>
         <pose>0.75 0.0 0.005 0 0 0</pose>
-        <name>in_front_of</name>
       </virtual_volume>
-      <name>in_front_of</name>
     </link>
     <static>true</static>
-    <name>rwc2019/sidetable</name>
   </model>
 </sdf>

--- a/models/rwc2019/sink/model.sdf
+++ b/models/rwc2019/sink/model.sdf
@@ -8,7 +8,6 @@
             <size>0.505 1.01 0.75</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -16,10 +15,8 @@
             <size>0.505 1.01 0.75</size>
           </box>
         </geometry>
-        <name>1</name>
       </visual>
       <pose>0.0 0.0 0.375 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="on_top_of">
       <virtual_volume name="on_top_of">
@@ -29,9 +26,7 @@
           </box>
         </geometry>
         <pose>0.025 0.0 0.895 0 0 0</pose>
-        <name>on_top_of</name>
       </virtual_volume>
-      <name>on_top_of</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
@@ -41,11 +36,8 @@
           </box>
         </geometry>
         <pose>0.7525 0.0 0.005 0 0 0</pose>
-        <name>in_front_of</name>
       </virtual_volume>
-      <name>in_front_of</name>
     </link>
     <static>true</static>
-    <name>rwc2019/sink</name>
   </model>
 </sdf>

--- a/models/rwc2019/trashbin/model.sdf
+++ b/models/rwc2019/trashbin/model.sdf
@@ -9,7 +9,6 @@
             <radius>0.195</radius>
           </cylinder>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -18,10 +17,8 @@
             <radius>0.195</radius>
           </cylinder>
         </geometry>
-        <name>1</name>
       </visual>
       <pose>0 0 0.225 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="on_top_of">
       <virtual_volume name="on_top_of">
@@ -31,10 +28,8 @@
             <radius>0.19</radius>
           </cylinder>
         </geometry>
-        <name>on_top_of</name>
       </virtual_volume>
       <pose>0 0 0.585 0 0 0</pose>
-      <name>on_top_of</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
@@ -43,12 +38,9 @@
             <size>1.0 1.0 0.01</size>
           </box>
         </geometry>
-        <name>in_front_of</name>
       </virtual_volume>
       <pose>0 0 0 0 0 0</pose>
-      <name>in_front_of</name>
     </link>
     <static>true</static>
-    <name>rwc2019/trashbin</name>
   </model>
 </sdf>

--- a/models/rwc2019/walls/model.sdf
+++ b/models/rwc2019/walls/model.sdf
@@ -8,7 +8,6 @@
             <uri>model://rwc2019/walls/shape/heightmap2.stl</uri>
           </mesh>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -16,12 +15,9 @@
             <uri>model://rwc2019/walls/shape/heightmap2.stl</uri>
           </mesh>
         </geometry>
-        <name>1</name>
       </visual>
       <pose>14.0 15.625 0 0 0 -1.5707963267948966</pose>
-      <name>1</name>
     </link>
     <static>true</static>
-    <name>rwc2019/walls</name>
   </model>
 </sdf>

--- a/models/table/model.sdf
+++ b/models/table/model.sdf
@@ -2,6 +2,5 @@
 <sdf version="1.6">
   <model name="table">
     <static>true</static>
-    <name>table</name>
   </model>
 </sdf>

--- a/models/table_120x80x76/model.sdf
+++ b/models/table_120x80x76/model.sdf
@@ -8,7 +8,6 @@
             <size>1.2 0.8 0.02</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -19,10 +18,8 @@
         <material>
           <ambient>0.8 0.8 0.8 1</ambient>
         </material>
-        <name>1</name>
       </visual>
       <pose>0 0 0.75 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="2">
       <collision name="2">
@@ -31,7 +28,6 @@
             <size>0.05 0.05 0.74</size>
           </box>
         </geometry>
-        <name>2</name>
       </collision>
       <visual name="2">
         <geometry>
@@ -42,10 +38,8 @@
         <material>
           <ambient>0.8 0.8 0.8 1</ambient>
         </material>
-        <name>2</name>
       </visual>
       <pose>-0.55 -0.35 0.37 0 0 0</pose>
-      <name>2</name>
     </link>
     <link name="3">
       <collision name="3">
@@ -54,7 +48,6 @@
             <size>0.05 0.05 0.74</size>
           </box>
         </geometry>
-        <name>3</name>
       </collision>
       <visual name="3">
         <geometry>
@@ -65,10 +58,8 @@
         <material>
           <ambient>0.8 0.8 0.8 1</ambient>
         </material>
-        <name>3</name>
       </visual>
       <pose>0.55 -0.35 0.37 0 0 0</pose>
-      <name>3</name>
     </link>
     <link name="4">
       <collision name="4">
@@ -77,7 +68,6 @@
             <size>0.05 0.05 0.74</size>
           </box>
         </geometry>
-        <name>4</name>
       </collision>
       <visual name="4">
         <geometry>
@@ -88,10 +78,8 @@
         <material>
           <ambient>0.8 0.8 0.8 1</ambient>
         </material>
-        <name>4</name>
       </visual>
       <pose>-0.55 0.35 0.37 0 0 0</pose>
-      <name>4</name>
     </link>
     <link name="5">
       <collision name="5">
@@ -100,7 +88,6 @@
             <size>0.05 0.05 0.74</size>
           </box>
         </geometry>
-        <name>5</name>
       </collision>
       <visual name="5">
         <geometry>
@@ -111,10 +98,8 @@
         <material>
           <ambient>0.8 0.8 0.8 1</ambient>
         </material>
-        <name>5</name>
       </visual>
       <pose>0.55 0.35 0.37 0 0 0</pose>
-      <name>5</name>
     </link>
     <link name="in_front_of">
       <virtual_volume name="in_front_of">
@@ -124,9 +109,7 @@
           </box>
         </geometry>
         <pose>0.9 0.0 0.005 0 0 0</pose>
-        <name>in_front_of</name>
       </virtual_volume>
-      <name>in_front_of</name>
     </link>
     <link name="on_top_of">
       <virtual_volume name="on_top_of">
@@ -136,9 +119,7 @@
           </box>
         </geometry>
         <pose>0.0 0.0 0.99 0 0 0</pose>
-        <name>on_top_of</name>
       </virtual_volume>
-      <name>on_top_of</name>
     </link>
     <link name="under">
       <virtual_volume name="under">
@@ -148,11 +129,8 @@
           </box>
         </geometry>
         <pose>0.0 0.0 0.255 0 0 0</pose>
-        <name>under</name>
       </virtual_volume>
-      <name>under</name>
     </link>
     <static>true</static>
-    <name>table_120x80x76</name>
   </model>
 </sdf>

--- a/models/table_200x100x76/model.sdf
+++ b/models/table_200x100x76/model.sdf
@@ -8,7 +8,6 @@
             <size>2.0 1.0 0.02</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -19,10 +18,8 @@
         <material>
           <ambient>0.8 0.8 0.8 1</ambient>
         </material>
-        <name>1</name>
       </visual>
       <pose>0.0 0.0 0.75 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="2">
       <collision name="2">
@@ -31,7 +28,6 @@
             <size>0.05 0.05 0.74</size>
           </box>
         </geometry>
-        <name>2</name>
       </collision>
       <visual name="2">
         <geometry>
@@ -42,10 +38,8 @@
         <material>
           <ambient>0.8 0.8 0.8 1</ambient>
         </material>
-        <name>2</name>
       </visual>
       <pose>-1.0 -0.5 0.37 0 0 0</pose>
-      <name>2</name>
     </link>
     <link name="3">
       <collision name="3">
@@ -54,7 +48,6 @@
             <size>0.05 0.05 0.74</size>
           </box>
         </geometry>
-        <name>3</name>
       </collision>
       <visual name="3">
         <geometry>
@@ -65,10 +58,8 @@
         <material>
           <ambient>0.8 0.8 0.8 1</ambient>
         </material>
-        <name>3</name>
       </visual>
       <pose>1.0 -0.5 0.37 0 0 0</pose>
-      <name>3</name>
     </link>
     <link name="4">
       <collision name="4">
@@ -77,7 +68,6 @@
             <size>0.05 0.05 0.74</size>
           </box>
         </geometry>
-        <name>4</name>
       </collision>
       <visual name="4">
         <geometry>
@@ -88,10 +78,8 @@
         <material>
           <ambient>0.8 0.8 0.8 1</ambient>
         </material>
-        <name>4</name>
       </visual>
       <pose>-1.0 0.5 0.37 0 0 0</pose>
-      <name>4</name>
     </link>
     <link name="5">
       <collision name="5">
@@ -100,7 +88,6 @@
             <size>0.05 0.05 0.74</size>
           </box>
         </geometry>
-        <name>5</name>
       </collision>
       <visual name="5">
         <geometry>
@@ -111,12 +98,9 @@
         <material>
           <ambient>0.8 0.8 0.8 1</ambient>
         </material>
-        <name>5</name>
       </visual>
       <pose>1.0 0.5 0.37 0 0 0</pose>
-      <name>5</name>
     </link>
     <static>true</static>
-    <name>table_200x100x76</name>
   </model>
 </sdf>

--- a/models/table_205x105x76/model.sdf
+++ b/models/table_205x105x76/model.sdf
@@ -8,7 +8,6 @@
             <size>2.05 1.05 0.02</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -19,10 +18,8 @@
         <material>
           <ambient>0.8 0.8 0.8 1</ambient>
         </material>
-        <name>1</name>
       </visual>
       <pose>0.0 0.0 0.75 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="2">
       <collision name="2">
@@ -31,7 +28,6 @@
             <size>0.05 0.05 0.74</size>
           </box>
         </geometry>
-        <name>2</name>
       </collision>
       <visual name="2">
         <geometry>
@@ -42,10 +38,8 @@
         <material>
           <ambient>0.8 0.8 0.8 1</ambient>
         </material>
-        <name>2</name>
       </visual>
       <pose>-1.0 -0.5 0.37 0 0 0</pose>
-      <name>2</name>
     </link>
     <link name="3">
       <collision name="3">
@@ -54,7 +48,6 @@
             <size>0.05 0.05 0.74</size>
           </box>
         </geometry>
-        <name>3</name>
       </collision>
       <visual name="3">
         <geometry>
@@ -65,10 +58,8 @@
         <material>
           <ambient>0.8 0.8 0.8 1</ambient>
         </material>
-        <name>3</name>
       </visual>
       <pose>1.0 -0.5 0.37 0 0 0</pose>
-      <name>3</name>
     </link>
     <link name="4">
       <collision name="4">
@@ -77,7 +68,6 @@
             <size>0.05 0.05 0.74</size>
           </box>
         </geometry>
-        <name>4</name>
       </collision>
       <visual name="4">
         <geometry>
@@ -88,10 +78,8 @@
         <material>
           <ambient>0.8 0.8 0.8 1</ambient>
         </material>
-        <name>4</name>
       </visual>
       <pose>-1.0 0.5 0.37 0 0 0</pose>
-      <name>4</name>
     </link>
     <link name="5">
       <collision name="5">
@@ -100,7 +88,6 @@
             <size>0.05 0.05 0.74</size>
           </box>
         </geometry>
-        <name>5</name>
       </collision>
       <visual name="5">
         <geometry>
@@ -111,12 +98,9 @@
         <material>
           <ambient>0.8 0.8 0.8 1</ambient>
         </material>
-        <name>5</name>
       </visual>
       <pose>1.0 0.5 0.37 0 0 0</pose>
-      <name>5</name>
     </link>
     <static>true</static>
-    <name>table_205x105x76</name>
   </model>
 </sdf>

--- a/models/table_2legs_180x80x76/model.sdf
+++ b/models/table_2legs_180x80x76/model.sdf
@@ -8,7 +8,6 @@
             <size>1.8 0.9 0.05</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -19,10 +18,8 @@
         <material>
           <ambient>0.8 0.8 0.8 1</ambient>
         </material>
-        <name>1</name>
       </visual>
       <pose>0 0 0.785 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="2">
       <collision name="2">
@@ -31,7 +28,6 @@
             <size>0.05 0.16 0.76</size>
           </box>
         </geometry>
-        <name>2</name>
       </collision>
       <visual name="2">
         <geometry>
@@ -42,10 +38,8 @@
         <material>
           <ambient>0.8 0.8 0.8 1</ambient>
         </material>
-        <name>2</name>
       </visual>
       <pose>-0.875 0 0.38 0 0 0</pose>
-      <name>2</name>
     </link>
     <link name="3">
       <collision name="3">
@@ -54,7 +48,6 @@
             <size>0.05 0.16 0.76</size>
           </box>
         </geometry>
-        <name>3</name>
       </collision>
       <visual name="3">
         <geometry>
@@ -65,10 +58,8 @@
         <material>
           <ambient>0.8 0.8 0.8 1</ambient>
         </material>
-        <name>3</name>
       </visual>
       <pose>0.875 0 0.38 0 0 0</pose>
-      <name>3</name>
     </link>
     <link name="4">
       <collision name="4">
@@ -77,7 +68,6 @@
             <size>0.05 0.76 0.06</size>
           </box>
         </geometry>
-        <name>4</name>
       </collision>
       <visual name="4">
         <geometry>
@@ -88,10 +78,8 @@
         <material>
           <ambient>0.8 0.8 0.8 1</ambient>
         </material>
-        <name>4</name>
       </visual>
       <pose>-0.875 0 0 0 0 0</pose>
-      <name>4</name>
     </link>
     <link name="5">
       <collision name="5">
@@ -100,7 +88,6 @@
             <size>0.05 0.76 0.06</size>
           </box>
         </geometry>
-        <name>5</name>
       </collision>
       <visual name="5">
         <geometry>
@@ -111,12 +98,9 @@
         <material>
           <ambient>0.8 0.8 0.8 1</ambient>
         </material>
-        <name>5</name>
       </visual>
       <pose>0.875 0 0.0 0 0 0</pose>
-      <name>5</name>
     </link>
     <static>true</static>
-    <name>table_2legs_180x80x76</name>
   </model>
 </sdf>

--- a/models/table_ahrend_180x90x75_with_drawers/model.sdf
+++ b/models/table_ahrend_180x90x75_with_drawers/model.sdf
@@ -8,7 +8,6 @@
             <size>1.8 0.9 0.05</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -19,10 +18,8 @@
         <material>
           <ambient>0.8 0.8 0.8 1</ambient>
         </material>
-        <name>1</name>
       </visual>
       <pose>0.0 0.0 0.725 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="2">
       <collision name="2">
@@ -31,7 +28,6 @@
             <size>0.05 0.05 0.74</size>
           </box>
         </geometry>
-        <name>2</name>
       </collision>
       <visual name="2">
         <geometry>
@@ -42,10 +38,8 @@
         <material>
           <ambient>0.8 0.8 0.8 1</ambient>
         </material>
-        <name>2</name>
       </visual>
       <pose>-0.9 -0.45 0.37 0 0 0</pose>
-      <name>2</name>
     </link>
     <link name="3">
       <collision name="3">
@@ -54,7 +48,6 @@
             <size>0.05 0.05 0.74</size>
           </box>
         </geometry>
-        <name>3</name>
       </collision>
       <visual name="3">
         <geometry>
@@ -65,10 +58,8 @@
         <material>
           <ambient>0.8 0.8 0.8 1</ambient>
         </material>
-        <name>3</name>
       </visual>
       <pose>-0.9 0.45 0.37 0 0 0</pose>
-      <name>3</name>
     </link>
     <link name="4">
       <collision name="4">
@@ -77,7 +68,6 @@
             <size>0.05 0.05 0.74</size>
           </box>
         </geometry>
-        <name>4</name>
       </collision>
       <visual name="4">
         <geometry>
@@ -88,10 +78,8 @@
         <material>
           <ambient>0.8 0.8 0.8 1</ambient>
         </material>
-        <name>4</name>
       </visual>
       <pose>0.9 -0.45 0.37 0 0 0</pose>
-      <name>4</name>
     </link>
     <link name="5">
       <collision name="5">
@@ -100,7 +88,6 @@
             <size>0.05 0.05 0.74</size>
           </box>
         </geometry>
-        <name>5</name>
       </collision>
       <visual name="5">
         <geometry>
@@ -111,10 +98,8 @@
         <material>
           <ambient>0.8 0.8 0.8 1</ambient>
         </material>
-        <name>5</name>
       </visual>
       <pose>0.9 0.45 0.37 0 0 0</pose>
-      <name>5</name>
     </link>
     <link name="6">
       <collision name="6">
@@ -123,7 +108,6 @@
             <size>0.39 0.72 0.53</size>
           </box>
         </geometry>
-        <name>6</name>
       </collision>
       <visual name="6">
         <geometry>
@@ -134,12 +118,9 @@
         <material>
           <ambient>0.8 0.8 0.8 1</ambient>
         </material>
-        <name>6</name>
       </visual>
       <pose>0.705 0.09 0.465 0 0 0</pose>
-      <name>6</name>
     </link>
     <static>true</static>
-    <name>table_ahrend_180x90x75_with_drawers</name>
   </model>
 </sdf>

--- a/models/test/model.sdf
+++ b/models/test/model.sdf
@@ -14,7 +14,6 @@
             <point>0.2 0.5</point>
           </polyline>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -28,10 +27,8 @@
             <point>0.2 0.5</point>
           </polyline>
         </geometry>
-        <name>1</name>
       </visual>
       <pose>0 0 0 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="2">
       <collision name="2">
@@ -46,7 +43,6 @@
             <point>0.2 0.5</point>
           </polyline>
         </geometry>
-        <name>2</name>
       </collision>
       <visual name="2">
         <geometry>
@@ -60,10 +56,8 @@
             <point>0.2 0.5</point>
           </polyline>
         </geometry>
-        <name>2</name>
       </visual>
       <pose>0 0 0.1 1.54 0 3.1415</pose>
-      <name>2</name>
     </link>
     <link name="3">
       <collision name="3">
@@ -73,7 +67,6 @@
             <radius>0.1</radius>
           </cylinder>
         </geometry>
-        <name>3</name>
       </collision>
       <visual name="3">
         <geometry>
@@ -82,10 +75,8 @@
             <radius>0.1</radius>
           </cylinder>
         </geometry>
-        <name>3</name>
       </visual>
       <pose>0 0 0 0 0 0</pose>
-      <name>3</name>
     </link>
     <link name="4">
       <collision name="4">
@@ -95,7 +86,6 @@
             <radius>0.05</radius>
           </cylinder>
         </geometry>
-        <name>4</name>
       </collision>
       <visual name="4">
         <geometry>
@@ -104,12 +94,9 @@
             <radius>0.05</radius>
           </cylinder>
         </geometry>
-        <name>4</name>
       </visual>
       <pose>0 0 0 0 0 0</pose>
-      <name>4</name>
     </link>
     <static>true</static>
-    <name>test</name>
   </model>
 </sdf>

--- a/models/tue_library/book_xxl/model.sdf
+++ b/models/tue_library/book_xxl/model.sdf
@@ -8,7 +8,6 @@
             <size>3.62 0.625 1.2</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -16,10 +15,8 @@
             <size>3.62 0.625 1.2</size>
           </box>
         </geometry>
-        <name>1</name>
       </visual>
       <pose>0 0 0.6 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="2">
       <collision name="2">
@@ -28,7 +25,6 @@
             <size>3.62 0.405 1.2</size>
           </box>
         </geometry>
-        <name>2</name>
       </collision>
       <visual name="2">
         <geometry>
@@ -36,10 +32,8 @@
             <size>3.62 0.405 1.2</size>
           </box>
         </geometry>
-        <name>2</name>
       </visual>
       <pose>0 -2.0 0.6 0 0 0</pose>
-      <name>2</name>
     </link>
     <link name="3">
       <collision name="3">
@@ -48,7 +42,6 @@
             <size>3.62 0.81 1.2</size>
           </box>
         </geometry>
-        <name>3</name>
       </collision>
       <visual name="3">
         <geometry>
@@ -56,10 +49,8 @@
             <size>3.62 0.81 1.2</size>
           </box>
         </geometry>
-        <name>3</name>
       </visual>
       <pose>0 -4.05 0.6 0 0 0</pose>
-      <name>3</name>
     </link>
     <link name="4">
       <collision name="4">
@@ -68,7 +59,6 @@
             <size>3.62 0.81 1.2</size>
           </box>
         </geometry>
-        <name>4</name>
       </collision>
       <visual name="4">
         <geometry>
@@ -76,10 +66,8 @@
             <size>3.62 0.81 1.2</size>
           </box>
         </geometry>
-        <name>4</name>
       </visual>
       <pose>0 -6.31 0.6 0 0 0</pose>
-      <name>4</name>
     </link>
     <link name="5">
       <collision name="5">
@@ -88,7 +76,6 @@
             <size>3.62 0.405 1.2</size>
           </box>
         </geometry>
-        <name>5</name>
       </collision>
       <visual name="5">
         <geometry>
@@ -96,12 +83,9 @@
             <size>3.62 0.405 1.2</size>
           </box>
         </geometry>
-        <name>5</name>
       </visual>
       <pose>0 -8.36 0.6 0 0 0</pose>
-      <name>5</name>
     </link>
     <static>true</static>
-    <name>tue_library/book_xxl</name>
   </model>
 </sdf>

--- a/models/tue_library/cartographics/model.sdf
+++ b/models/tue_library/cartographics/model.sdf
@@ -8,7 +8,6 @@
             <size>3.82 1.525 1.2</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -16,10 +15,8 @@
             <size>3.82 1.525 1.2</size>
           </box>
         </geometry>
-        <name>1</name>
       </visual>
       <pose>0 0 0.6 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="2">
       <collision name="2">
@@ -28,7 +25,6 @@
             <size>1.42 1.86 1.2</size>
           </box>
         </geometry>
-        <name>2</name>
       </collision>
       <visual name="2">
         <geometry>
@@ -36,10 +32,8 @@
             <size>1.42 1.86 1.2</size>
           </box>
         </geometry>
-        <name>2</name>
       </visual>
       <pose>1.2 4.26 0.6 0 0 0</pose>
-      <name>2</name>
     </link>
     <link name="3">
       <collision name="3">
@@ -48,7 +42,6 @@
             <size>1.42 1.86 1.2</size>
           </box>
         </geometry>
-        <name>3</name>
       </collision>
       <visual name="3">
         <geometry>
@@ -56,12 +49,9 @@
             <size>1.42 1.86 1.2</size>
           </box>
         </geometry>
-        <name>3</name>
       </visual>
       <pose>-1.2 4.26 0.6 0 0 0</pose>
-      <name>3</name>
     </link>
     <static>true</static>
-    <name>tue_library/cartographics</name>
   </model>
 </sdf>

--- a/models/tue_library/desk.corner/model.sdf
+++ b/models/tue_library/desk.corner/model.sdf
@@ -18,7 +18,6 @@
             <point>-0.65 0.025</point>
           </polyline>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -36,12 +35,9 @@
             <point>-0.65 0.025</point>
           </polyline>
         </geometry>
-        <name>1</name>
       </visual>
       <pose>0 0 0 0 0 0</pose>
-      <name>1</name>
     </link>
     <static>true</static>
-    <name>tue_library/desk.corner</name>
   </model>
 </sdf>

--- a/models/tue_library/desks.support/model.sdf
+++ b/models/tue_library/desks.support/model.sdf
@@ -8,7 +8,6 @@
             <uri>model://tue_library/desks.support/shape/heightmap.stl</uri>
           </mesh>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -16,12 +15,9 @@
             <uri>model://tue_library/desks.support/shape/heightmap.stl</uri>
           </mesh>
         </geometry>
-        <name>1</name>
       </visual>
       <pose>0 0 0 0 0 0</pose>
-      <name>1</name>
     </link>
     <static>true</static>
-    <name>tue_library/desks.support</name>
   </model>
 </sdf>

--- a/models/tue_library/desks.top/model.sdf
+++ b/models/tue_library/desks.top/model.sdf
@@ -8,7 +8,6 @@
             <uri>model://tue_library/desks.top/shape/heightmap.stl</uri>
           </mesh>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -16,12 +15,9 @@
             <uri>model://tue_library/desks.top/shape/heightmap.stl</uri>
           </mesh>
         </geometry>
-        <name>1</name>
       </visual>
       <pose>0 0 0 0 0 0</pose>
-      <name>1</name>
     </link>
     <static>true</static>
-    <name>tue_library/desks.top</name>
   </model>
 </sdf>

--- a/models/tue_library/door/model.sdf
+++ b/models/tue_library/door/model.sdf
@@ -8,7 +8,6 @@
             <size>1.0 0.05 2.0</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -16,12 +15,9 @@
             <size>1.0 0.05 2.0</size>
           </box>
         </geometry>
-        <name>1</name>
       </visual>
       <pose>0 0 1.0 0 0 0</pose>
-      <name>1</name>
     </link>
     <static>true</static>
-    <name>tue_library/door</name>
   </model>
 </sdf>

--- a/models/tue_library/journals/model.sdf
+++ b/models/tue_library/journals/model.sdf
@@ -8,7 +8,6 @@
             <size>3.82 0.61 1.2</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -16,10 +15,8 @@
             <size>3.82 0.61 1.2</size>
           </box>
         </geometry>
-        <name>1</name>
       </visual>
       <pose>0 0 0.6 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="2">
       <collision name="2">
@@ -28,7 +25,6 @@
             <size>3.82 0.61 1.2</size>
           </box>
         </geometry>
-        <name>2</name>
       </collision>
       <visual name="2">
         <geometry>
@@ -36,10 +32,8 @@
             <size>3.82 0.61 1.2</size>
           </box>
         </geometry>
-        <name>2</name>
       </visual>
       <pose>0 1.65 0.6 0 0 0</pose>
-      <name>2</name>
     </link>
     <link name="3">
       <collision name="3">
@@ -48,7 +42,6 @@
             <size>3.82 0.61 1.2</size>
           </box>
         </geometry>
-        <name>3</name>
       </collision>
       <visual name="3">
         <geometry>
@@ -56,10 +49,8 @@
             <size>3.82 0.61 1.2</size>
           </box>
         </geometry>
-        <name>3</name>
       </visual>
       <pose>0 3.4 0.6 0 0 0</pose>
-      <name>3</name>
     </link>
     <link name="4">
       <collision name="4">
@@ -68,7 +59,6 @@
             <size>3.82 0.61 1.2</size>
           </box>
         </geometry>
-        <name>4</name>
       </collision>
       <visual name="4">
         <geometry>
@@ -76,10 +66,8 @@
             <size>3.82 0.61 1.2</size>
           </box>
         </geometry>
-        <name>4</name>
       </visual>
       <pose>0 5.15 0.6 0 0 0</pose>
-      <name>4</name>
     </link>
     <link name="5">
       <collision name="5">
@@ -88,7 +76,6 @@
             <size>3.82 0.61 1.2</size>
           </box>
         </geometry>
-        <name>5</name>
       </collision>
       <visual name="5">
         <geometry>
@@ -96,10 +83,8 @@
             <size>3.82 0.61 1.2</size>
           </box>
         </geometry>
-        <name>5</name>
       </visual>
       <pose>0 6.8 0.6 0 0 0</pose>
-      <name>5</name>
     </link>
     <link name="6">
       <collision name="6">
@@ -108,7 +93,6 @@
             <size>3.82 0.305 1.2</size>
           </box>
         </geometry>
-        <name>6</name>
       </collision>
       <visual name="6">
         <geometry>
@@ -116,12 +100,9 @@
             <size>3.82 0.305 1.2</size>
           </box>
         </geometry>
-        <name>6</name>
       </visual>
       <pose>0 8.4 0.6 0 0 0</pose>
-      <name>6</name>
     </link>
     <static>true</static>
-    <name>tue_library/journals</name>
   </model>
 </sdf>

--- a/models/tue_library/model.sdf
+++ b/models/tue_library/model.sdf
@@ -4,7 +4,6 @@
     <light name="sun" type="directional">
       <direction>0.5 0.1 -0.9</direction>
       <pose>0 0 10 0 0 0</pose>
-      <name>sun</name>
       <specular>0.2 0.2 0.2 1</specular>
       <cast_shadows>true</cast_shadows>
       <diffuse>0.8 0.8 0.8 1</diffuse>
@@ -15,107 +14,107 @@
         <linear>0.01</linear>
       </attenuation>
     </light>
-    <include name="floor">
+    <include>
       <pose>0 0 0 0 0 0</pose>
       <name>floor</name>
       <uri>model://floor</uri>
     </include>
-    <include name="walls">
+    <include>
       <pose>0 0 0 0 0 0</pose>
       <name>walls</name>
       <uri>model://tue_library/walls</uri>
     </include>
-    <include name="desks-support">
+    <include>
       <pose>0 0 0 0 0 0</pose>
       <name>desks-support</name>
       <uri>model://tue_library/desks.support</uri>
     </include>
-    <include name="desks-top">
+    <include>
       <pose>0 0 0.695 0 0 0</pose>
       <name>desks-top</name>
       <uri>model://tue_library/desks.top</uri>
     </include>
-    <include name="relax-room-1">
+    <include>
       <pose>-27.97 3.212 0 0 0 0</pose>
       <name>relax-room-1</name>
       <uri>model://tue_library/relax_room</uri>
     </include>
-    <include name="relax-room-2">
+    <include>
       <pose>-27.97 -2.652 0 0 0 0</pose>
       <name>relax-room-2</name>
       <uri>model://tue_library/relax_room</uri>
     </include>
-    <include name="relax-room-3">
+    <include>
       <pose>21.65 3.212 0 0 0 0</pose>
       <name>relax-room-3</name>
       <uri>model://tue_library/relax_room</uri>
     </include>
-    <include name="relax-room-4">
+    <include>
       <pose>21.65 -2.652 0 0 0 0</pose>
       <name>relax-room-4</name>
       <uri>model://tue_library/relax_room</uri>
     </include>
-    <include name="book_xxl">
+    <include>
       <pose>-27.97 16.4 0 0 0 0</pose>
       <name>book_xxl</name>
       <uri>model://tue_library/book_xxl</uri>
     </include>
-    <include name="theses">
+    <include>
       <pose>21.65 16.7 0 0 0 0</pose>
       <name>theses</name>
       <uri>model://tue_library/theses</uri>
     </include>
-    <include name="cartographics">
+    <include>
       <pose>21.65 -15.29 0 0 0 0</pose>
       <name>cartographics</name>
       <uri>model://tue_library/cartographics</uri>
     </include>
-    <include name="journals">
+    <include>
       <pose>-27.97 -15.97 0 0 0 0</pose>
       <name>journals</name>
       <uri>model://tue_library/journals</uri>
     </include>
-    <include name="elevator">
+    <include>
       <pose>-10.5 8.0 0 0 0 0</pose>
       <name>elevator</name>
       <uri>model://tue_library/door</uri>
     </include>
-    <include name="lecture_room_1">
+    <include>
       <pose>-6.8 8.0 0 0 0 0</pose>
       <name>lecture_room_1</name>
       <uri>model://tue_library/door</uri>
     </include>
-    <include name="lecture_room_2">
+    <include>
       <pose>0.5 8.0 0 0 0 0</pose>
       <name>lecture_room_2</name>
       <uri>model://tue_library/door</uri>
     </include>
-    <include name="copier">
+    <include>
       <pose>4.2 8.0 0 0 0 0</pose>
       <name>copier</name>
       <uri>model://tue_library/door</uri>
     </include>
-    <include name="stairway">
+    <include>
       <pose>-1.0 0.1 0 0 0 1.57</pose>
       <name>stairway</name>
       <uri>model://tue_library/door</uri>
     </include>
-    <include name="meeting_room_1">
+    <include>
       <pose>9.3 -16.5 0 0 0 1.57</pose>
       <name>meeting_room_1</name>
       <uri>model://tue_library/door</uri>
     </include>
-    <include name="meeting_room_4">
+    <include>
       <pose>-15.5 -16.5 0 0 0 1.57</pose>
       <name>meeting_room_4</name>
       <uri>model://tue_library/door</uri>
     </include>
-    <include name="amigo_case">
+    <include>
       <pose>-3.7 7.3 0.0 0 0 1.57</pose>
       <name>amigo_case</name>
       <uri>model://amigo_case</uri>
     </include>
-    <include name="laptop_case">
+    <include>
       <pose>-2.7 7.3 0.0 0 0 1.57</pose>
       <name>laptop_case</name>
       <uri>model://laptop_case</uri>
@@ -132,6 +131,5 @@
         </solver>
       </ode>
     </physics>
-    <name>tue_library</name>
   </world>
 </sdf>

--- a/models/tue_library/relax_room/model.sdf
+++ b/models/tue_library/relax_room/model.sdf
@@ -8,7 +8,6 @@
             <uri>model://tue_library/relax_room/heightmap.stl</uri>
           </mesh>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -16,12 +15,9 @@
             <uri>model://tue_library/relax_room/heightmap.stl</uri>
           </mesh>
         </geometry>
-        <name>1</name>
       </visual>
       <pose>0 0 0 0 0 0</pose>
-      <name>1</name>
     </link>
     <static>true</static>
-    <name>tue_library/relax_room</name>
   </model>
 </sdf>

--- a/models/tue_library/theses/model.sdf
+++ b/models/tue_library/theses/model.sdf
@@ -8,7 +8,6 @@
             <size>3.82 0.305 1.2</size>
           </box>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -16,10 +15,8 @@
             <size>3.82 0.305 1.2</size>
           </box>
         </geometry>
-        <name>1</name>
       </visual>
       <pose>0 0 0.6 0 0 0</pose>
-      <name>1</name>
     </link>
     <link name="2">
       <collision name="2">
@@ -28,7 +25,6 @@
             <size>3.82 0.61 1.2</size>
           </box>
         </geometry>
-        <name>2</name>
       </collision>
       <visual name="2">
         <geometry>
@@ -36,10 +32,8 @@
             <size>3.82 0.61 1.2</size>
           </box>
         </geometry>
-        <name>2</name>
       </visual>
       <pose>0 -2.8 0.6 0 0 0</pose>
-      <name>2</name>
     </link>
     <link name="3">
       <collision name="3">
@@ -48,7 +42,6 @@
             <size>3.82 0.61 1.2</size>
           </box>
         </geometry>
-        <name>3</name>
       </collision>
       <visual name="3">
         <geometry>
@@ -56,10 +49,8 @@
             <size>3.82 0.61 1.2</size>
           </box>
         </geometry>
-        <name>3</name>
       </visual>
       <pose>0 -5.76 0.6 0 0 0</pose>
-      <name>3</name>
     </link>
     <link name="4">
       <collision name="4">
@@ -68,7 +59,6 @@
             <size>3.82 0.305 1.2</size>
           </box>
         </geometry>
-        <name>4</name>
       </collision>
       <visual name="4">
         <geometry>
@@ -76,12 +66,9 @@
             <size>3.82 0.305 1.2</size>
           </box>
         </geometry>
-        <name>4</name>
       </visual>
       <pose>0 -8.5 0.6 0 0 0</pose>
-      <name>4</name>
     </link>
     <static>true</static>
-    <name>tue_library/theses</name>
   </model>
 </sdf>

--- a/models/tue_library/walls/model.sdf
+++ b/models/tue_library/walls/model.sdf
@@ -8,7 +8,6 @@
             <uri>model://tue_library/walls/heightmap.stl</uri>
           </mesh>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -16,12 +15,9 @@
             <uri>model://tue_library/walls/heightmap.stl</uri>
           </mesh>
         </geometry>
-        <name>1</name>
       </visual>
       <pose>0 0 0 0 0 0</pose>
-      <name>1</name>
     </link>
     <static>true</static>
-    <name>tue_library/walls</name>
   </model>
 </sdf>

--- a/models/walls/model.sdf
+++ b/models/walls/model.sdf
@@ -2,6 +2,5 @@
 <sdf version="1.6">
   <model name="walls">
     <static>true</static>
-    <name>walls</name>
   </model>
 </sdf>

--- a/models/waypoint/model.sdf
+++ b/models/waypoint/model.sdf
@@ -2,6 +2,5 @@
 <sdf version="1.6">
   <model name="waypoint">
     <static>true</static>
-    <name>waypoint</name>
   </model>
 </sdf>

--- a/models/wonderland/model.sdf
+++ b/models/wonderland/model.sdf
@@ -4,7 +4,6 @@
     <light name="sun" type="directional">
       <direction>0.5 0.1 -0.9</direction>
       <pose>0 0 10 0 0 0</pose>
-      <name>sun</name>
       <specular>0.2 0.2 0.2 1</specular>
       <cast_shadows>true</cast_shadows>
       <diffuse>0.8 0.8 0.8 1</diffuse>
@@ -15,17 +14,17 @@
         <linear>0.01</linear>
       </attenuation>
     </light>
-    <include name="walls">
+    <include>
       <pose>0 0 0 0 0 0</pose>
       <name>walls</name>
       <uri>model://wonderland/walls</uri>
     </include>
-    <include name="floor">
+    <include>
       <pose>0 0 0 0 0 0</pose>
       <name>floor</name>
       <uri>model://floor</uri>
     </include>
-    <include name="table">
+    <include>
       <pose>10 9 0 0 0 1.57</pose>
       <name>table</name>
       <uri>model://table_120x80x76</uri>
@@ -42,6 +41,5 @@
         </solver>
       </ode>
     </physics>
-    <name>wonderland</name>
   </world>
 </sdf>

--- a/models/wonderland/walls/model.sdf
+++ b/models/wonderland/walls/model.sdf
@@ -8,7 +8,6 @@
             <uri>model://wonderland/walls/shape/heightmap.stl</uri>
           </mesh>
         </geometry>
-        <name>1</name>
       </collision>
       <visual name="1">
         <geometry>
@@ -16,12 +15,9 @@
             <uri>model://wonderland/walls/shape/heightmap.stl</uri>
           </mesh>
         </geometry>
-        <name>1</name>
       </visual>
       <pose>0 0 0 0 0 0</pose>
-      <name>1</name>
     </link>
     <static>true</static>
-    <name>wonderland/walls</name>
   </model>
 </sdf>

--- a/models/world_model_illustration/model.sdf
+++ b/models/world_model_illustration/model.sdf
@@ -4,7 +4,6 @@
     <light name="sun" type="directional">
       <direction>0.5 0.1 -0.9</direction>
       <pose>0 0 10 0 0 0</pose>
-      <name>sun</name>
       <specular>0.2 0.2 0.2 1</specular>
       <cast_shadows>true</cast_shadows>
       <diffuse>0.8 0.8 0.8 1</diffuse>
@@ -15,12 +14,12 @@
         <linear>0.01</linear>
       </attenuation>
     </light>
-    <include name="floor">
+    <include>
       <pose>0 0 0 0 0 0</pose>
       <name>floor</name>
       <uri>model://floor</uri>
     </include>
-    <include name="table">
+    <include>
       <pose>0.1 1.7 0 0 0 0</pose>
       <name>table</name>
       <uri>model://table_120x80x76</uri>
@@ -37,6 +36,5 @@
         </solver>
       </ode>
     </physics>
-    <name>world_model_illustration</name>
   </world>
 </sdf>

--- a/src/ed_object_models/conversion_sdf.py
+++ b/src/ed_object_models/conversion_sdf.py
@@ -355,17 +355,12 @@ def parse_to_xml(xml, item, list_name=""):
     elif isinstance(item, dict):
         for k, v in item.items():
             # attributes
-            if k == "name" or k == "version" or k == "type":
+            attributes = ["version", "type"]
+            if xml.tag != "include":
+                attributes.append("name")
+            if k in attributes:
                 xml.set(k, v)
-
-                # Names in includes are elements, not attributes. Using below code generates names as attributes AND as
-                # elements:
-                if not k == "name":
-                    continue
-
-                # Another solution to above would be to input an extra argument to the parse_to_xml function to check if
-                # the file that is parsed is a world or a model. For models the names can then be set as attributes, for
-                # worlds as elements.
+                continue
 
             if isinstance(v, list):
                 parse_to_xml(xml, v, k)

--- a/src/ed_object_models/conversion_sdf.py
+++ b/src/ed_object_models/conversion_sdf.py
@@ -335,7 +335,8 @@ def read_areas(areas, link_names, model_name):
 def parse_to_xml(xml, item, list_name=""):
     # type: (ET.Element, Union[list, dict, str, float, int], str) -> None
     """
-    Extend XML with elements from a dict, list or a string
+    Extend XML with elements from a dict, list or a string.
+    This takes SDF attribute/element rules into account
 
     :param xml: xml element
     :type xml: xml.etree.ElementTree.Element
@@ -355,16 +356,17 @@ def parse_to_xml(xml, item, list_name=""):
     elif isinstance(item, dict):
         for k, v in item.items():
             # attributes
-            attributes = ["version", "type"]
+            attributes = ["version", "type"]  # children that are XML attributes in all SDF elements
             if xml.tag != "include":
-                attributes.append("name")
-            if k in attributes:
+                attributes.append("name")  # In 'include' name is a child element, in other elements it is an attribute
+
+            if k in attributes:  # Write child as attribute
                 xml.set(k, v)
                 continue
 
-            if isinstance(v, list):
+            if isinstance(v, list):  # Write child list
                 parse_to_xml(xml, v, k)
-            else:
+            else:  # Write child as element
                 child = ET.SubElement(xml, k)
                 parse_to_xml(child, v)
     elif isinstance(item, str) or isinstance(item, float) or isinstance(item, int):


### PR DESCRIPTION
This reduces some of the warning of the sdf library.

We still use some additional elements and attributes, which will keep causing warnings. But we did set name both as a child element and as an attribute. Because sometimes elements are used in the sdf spec, sometimes attributes. I was able to fix the generation script and wrote a script to convert the existing files.