### PR TITLE
[impuls/couch_long/short] Add left and right version of the on_top_of virtual volume

### DIFF
--- a/models/impuls/couch_long/model.sdf
+++ b/models/impuls/couch_long/model.sdf
@@ -69,14 +69,24 @@
       </visual>
       <pose>0.125 0 0.21 0 0 0</pose>
     </link>
-    <link name="on_top_of">
+    <link name="on_top_of_couch_long_right">
       <virtual_volume name="on_top_of_vv">
         <geometry>
           <box>
-            <size>0.60 1.64 0.3</size>
+            <size>0.60 0.80 0.3</size>
           </box>
         </geometry>
-        <pose>0.125 0.0 0.57 0 0 0</pose>
+        <pose>0.125 -0.41 0.57 0 0 0</pose>
+      </virtual_volume>
+    </link>
+    <link name="on_top_of_couch_long_left">
+      <virtual_volume name="on_top_of_vv">
+        <geometry>
+          <box>
+            <size>0.60 0.80 0.3</size>
+          </box>
+        </geometry>
+        <pose>0.125 0.41 0.57 0 0 0</pose>
       </virtual_volume>
     </link>
     <link name="in_front_of">

--- a/models/impuls/couch_long/model.sdf
+++ b/models/impuls/couch_long/model.sdf
@@ -18,6 +18,16 @@
       </visual>
       <pose>-0.30 0.0 0.395 0 0 0</pose>
     </link>
+    <link name="in_front_of">
+      <virtual_volume name="in_front_of_vv">
+        <geometry>
+          <box>
+            <size>0.2 1.6 0.01</size>
+          </box>
+        </geometry>
+        <pose>0.65 0.0 0.005 0 0 0</pose>
+      </virtual_volume>
+    </link>
     <link name="side_left">
      <collision name="side_left_col">
         <geometry>
@@ -69,18 +79,18 @@
       </visual>
       <pose>0.125 0 0.21 0 0 0</pose>
     </link>
-    <link name="on_top_of_couch_long_right">
+    <link name="on_top_of">
       <virtual_volume name="on_top_of_vv">
         <geometry>
           <box>
-            <size>0.60 0.80 0.3</size>
+            <size>0.60 1.64 0.3</size>
           </box>
         </geometry>
-        <pose>0.125 -0.41 0.57 0 0 0</pose>
+        <pose>0.125 0.0 0.57 0 0 0</pose>
       </virtual_volume>
     </link>
     <link name="on_top_of_couch_long_left">
-      <virtual_volume name="on_top_of_vv">
+     <virtual_volume name="on_top_of_couch_long_left_vv">
         <geometry>
           <box>
             <size>0.60 0.80 0.3</size>
@@ -89,14 +99,14 @@
         <pose>0.125 0.41 0.57 0 0 0</pose>
       </virtual_volume>
     </link>
-    <link name="in_front_of">
-      <virtual_volume name="in_front_of_vv">
+    <link name="on_top_of_couch_long_right">
+      <virtual_volume name="on_top_of_couch_long_right_vv">
         <geometry>
           <box>
-            <size>0.2 1.6 0.01</size>
+            <size>0.60 0.80 0.3</size>
           </box>
         </geometry>
-        <pose>0.65 0.0 0.005 0 0 0</pose>
+        <pose>0.125 -0.41 0.57 0 0 0</pose>
       </virtual_volume>
     </link>
     <static>true</static>

--- a/models/impuls/couch_short/model.sdf
+++ b/models/impuls/couch_short/model.sdf
@@ -69,8 +69,28 @@
       </visual>
       <pose>0.125 0 0.21 0 0 0</pose>
     </link>
-    <link name="on_top_of_couch_short_left">
+    <link name="in_front_of">
+      <virtual_volume name="in_front_of_vv">
+        <geometry>
+          <box>
+            <size>0.2 1.55 0.01</size>
+          </box>
+        </geometry>
+        <pose>0.65 0.0 0.005 0 0 0</pose>
+      </virtual_volume>
+    </link>
+    <link name="on_top_of">
       <virtual_volume name="on_top_of_vv">
+        <geometry>
+          <box>
+            <size>0.60 1.40 0.3</size>
+          </box>
+        </geometry>
+        <pose>0.125 0.0 0.57 0 0 0</pose>
+      </virtual_volume>
+    </link>
+    <link name="on_top_of_couch_short_left">
+      <virtual_volume name="on_top_of_on_top_of_couch_short_left_vv">
         <geometry>
           <box>
             <size>0.60 0.69 0.3</size>
@@ -80,23 +100,13 @@
       </virtual_volume>
     </link>
     <link name="on_top_of_couch_short_right">
-      <virtual_volume name="on_top_of_vv">
+      <virtual_volume name="on_top_of_on_top_of_couch_short_right_vv">
         <geometry>
           <box>
             <size>0.60 0.69 0.3</size>
           </box>
         </geometry>
         <pose>0.125 -0.35 0.57 0 0 0</pose>
-      </virtual_volume>
-    </link>
-    <link name="in_front_of">
-      <virtual_volume name="in_front_of_vv">
-        <geometry>
-          <box>
-            <size>0.2 1.55 0.01</size>
-          </box>
-        </geometry>
-        <pose>0.65 0.0 0.005 0 0 0</pose>
       </virtual_volume>
     </link>
     <static>true</static>

--- a/models/impuls/couch_short/model.sdf
+++ b/models/impuls/couch_short/model.sdf
@@ -69,7 +69,7 @@
       </visual>
       <pose>0.125 0 0.21 0 0 0</pose>
     </link>
-    <link name="on_top_of_couch_short_right">
+    <link name="on_top_of_couch_short_left">
       <virtual_volume name="on_top_of_vv">
         <geometry>
           <box>
@@ -79,7 +79,7 @@
         <pose>0.125 0.35 0.57 0 0 0</pose>
       </virtual_volume>
     </link>
-    <link name="on_top_of_couch_short_left">
+    <link name="on_top_of_couch_short_right">
       <virtual_volume name="on_top_of_vv">
         <geometry>
           <box>

--- a/models/impuls/couch_short/model.sdf
+++ b/models/impuls/couch_short/model.sdf
@@ -89,8 +89,8 @@
         <pose>0.125 0.0 0.57 0 0 0</pose>
       </virtual_volume>
     </link>
-    <link name="on_top_of_couch_short_left">
-      <virtual_volume name="on_top_of_on_top_of_couch_short_left_vv">
+    <link name="on_top_of_left">
+      <virtual_volume name="on_top_of_left_vv">
         <geometry>
           <box>
             <size>0.60 0.69 0.3</size>
@@ -99,8 +99,8 @@
         <pose>0.125 0.35 0.57 0 0 0</pose>
       </virtual_volume>
     </link>
-    <link name="on_top_of_couch_short_right">
-      <virtual_volume name="on_top_of_on_top_of_couch_short_right_vv">
+    <link name="on_top_of_right">
+      <virtual_volume name="on_top_of_right_vv">
         <geometry>
           <box>
             <size>0.60 0.69 0.3</size>

--- a/models/impuls/couch_short/model.sdf
+++ b/models/impuls/couch_short/model.sdf
@@ -69,14 +69,24 @@
       </visual>
       <pose>0.125 0 0.21 0 0 0</pose>
     </link>
-    <link name="on_top_of">
+    <link name="on_top_of_couch_short_right">
       <virtual_volume name="on_top_of_vv">
         <geometry>
           <box>
-            <size>0.60 1.40 0.3</size>
+            <size>0.60 0.69 0.3</size>
           </box>
         </geometry>
-        <pose>0.125 0.0 0.57 0 0 0</pose>
+        <pose>0.125 0.35 0.57 0 0 0</pose>
+      </virtual_volume>
+    </link>
+    <link name="on_top_of_couch_short_left">
+      <virtual_volume name="on_top_of_vv">
+        <geometry>
+          <box>
+            <size>0.60 0.69 0.3</size>
+          </box>
+        </geometry>
+        <pose>0.125 -0.35 0.57 0 0 0</pose>
       </virtual_volume>
     </link>
     <link name="in_front_of">


### PR DESCRIPTION
This is to make sure when people sit for example: on the left side of the couch, the entire couch is not recognized as occupied. 
So I split the short couch and long couch volumes accordingly. The 'in_front_of' volume remains unchanged though.